### PR TITLE
docs: improve documentation coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,38 @@
 
 Nix-native Go builder with per-package derivations and fine-grained caching.
 
+## Why go2nix?
+
+go2nix is for projects that want more visibility and reuse than the usual
+"fetch all modules, then build everything in one derivation" model.
+
+In practice that means:
+
+- the lockfile pins **modules**, not the package graph
+- the builder discovers the **package graph** and compiles it at package granularity
+- Nix can cache and rebuild **individual Go packages**, not just the whole app
+- local packages, third-party packages, and test-only packages can be modeled
+  separately in default mode
+
+This tends to work especially well for monorepos and multi-package repositories
+that want to maximize Nix store reuse. When only part of the Go package graph
+changes, go2nix can often reuse the rest of the graph instead of rebuilding the
+whole application derivation.
+
+The approach is architecturally inspired by Bazel's `rules_go`: both systems
+work from an explicit package graph instead of treating `go build` as a black
+box. The difference is scope — `rules_go` is a full Bazel rule ecosystem,
+while go2nix is a Nix-native builder with a much narrower goal. It does not
+aim to replicate toolchain transitions, proto rules, or the full feature
+surface of `rules_go`.
+
+If you just want the simplest way to package a Go program in nixpkgs,
+`buildGoModule` is still the default choice. go2nix is aimed at cases where
+per-package reuse and explicit graph handling are worth the extra machinery.
+
+See [Architecture](docs/src/go2nix-architecture.md) for how the builder works
+and [Builder API](docs/src/builder-api.md) for the full attribute reference.
+
 ## Quick start
 
 ### 1. Generate a lockfile
@@ -53,10 +85,10 @@ nix build
 
 ## Builder modes
 
-| Mode | How it works | Lockfile | Caching |
-|------|-------------|----------|---------|
-| **Default** | `go tool compile/link` per-package | `[mod]` only | Per-package |
-| **Experimental** | Recursive-nix at build time | `[mod]` only | Per-package |
+| Mode | How it works | Requires |
+|------|-------------|----------|
+| **Default** | `go tool compile/link` per-package | [go2nix-nix-plugin](packages/go2nix-nix-plugin/) — Nix plugin providing `builtins.resolveGoPackages` |
+| **Experimental** | Recursive-nix at build time | Nix >= 2.34 with `recursive-nix`, `ca-derivations`, `dynamic-derivations` |
 
 ```nix
 # Default (recommended):
@@ -66,8 +98,8 @@ goEnv.buildGoApplication { ... }
 goEnv.buildGoApplicationExperimental { ... }
 ```
 
-See [docs/src/go2nix-architecture.md](docs/src/go2nix-architecture.md) for
-details on each mode.
+See [Default Mode](docs/src/modes/default-mode.md) and
+[Experimental Mode](docs/src/modes/experimental-mode.md) for details.
 
 ## CLI commands
 
@@ -76,12 +108,36 @@ details on each mode.
 | `go2nix generate` | Generate `go2nix.toml` lockfile |
 | `go2nix check` | Validate lockfile against `go.mod` |
 
-Run `go2nix generate -h` for all flags.
+See [CLI Reference](docs/src/cli-reference.md) for all commands and flags.
 
-## Documentation
+## Comparison with Nix alternatives
 
-- [Architecture](docs/src/go2nix-architecture.md) — builder modes, lockfile format,
-  compilation pipeline
+| Tool | Main model | Best at | Tradeoff vs go2nix |
+|------|------------|---------|--------------------|
+| `buildGoModule` | One fetch derivation + one main build derivation | Standard nixpkgs packaging, lowest conceptual overhead | Coarser caching; Nix does not model the Go package graph |
+| `gomod2nix` | Lock modules, then build with `go build` in a conventional app derivation | Offline reproducible app builds with a mature lockfile workflow | Still largely app-level/module-level, not package-graph-level |
+| `gobuild.nix` | Per-module derivations backed by `GOCACHEPROG` | Incremental module builds and package-set style composition | Granularity is centered on modules and Go cache subsets, not direct per-package derivations |
+| `nix-gocacheprog` | Reuse Go's own cache through a host daemon and sandbox hole | Fast local development on one machine | Intentionally impure; optimization layer, not a pure package-graph builder |
+| `go2nix` | Discover package graph and compile with `go tool compile/link` per package | Fine-grained Nix caching and explicit package-level rebuilds | More moving parts; default mode needs the plugin |
+
+### In one sentence
+
+- Choose `buildGoModule` when you want the standard nixpkgs path.
+- Choose `gomod2nix` when you want an offline lockfile-driven app build.
+- Choose `nix-gocacheprog` when you want faster local iteration and accept impurity.
+- Choose `gobuild.nix` when per-module package-set composition is the goal.
+- Choose `go2nix` when you want Nix to understand and cache the Go build at
+  package granularity.
+
+## Repository layout
+
+```
+go/go2nix/       Go CLI (generate, compile, resolve, test runner)
+nix/             Nix builders (dag/ for default mode, dynamic/ for experimental)
+packages/        Nix package definitions (go2nix, nix-plugin, test fixtures)
+tests/           Integration test fixtures and harnesses
+docs/            mdBook documentation
+```
 
 ## Development
 
@@ -92,9 +148,9 @@ direnv allow   # or: nix develop
 ```
 
 ```bash
-go test ./pkg/...      # Go tests
-nix-build tests/       # Nix integration tests
-nix fmt                # format all files
+cd go/go2nix && go test ./...               # Go unit tests
+nix build .#test-dag-fixture-testify-basic  # Nix integration test (one fixture)
+nix fmt                                     # format all files
 ```
 
 ## License

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,8 +1,10 @@
 # Summary
 
 - [Architecture](go2nix-architecture.md)
+- [Builder API](builder-api.md)
 - [CLI Reference](cli-reference.md)
 - [Lockfile Format](lockfile-format.md)
+- [Test Support](test-support.md)
 - [Builder Modes](modes/README.md)
   - [Default Mode](modes/default-mode.md)
   - [Experimental Mode](modes/experimental-mode.md)

--- a/docs/src/builder-api.md
+++ b/docs/src/builder-api.md
@@ -1,0 +1,192 @@
+# Builder API Reference
+
+Both builders accept a shared set of attributes. Differences are noted below.
+
+## `buildGoApplication` (default mode)
+
+```nix
+goEnv.buildGoApplication {
+  src = ./.;
+  goLock = ./go2nix.toml;
+  pname = "my-app";
+  version = "0.1.0";
+}
+```
+
+## `buildGoApplicationExperimental` (experimental mode)
+
+```nix
+goEnv.buildGoApplicationExperimental {
+  src = ./.;
+  goLock = ./go2nix.toml;
+  pname = "my-app";
+  version = "0.1.0";
+}
+```
+
+Requires `nixPackage` to be set in `mkGoEnv` and Nix >= 2.34 with
+`recursive-nix`, `ca-derivations`, and `dynamic-derivations` enabled.
+
+## Required attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `src` | path | Source tree. For monorepos with `modRoot`, this should be the repository root. |
+| `goLock` | path | Path to `go2nix.toml` lockfile. |
+| `pname` | string | Package name for the output derivation. |
+| `version` | string | Package version. |
+
+## Optional attributes
+
+| Attribute | Type | Default | Modes | Description |
+|-----------|------|---------|-------|-------------|
+| `subPackages` | list of strings | `[ "." ]` | both | Packages to build, relative to `modRoot`. A `./` prefix is auto-added if missing. |
+| `modRoot` | string | `"."` | both | Subdirectory within `src` containing `go.mod`. |
+| `tags` | list of strings | `[]` | both | Go build tags. |
+| `ldflags` | list of strings | `[]` | both | Flags passed to `go tool link` (`-s`, `-w`, `-X`, etc.). |
+| `gcflags` | list of strings | `[]` | both | Extra flags passed to `go tool compile`. |
+| `CGO_ENABLED` | `0`, `1`, or `null` | `null` (auto) | both | Override CGO detection. When `null`, CGO is enabled per-package based on the presence of C/C++ files. |
+| `pgoProfile` | path or `null` | `null` | both | Path to a pprof CPU profile for profile-guided optimization. |
+| `nativeBuildInputs` | list | `[]` | both | Extra build inputs for the final derivation. |
+| `packageOverrides` | attrset | `{}` | both | Per-package customization (see below). |
+| `doCheck` | bool | `modRoot == "."` | default only | Run tests. Defaults to `false` when `modRoot` is set, because test discovery may not find local replace targets outside the module root. |
+| `checkFlags` | list of strings | `[]` | default only | Flags passed to the compiled test binary (e.g., `-v`, `-count=1`). |
+| `goProxy` | string or `null` | `null` | default only | Custom GOPROXY URL. |
+| `allowGoReference` | bool | `false` | default only | Allow the output to reference the Go toolchain. |
+| `meta` | attrset | `{}` | default only | Nix meta attributes. |
+
+## `modRoot`
+
+When building one module inside a larger source tree (e.g., a monorepo), set
+`src` to the repository root and `modRoot` to the subdirectory containing
+`go.mod`:
+
+```nix
+goEnv.buildGoApplication {
+  src = ./.;
+  goLock = ./app/go2nix.toml;
+  pname = "my-app";
+  version = "0.1.0";
+  modRoot = "app";
+  subPackages = [ "cmd/server" ];
+}
+```
+
+This is necessary when the module uses `replace` directives pointing to sibling
+directories outside `modRoot`. The builder needs access to the full `src` tree,
+with `modRoot` telling it where `go.mod` lives.
+
+When `modRoot != "."`, `doCheck` defaults to `false` because the filtered
+source tree for tests may not include out-of-tree replace targets. Override
+with `doCheck = true` if your layout doesn't use out-of-tree replaces.
+
+## `subPackages`
+
+List of packages to build, relative to `modRoot`. Each entry is a Go package
+path like `"cmd/server"` or `"."` (the module root package).
+
+A `./` prefix is added automatically if missing, so `"cmd/server"` and
+`"./cmd/server"` are equivalent.
+
+The default `[ "." ]` builds the package at `modRoot`.
+
+## `packageOverrides`
+
+Per-package customization keyed by Go import path or module path:
+
+```nix
+packageOverrides = {
+  "github.com/mattn/go-sqlite3" = {
+    nativeBuildInputs = [ pkg-config sqlite ];
+  };
+};
+```
+
+Override lookup: exact import path first, then module path.
+
+### Supported override attributes
+
+| Attribute | Default mode | Experimental mode |
+|-----------|-------------|-------------------|
+| `nativeBuildInputs` | yes | yes |
+| `env` | yes | no |
+
+The `env` attribute sets environment variables on the per-package derivation:
+
+```nix
+packageOverrides = {
+  "github.com/example/pkg" = {
+    env = {
+      CGO_CFLAGS = "-I${libfoo.dev}/include";
+    };
+  };
+};
+```
+
+The experimental builder rejects unknown attributes (including `env`) at eval
+time. Derivations are synthesized at build time by `go2nix resolve`, so only
+`nativeBuildInputs` (store paths) can be forwarded.
+
+## `mkGoEnv`
+
+Both builders are accessed through a scope created by `mkGoEnv`:
+
+```nix
+goEnv = go2nix.lib.mkGoEnv {
+  inherit (pkgs) go callPackage;
+  go2nix = go2nix.packages.${system}.go2nix;
+
+  # Optional:
+  tags = [ "nethttpomithttp2" ];
+  netrcFile = ./my-netrc;
+  nixPackage = pkgs.nixVersions.latest;  # required for experimental mode
+};
+```
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `go` | derivation | required | Go toolchain. |
+| `go2nix` | derivation | required | go2nix CLI binary. |
+| `callPackage` | function | required | `pkgs.callPackage`. |
+| `tags` | list of strings | `[]` | Build tags applied to all builds in this scope. |
+| `netrcFile` | path or `null` | `null` | `.netrc` file for private module authentication (see below). |
+| `nixPackage` | derivation or `null` | `null` | Nix binary. Required for `buildGoApplicationExperimental`. |
+
+## Private modules (`netrcFile`)
+
+Go modules hosted behind authentication (private Git repos, private proxies)
+require credentials. Set `netrcFile` in `mkGoEnv` to a `.netrc` file:
+
+```nix
+goEnv = go2nix.lib.mkGoEnv {
+  inherit (pkgs) go callPackage;
+  go2nix = go2nix.packages.${system}.go2nix;
+  netrcFile = ./secrets/netrc;
+};
+```
+
+The file uses standard [`.netrc` format](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html):
+
+```
+machine github.com
+login x-access-token
+password ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+machine proxy.example.com
+login myuser
+password mytoken
+```
+
+The file is copied to `$HOME/.netrc` inside each module fetch derivation.
+Go's default `GOPROXY` (`https://proxy.golang.org,direct`) falls back to
+direct VCS access when the proxy returns 404, so `netrcFile` covers both
+proxy-authenticated and direct-access private module setups.
+
+In experimental mode, the file is passed as `--netrc-file` to
+`go2nix resolve`, which forwards it to the module FODs built inside
+the recursive-nix sandbox.
+
+**Note:** The netrc file becomes a Nix store path, so its contents are
+world-readable in `/nix/store`. For sensitive credentials, consider using
+a secrets manager or a file reference outside the store (e.g., via
+`builtins.readFile` from a non-tracked path).

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -143,3 +143,61 @@ go2nix resolve [flags]
 
 This command is not intended for direct use — it is invoked by the dynamic
 mode Nix builder inside a recursive-nix build.
+
+## build-modinfo
+
+Generate a `modinfo` linker directive for embedding `debug/buildinfo`
+metadata into the final binary. Used internally by the link hook.
+
+```
+go2nix build-modinfo [flags] <module-root>
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--lockfile` | Yes | Path to go2nix.toml lockfile |
+| `--go` | No | Path to go binary (default: from PATH) |
+
+Outputs a `modinfo` directive for the linker's importcfg (embedding
+`debug/buildinfo` metadata), and optionally a `godebug` line with the
+default GODEBUG value parsed from the module's `go.mod` (used for
+`-X=runtime.godebugDefault=...`).
+
+## generate-test-main
+
+Generate a `_testmain.go` file that registers test, benchmark, fuzz, and
+example functions. Used internally by the test runner.
+
+```
+go2nix generate-test-main [flags]
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--import-path` | Yes | Import path of the package under test |
+| `--test-files` | No | Comma-separated absolute paths to internal `_test.go` files |
+| `--xtest-files` | No | Comma-separated absolute paths to external `_test.go` files |
+| `--output` | No | Output file path (default: stdout) |
+
+## test-packages
+
+Compile and run tests for all testable local packages in a module. Used
+internally by the default mode's check phase.
+
+```
+go2nix test-packages [flags] <module-root>
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--import-cfg` | Yes | Path to importcfg file (from build phase) |
+| `--local-dir` | Yes | Directory with compiled local `.a` files |
+| `--tags` | No | Comma-separated build tags |
+| `--gc-flags` | No | Extra flags for `go tool compile` |
+| `--trim-path` | No | Path prefix to trim |
+| `--check-flags` | No | Flags passed to the test binary (e.g., `-v -count=1`) |
+
+Discovers local packages with `_test.go` files, compiles internal and
+external test archives, generates test mains, links test binaries, and
+runs them. See [test-support.md](test-support.md) for details on the
+test pipeline.

--- a/docs/src/go2nix-architecture.md
+++ b/docs/src/go2nix-architecture.md
@@ -14,6 +14,24 @@ The system has two components:
 1. **A Nix library** that reads lockfiles and builds Go applications using
    one of two modes.
 
+## Design context
+
+go2nix builds Go applications at package granularity rather than treating
+`go build` as a single opaque step. The approach is architecturally inspired
+by Bazel's `rules_go` — both systems work from an explicit package graph —
+but go2nix has a much narrower scope: bring package-graph-aware Go builds to
+Nix derivations and lockfiles, not replicate a full Bazel rule ecosystem.
+
+### Comparison with other Nix Go builders
+
+| Tool | Granularity | Key difference from go2nix |
+|------|-------------|---------------------------|
+| `buildGoModule` | App-level (one fetch + one build derivation) | Nix doesn't model the Go package graph; any change rebuilds the whole app |
+| `gomod2nix` | Module-level (lockfile-driven offline builds) | Focuses on locking and fetching modules, not per-package compilation |
+| `gobuild.nix` | Module-level (`GOCACHEPROG`-backed cache reuse) | Per-module derivations, not per-package; different caching layer |
+| `nix-gocacheprog` | Impure shared cache | Optimization for local iteration speed, not a pure builder |
+| **go2nix** | Package-level (per-package derivations) | Discovers the import graph and compiles each package as its own derivation |
+
 ## Builder modes
 
 | Mode | How it works | Lockfile | Caching | Nix features |

--- a/docs/src/test-support.md
+++ b/docs/src/test-support.md
@@ -1,0 +1,113 @@
+# Test Support
+
+go2nix runs Go tests during the check phase of default mode builds. Tests are
+compiled and executed per-package, approximating `go test` semantics for
+supported cases (see [Limitations](#limitations) below).
+
+## Enabling tests
+
+Tests are controlled by `doCheck`:
+
+```nix
+goEnv.buildGoApplication {
+  src = ./.;
+  goLock = ./go2nix.toml;
+  pname = "my-app";
+  version = "0.1.0";
+  doCheck = true;
+}
+```
+
+`doCheck` defaults to `true` when `modRoot == "."` and `false` otherwise.
+When `modRoot` points to a subdirectory, the source tree filtered for the
+final derivation may not include local replace targets outside the module
+root, causing test discovery to fail. Override with `doCheck = true` if your
+layout doesn't use out-of-tree replaces.
+
+## What gets tested
+
+The test runner discovers all local packages (under `modRoot`) that contain
+`_test.go` files and runs their tests. Third-party packages are not tested.
+
+Each testable package goes through these steps:
+
+1. **Internal test compilation** — library source files + `_test.go` files
+   in the same package are compiled together into a single archive that
+   replaces the library archive.
+2. **Dependent recompilation** — local packages that transitively depend on
+   the package under test are recompiled against the test archive so the
+   dependency graph stays consistent (Go's "recompileForTest" logic).
+3. **External test compilation** — `_test.go` files in the `*_test` package
+   (xtests) are compiled as a separate package that imports the internal
+   test archive.
+4. **Test main generation** — a `_testmain.go` is generated that registers
+   all `Test*`, `Benchmark*`, `Fuzz*`, and `Example*` functions.
+5. **Link and run** — the test binary is linked and executed in the package's
+   source directory.
+
+### Internal tests vs external tests (xtests)
+
+Go has two kinds of test files, both supported:
+
+- **Internal tests** (`package foo`): `_test.go` files in the same package.
+  These can access unexported identifiers. They are compiled together with
+  the package's regular source files into a single archive.
+
+- **External tests** (`package foo_test`): `_test.go` files in the `_test`
+  package. These can only access exported identifiers and test the public
+  API. They are compiled as a separate package (`foo_test`) that imports
+  `foo`.
+
+When a package has both, the internal test archive replaces the original
+library archive, and any local dependents reachable from the xtest's import
+graph are recompiled to see the replacement.
+
+## Test-only dependencies
+
+When `doCheck = true`, the plugin runs a second `go list -deps -test` pass
+to discover third-party packages that are only reachable through test
+imports (e.g., `github.com/stretchr/testify`). These are built as separate
+`testPackages` derivations and included in a `testDepsImportcfg` bundle
+that is a superset of the build importcfg.
+
+This means test-only dependencies don't affect the build derivation or its
+cache key — they only appear in the check phase.
+
+## `//go:embed` in tests
+
+Embed directives in test files are supported:
+
+- `TestEmbedPatterns` (from internal `_test.go` files) are resolved and
+  their files are symlinked into the internal test source directory alongside
+  the package's regular embed files. The embed configs are merged.
+
+- `XTestEmbedPatterns` (from external `_test.go` files) are resolved and
+  symlinked into the xtest source directory with their own embed config.
+
+## `checkFlags`
+
+Extra flags passed to the test binary (not to `go test`, since go2nix
+compiles and runs tests directly):
+
+```nix
+goEnv.buildGoApplication {
+  src = ./.;
+  goLock = ./go2nix.toml;
+  pname = "my-app";
+  version = "0.1.0";
+  checkFlags = [ "-v" "-count=1" ];
+}
+```
+
+These map to the standard `testing` package flags (`-v`, `-run`, `-count`,
+`-bench`, `-timeout`, etc.).
+
+## Limitations
+
+- **Default mode only.** The experimental builder does not run tests.
+- **`modRoot != "."`** disables tests by default. The source filter for the
+  final derivation may exclude sibling modules needed by tests.
+- **No test caching.** Tests run fresh on every build (there is no
+  persistent test cache across derivations).
+- **Third-party tests are not run.** Only local packages under the module
+  root are tested.


### PR DESCRIPTION
## Summary

- Rewrite README: add motivation, quick start, builder modes with requirements, landscape comparison table, repository layout, fix dev commands
- Add `builder-api.md`: full attribute reference for both builders, modRoot/subPackages, packageOverrides (env + nativeBuildInputs), mkGoEnv, netrcFile
- Add `test-support.md`: doCheck, internal vs external tests, test-only deps, embed in tests, checkFlags, limitations
- Complete `cli-reference.md`: add missing build-modinfo, generate-test-main, test-packages commands
- Add design context and Nix builder comparison table to `go2nix-architecture.md`