### PR TITLE
fix: support test-only //go:embed and fix EmbedFiles resolution

### DIFF
--- a/go/go2nix/pkg/compile/compile.go
+++ b/go/go2nix/pkg/compile/compile.go
@@ -25,7 +25,8 @@ type Options struct {
 	GCFlags    string // extra flags for go tool compile (space-separated, e.g. "-race")
 	GoVersion  string // Go language version for -lang flag (e.g., "1.21"); auto-detected from go.mod if empty
 	PGOProfile string // path to pprof CPU profile for PGO; empty disables PGO
-	GoFiles    []string // explicit Go files to compile (bypasses ListFiles discovery; paths relative to SrcDir)
+	GoFiles    []string          // explicit Go files to compile (bypasses ListFiles discovery; paths relative to SrcDir)
+	EmbedCfg   *gofiles.EmbedCfg // explicit embed config (used with GoFiles to pass pre-resolved embed metadata)
 
 	// Resolved once by CompilePackage; avoids repeated go env subprocesses.
 	goroot        string
@@ -90,6 +91,7 @@ func CompileGoPackage(opts Options) error {
 		// Explicit file list (used by test runner for _test.go files that
 		// go/build.ImportDir would place in TestGoFiles, not GoFiles).
 		files.GoFiles = opts.GoFiles
+		files.EmbedCfg = opts.EmbedCfg
 	} else {
 		var err error
 		files, err = gofiles.ListFiles(opts.SrcDir, opts.Tags)

--- a/go/go2nix/pkg/gofiles/gofiles.go
+++ b/go/go2nix/pkg/gofiles/gofiles.go
@@ -56,16 +56,15 @@ func BuildContext(tags string) build.Context {
 // embed patterns if present.
 func BuildPkgFiles(pkg *build.Package, dir string) (PkgFiles, error) {
 	result := PkgFiles{
-		GoFiles:    nonNil(pkg.GoFiles),
-		CgoFiles:   nonNil(pkg.CgoFiles),
-		SFiles:     nonNil(pkg.SFiles),
-		CFiles:     nonNil(pkg.CFiles),
-		CXXFiles:   nonNil(pkg.CXXFiles),
-		FFiles:     nonNil(pkg.FFiles),
-		HFiles:     nonNil(pkg.HFiles),
-		SysoFiles:  nonNil(pkg.SysoFiles),
-		EmbedFiles: nonNil(pkg.EmbedPatterns),
-		IsCommand:  pkg.IsCommand(),
+		GoFiles:   nonNil(pkg.GoFiles),
+		CgoFiles:  nonNil(pkg.CgoFiles),
+		SFiles:    nonNil(pkg.SFiles),
+		CFiles:    nonNil(pkg.CFiles),
+		CXXFiles:  nonNil(pkg.CXXFiles),
+		FFiles:    nonNil(pkg.FFiles),
+		HFiles:    nonNil(pkg.HFiles),
+		SysoFiles: nonNil(pkg.SysoFiles),
+		IsCommand: pkg.IsCommand(),
 	}
 
 	if len(pkg.EmbedPatterns) > 0 {
@@ -74,6 +73,17 @@ func BuildPkgFiles(pkg *build.Package, dir string) (PkgFiles, error) {
 			return PkgFiles{}, fmt.Errorf("resolving embed patterns in %s: %w", dir, err)
 		}
 		result.EmbedCfg = cfg
+		// EmbedFiles must contain resolved file paths (from EmbedCfg.Files),
+		// not raw patterns. The test runner symlinks these into synthetic
+		// source directories, so they must be actual relative paths.
+		embedFiles := make([]string, 0, len(cfg.Files))
+		for f := range cfg.Files {
+			embedFiles = append(embedFiles, f)
+		}
+		sort.Strings(embedFiles)
+		result.EmbedFiles = embedFiles
+	} else {
+		result.EmbedFiles = []string{}
 	}
 
 	return result, nil

--- a/go/go2nix/pkg/gofiles/gofiles.go
+++ b/go/go2nix/pkg/gofiles/gofiles.go
@@ -227,6 +227,51 @@ func ResolveEmbedCfg(dir string, patterns []string) (*EmbedCfg, error) {
 	return cfg, nil
 }
 
+// MergeEmbedCfg combines two EmbedCfg values into one. Returns an error if
+// the same pattern key maps to different file lists in the two configs.
+// Either or both inputs may be nil; nil inputs are treated as empty.
+func MergeEmbedCfg(a, b *EmbedCfg) (*EmbedCfg, error) {
+	if a == nil && b == nil {
+		return nil, nil
+	}
+	merged := &EmbedCfg{
+		Patterns: make(map[string][]string),
+		Files:    make(map[string]string),
+	}
+	for _, cfg := range []*EmbedCfg{a, b} {
+		if cfg == nil {
+			continue
+		}
+		for pat, files := range cfg.Patterns {
+			if existing, ok := merged.Patterns[pat]; ok {
+				if !sliceEqual(existing, files) {
+					return nil, fmt.Errorf("embed pattern %q resolves inconsistently across production and test configs", pat)
+				}
+			}
+			merged.Patterns[pat] = files
+		}
+		for file, path := range cfg.Files {
+			if existingPath, ok := merged.Files[file]; ok && existingPath != path {
+				return nil, fmt.Errorf("embed file %q maps to both %q and %q", file, existingPath, path)
+			}
+			merged.Files[file] = path
+		}
+	}
+	return merged, nil
+}
+
+func sliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // validEmbedPattern reports whether pattern is a valid //go:embed pattern.
 func validEmbedPattern(pattern string) bool {
 	return pattern != "." && fs.ValidPath(pattern)

--- a/go/go2nix/pkg/localpkgs/localpkgs.go
+++ b/go/go2nix/pkg/localpkgs/localpkgs.go
@@ -20,13 +20,17 @@ import (
 
 // LocalPkg describes a local package with its files and location.
 type LocalPkg struct {
-	ImportPath   string   `json:"import_path"`
-	SrcDir       string   `json:"src_dir"`
-	LocalDeps    []string `json:"local_deps"` // local-to-local dependency import paths
-	TestGoFiles  []string `json:"test_go_files"`
-	XTestGoFiles []string `json:"xtest_go_files"`
-	TestImports  []string `json:"test_imports"`
-	XTestImports []string `json:"xtest_imports"`
+	ImportPath      string            `json:"import_path"`
+	SrcDir          string            `json:"src_dir"`
+	LocalDeps       []string          `json:"local_deps"` // local-to-local dependency import paths
+	TestGoFiles     []string          `json:"test_go_files"`
+	XTestGoFiles    []string          `json:"xtest_go_files"`
+	TestImports     []string          `json:"test_imports"`
+	XTestImports    []string          `json:"xtest_imports"`
+	TestEmbedFiles  []string          `json:"test_embed_files"`
+	XTestEmbedFiles []string          `json:"xtest_embed_files"`
+	TestEmbedCfg    *gofiles.EmbedCfg `json:"test_embed_cfg,omitempty"`
+	XTestEmbedCfg   *gofiles.EmbedCfg `json:"xtest_embed_cfg,omitempty"`
 	gofiles.PkgFiles
 }
 
@@ -105,15 +109,45 @@ func ListLocalPackages(root string, tags string) ([]*LocalPkg, error) {
 				}
 			}
 
+			// Resolve test-only embed patterns.
+			var testEmbedFiles []string
+			var testEmbedCfg *gofiles.EmbedCfg
+			if len(pkg.TestEmbedPatterns) > 0 {
+				cfg, err := gofiles.ResolveEmbedCfg(path, pkg.TestEmbedPatterns)
+				if err != nil {
+					return fmt.Errorf("resolving test embed patterns for %s: %w", importPath, err)
+				}
+				testEmbedCfg = cfg
+				for f := range cfg.Files {
+					testEmbedFiles = append(testEmbedFiles, f)
+				}
+			}
+			var xtestEmbedFiles []string
+			var xtestEmbedCfg *gofiles.EmbedCfg
+			if len(pkg.XTestEmbedPatterns) > 0 {
+				cfg, err := gofiles.ResolveEmbedCfg(path, pkg.XTestEmbedPatterns)
+				if err != nil {
+					return fmt.Errorf("resolving xtest embed patterns for %s: %w", importPath, err)
+				}
+				xtestEmbedCfg = cfg
+				for f := range cfg.Files {
+					xtestEmbedFiles = append(xtestEmbedFiles, f)
+				}
+			}
+
 			localPkg := &LocalPkg{
-				ImportPath:   importPath,
-				SrcDir:       path,
-				LocalDeps:    local,
-				TestGoFiles:  nonNil(pkg.TestGoFiles),
-				XTestGoFiles: nonNil(pkg.XTestGoFiles),
-				TestImports:  nonNil(pkg.TestImports),
-				XTestImports: nonNil(pkg.XTestImports),
-				PkgFiles:     pf,
+				ImportPath:      importPath,
+				SrcDir:          path,
+				LocalDeps:       local,
+				TestGoFiles:     nonNil(pkg.TestGoFiles),
+				XTestGoFiles:    nonNil(pkg.XTestGoFiles),
+				TestImports:     nonNil(pkg.TestImports),
+				XTestImports:    nonNil(pkg.XTestImports),
+				TestEmbedFiles:  nonNil(testEmbedFiles),
+				XTestEmbedFiles: nonNil(xtestEmbedFiles),
+				TestEmbedCfg:    testEmbedCfg,
+				XTestEmbedCfg:   xtestEmbedCfg,
+				PkgFiles:        pf,
 			}
 			pkgs[importPath] = localPkg
 			localDeps[importPath] = local

--- a/go/go2nix/pkg/testrunner/testrunner.go
+++ b/go/go2nix/pkg/testrunner/testrunner.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/numtide/go2nix/pkg/compile"
+	"github.com/numtide/go2nix/pkg/gofiles"
 	"github.com/numtide/go2nix/pkg/localpkgs"
 	"github.com/numtide/go2nix/pkg/testmain"
 	"github.com/numtide/go2nix/pkg/toposort"
@@ -182,8 +183,8 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 				return fmt.Errorf("symlinking %s: %w", f, err)
 			}
 		}
-		// Also symlink embed files if any
-		for _, f := range pkg.EmbedFiles {
+		// Symlink production embed files and test-only embed files.
+		for _, f := range append(pkg.EmbedFiles, pkg.TestEmbedFiles...) {
 			src := filepath.Join(pkg.SrcDir, f)
 			dst := filepath.Join(mergedDir, f)
 			if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
@@ -192,6 +193,12 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 			if err := os.Symlink(src, dst); err != nil && !os.IsExist(err) {
 				return fmt.Errorf("symlinking embed %s: %w", f, err)
 			}
+		}
+
+		// Merge production + test embed configs for the compiler.
+		mergedEmbedCfg, err := gofiles.MergeEmbedCfg(pkg.EmbedCfg, pkg.TestEmbedCfg)
+		if err != nil {
+			return fmt.Errorf("merging embed configs for %s: %w", pkg.ImportPath, err)
 		}
 
 		// Explicit file list: go/build.ImportDir would classify _test.go
@@ -208,6 +215,7 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 			Tags:       opts.Tags,
 			GCFlags:    opts.GCFlags,
 			GoFiles:    goFiles,
+			EmbedCfg:   mergedEmbedCfg,
 		}); err != nil {
 			return fmt.Errorf("compiling internal test: %w", err)
 		}
@@ -283,6 +291,17 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 				return fmt.Errorf("symlinking %s: %w", f, err)
 			}
 		}
+		// Symlink xtest embed files.
+		for _, f := range pkg.XTestEmbedFiles {
+			src := filepath.Join(pkg.SrcDir, f)
+			dst := filepath.Join(xtestDir, f)
+			if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+				return fmt.Errorf("creating xtest embed dir for %s: %w", f, err)
+			}
+			if err := os.Symlink(src, dst); err != nil && !os.IsExist(err) {
+				return fmt.Errorf("symlinking xtest embed %s: %w", f, err)
+			}
+		}
 
 		// Explicit file list: _test.go files would be classified as
 		// TestGoFiles/XTestGoFiles by ImportDir, not GoFiles.
@@ -295,6 +314,7 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 			Tags:       opts.Tags,
 			GCFlags:    opts.GCFlags,
 			GoFiles:    pkg.XTestGoFiles,
+			EmbedCfg:   pkg.XTestEmbedCfg,
 		}); err != nil {
 			return fmt.Errorf("compiling external test: %w", err)
 		}


### PR DESCRIPTION
## Summary

- **EmbedFiles stored raw patterns instead of resolved paths** — `BuildPkgFiles` was copying `pkg.EmbedPatterns` (globs like `data` or `*.txt`) into `PkgFiles.EmbedFiles`. The test runner symlinks these into synthetic source directories, so they must be actual relative file paths. Now populated from resolved `EmbedCfg.Files` keys.

- **Test-only `//go:embed` patterns were not discovered or materialized** — `LocalPkg` now captures `TestEmbedPatterns` and `XTestEmbedPatterns` from `go/build.Package` and resolves them via the existing `ResolveEmbedCfg` path. Internal test compilation merges production + test embed configs and symlinks both file sets. External test compilation symlinks xtest embed files and passes `XTestEmbedCfg` to the compiler.

- **`MergeEmbedCfg` helper** — deterministically combines two configs and errors if the same pattern resolves inconsistently, rather than silently overwriting.

- **`compile.Options.EmbedCfg`** — new field so callers using explicit `GoFiles` can pass pre-resolved embed metadata through to the compiler (previously embedcfg was always nil when GoFiles was set explicitly).