### PR TITLE
feat: auto-normalize subPackages with ./ prefix

### DIFF
--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -54,6 +54,8 @@
 let
   inherit (builtins) concatStringsSep;
 
+  normalizedSubPackages = helpers.normalizeSubPackages subPackages;
+
   # --- Module resolution from lockfile (pure-Nix TOML parsing) ---
   lockfile = builtins.fromTOML (builtins.readFile goLock);
   modTable = lockfile.mod or { };
@@ -87,10 +89,10 @@ let
       inherit
         src
         tags
-        subPackages
         modRoot
         doCheck
         ;
+      subPackages = normalizedSubPackages;
     }
     // (if goProxy != null then { inherit goProxy; } else { })
   );
@@ -383,7 +385,7 @@ let
       subPkgDirs = map (sp:
         let clean = lib.removePrefix "./" sp;
         in if modRoot == "." then clean else "${modRoot}/${clean}"
-      ) subPackages;
+      ) normalizedSubPackages;
       # Include modRoot for go.mod access.
       allowedDirs = [ modRoot ] ++ subPkgDirs;
       # When modRoot is "." or any subPackage resolves to ".", the entire
@@ -469,7 +471,7 @@ stdenv.mkDerivation (
 
     env = {
       goModuleRoot = moduleRoot;
-      goSubPackages = concatStringsSep " " subPackages;
+      goSubPackages = concatStringsSep " " normalizedSubPackages;
       goLdflags = ldflagsStr;
       goGcflags = gcflagsStr;
       goLockfile = "${builtins.path { path = goLock; name = "go2nix-lockfile"; }}";

--- a/nix/dynamic/default.nix
+++ b/nix/dynamic/default.nix
@@ -25,6 +25,7 @@
   cacert,
   netrcFile,
   stdlib,
+  helpers,
 }:
 
 {
@@ -55,6 +56,8 @@ assert
   lib.assertMsg (lib.versionAtLeast "${major}.${minor}" "2.34") "go2nix dynamic mode requires Nix >= 2.34 (v4 derivation JSON format), got ${nixPackage.version}";
 
 let
+  normalizedSubPackages = helpers.normalizeSubPackages subPackages;
+
   # Validate packageOverrides: experimental mode only supports nativeBuildInputs.
   # Derivations are synthesized at build time by `go2nix resolve`, so env and
   # other attrs cannot be forwarded. Fail early instead of silently dropping.
@@ -135,7 +138,7 @@ let
         --bash ${bash}/bin/bash \
         --coreutils ${coreutils}/bin/mkdir \
         --pname ${lib.escapeShellArg pname} \
-        --sub-packages ${lib.escapeShellArg (lib.concatStringsSep "," subPackages)} \
+        --sub-packages ${lib.escapeShellArg (lib.concatStringsSep "," normalizedSubPackages)} \
         --tags ${lib.escapeShellArg (lib.concatStringsSep "," tags)} \
         --ldflags ${lib.escapeShellArg (lib.concatStringsSep " " ldflags)} \
         --overrides ${lib.escapeShellArg overridesJSON} \

--- a/nix/helpers.nix
+++ b/nix/helpers.nix
@@ -70,4 +70,11 @@
         "!y"
         "!z"
       ];
+
+  # Normalize a subPackages list: ensure all entries have "./" prefix so
+  # they are interpreted as relative paths, not stdlib packages.
+  # "." is passed through as-is.
+  normalizeSubPackages = map (
+    sp: if sp == "." || builtins.substring 0 2 sp == "./" then sp else "./${sp}"
+  );
 }


### PR DESCRIPTION
## Summary

- Add `normalizeSubPackages` helper to `nix/helpers.nix` that auto-prepends `./` to subPackages entries missing it
- Both default (dag) and experimental (dynamic) builders use the shared helper
- Users can now write `subPackages = [ "cmd/server" ]` instead of `[ "./cmd/server" ]`
- `"."` is passed through as-is
- Matches `buildGoModule` behavior which also normalizes the prefix