### PR TITLE
fix: validate packageOverrides consistently across all builders

### DIFF
--- a/docs/src/modes/experimental-mode.md
+++ b/docs/src/modes/experimental-mode.md
@@ -99,6 +99,11 @@ goEnv.buildGoApplicationExperimental {
 Overrides are serialized to JSON and passed to `go2nix resolve`, which adds
 the extra inputs to the appropriate CA derivations.
 
+**Note:** The experimental builder only supports `nativeBuildInputs` in
+`packageOverrides`. The `env` attribute supported by the default builder is
+not available here because derivations are synthesized at build time by
+`go2nix resolve`. Unknown attributes are rejected at eval time.
+
 ## Usage
 
 ```nix

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -308,9 +308,17 @@ let
       mkDeriv = if isCgo then stdenv.mkDerivation else stdenvNoCC.mkDerivation;
 
       pkgOverride = packageOverrides.${importPath} or packageOverrides.${minfo.path} or { };
+      knownOverrideAttrs = [
+        "nativeBuildInputs"
+        "env"
+      ];
+      unknownAttrs = builtins.attrNames (builtins.removeAttrs pkgOverride knownOverrideAttrs);
       extraNativeBuildInputs = pkgOverride.nativeBuildInputs or [ ];
       extraEnv = pkgOverride.env or { };
     in
+    assert
+      unknownAttrs == [ ]
+      || builtins.throw "packageOverrides.${importPath}: unknown attributes ${builtins.toJSON unknownAttrs}. Valid: nativeBuildInputs, env";
     mkDeriv {
       name = pkg.drvName;
       __structuredAttrs = true;

--- a/nix/dynamic/default.nix
+++ b/nix/dynamic/default.nix
@@ -55,6 +55,20 @@ assert
   lib.assertMsg (lib.versionAtLeast "${major}.${minor}" "2.34") "go2nix dynamic mode requires Nix >= 2.34 (v4 derivation JSON format), got ${nixPackage.version}";
 
 let
+  # Validate packageOverrides: experimental mode only supports nativeBuildInputs.
+  # Derivations are synthesized at build time by `go2nix resolve`, so env and
+  # other attrs cannot be forwarded. Fail early instead of silently dropping.
+  validatedOverrides = lib.mapAttrs (path: cfg:
+    let
+      knownAttrs = [ "nativeBuildInputs" ];
+      unknownAttrs = builtins.attrNames (builtins.removeAttrs cfg knownAttrs);
+    in
+    assert
+      unknownAttrs == [ ]
+      || builtins.throw "packageOverrides.${path}: unknown attributes ${builtins.toJSON unknownAttrs}. Experimental mode only supports: nativeBuildInputs";
+    cfg
+  ) packageOverrides;
+
   # Serialize packageOverrides to JSON for the resolve command.
   # Only pass nativeBuildInputs store paths — resolve adds them to derivation inputs.
   # Auto-expand .dev outputs (like stdenv's multiple-outputs.sh hook) so users
@@ -73,7 +87,7 @@ let
             [ input ]
         ) (cfg.nativeBuildInputs or [ ])
       );
-    }) packageOverrides
+    }) validatedOverrides
   );
 
   wrapperDrv = stdenv.mkDerivation {


### PR DESCRIPTION
## Summary

- **testPackages** in the DAG builder was missing unknown-attr validation that `packages` and `localPackages` already enforce — a typo like `nativeBuildInput` on a test-only dependency was silently ignored instead of failing fast
- **Experimental builder** silently dropped `env` overrides and accepted unknown attrs without error — now rejects unsupported attrs at eval time with a clear message
- Documents that experimental mode only supports `nativeBuildInputs` in `packageOverrides` (derivations are synthesized at build time by `go2nix resolve`, so `env` cannot be forwarded)