### PR TITLE
feat: test manifest support (hook composition step 2)

### DIFF
--- a/go/go2nix/cmd/go2nix/testpkgs.go
+++ b/go/go2nix/cmd/go2nix/testpkgs.go
@@ -4,33 +4,84 @@ import (
 	"flag"
 	"log/slog"
 	"os"
+	"path/filepath"
+	"strings"
 
+	"github.com/numtide/go2nix/pkg/compile"
 	"github.com/numtide/go2nix/pkg/testrunner"
 )
 
 func runTestPackagesCmd(args []string) {
 	fs := flag.NewFlagSet("test-packages", flag.ExitOnError)
-	importCfg := fs.String("import-cfg", "", "path to importcfg file")
-	localDir := fs.String("local-dir", "", "directory with compiled local .a files")
-	tags := fs.String("tags", "", "comma-separated build tags")
-	gcflags := fs.String("gc-flags", "", "extra flags for go tool compile")
+	manifest := fs.String("manifest", "", "path to test-manifest.json (when set, manifest fields are authoritative)")
+	importCfg := fs.String("import-cfg", "", "path to importcfg file (legacy, ignored when --manifest is set)")
+	localDir := fs.String("local-dir", "", "directory with compiled local .a files (legacy, ignored when --manifest is set)")
+	tags := fs.String("tags", "", "comma-separated build tags (legacy, ignored when --manifest is set)")
+	gcflags := fs.String("gc-flags", "", "extra flags for go tool compile (legacy, ignored when --manifest is set)")
 	trimPath := fs.String("trim-path", "", "path prefix to trim (default: $NIX_BUILD_TOP)")
-	checkFlags := fs.String("check-flags", "", "flags to pass to test binaries")
+	checkFlags := fs.String("check-flags", "", "flags to pass to test binaries (legacy, ignored when --manifest is set)")
 	fs.Parse(args)
 
-	if fs.NArg() != 1 || *importCfg == "" || *localDir == "" {
-		slog.Error("usage: go2nix test-packages --import-cfg FILE --local-dir DIR [--tags TAGS] [--gc-flags FLAGS] [--trim-path PATH] [--check-flags FLAGS] <module-root>")
-		os.Exit(1)
-	}
+	var opts testrunner.Options
 
-	opts := testrunner.Options{
-		ModuleRoot: fs.Arg(0),
-		ImportCfg:  *importCfg,
-		LocalDir:   *localDir,
-		TrimPath:   *trimPath,
-		Tags:       *tags,
-		GCFlags:    *gcflags,
-		CheckFlags: *checkFlags,
+	if *manifest != "" {
+		// Manifest mode: manifest fields are authoritative.
+		m, err := compile.LoadTestManifest(*manifest)
+		if err != nil {
+			slog.Error("test-packages: failed to load manifest", "err", err)
+			os.Exit(1)
+		}
+
+		// Merge importcfg parts.
+		tmpDir := os.Getenv("NIX_BUILD_TOP")
+		if tmpDir == "" {
+			tmpDir = os.TempDir()
+		}
+		mergedCfg, err := compile.MergeImportcfg(m.ImportcfgParts, tmpDir)
+		if err != nil {
+			slog.Error("test-packages: failed to merge importcfg", "err", err)
+			os.Exit(1)
+		}
+
+		// Reconstruct local-pkgs directory from manifest's localArchives map.
+		localPkgsDir := filepath.Join(tmpDir, "local-pkgs")
+		for importPath, archivePath := range m.LocalArchives {
+			dir := filepath.Join(localPkgsDir, filepath.Dir(importPath))
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				slog.Error("test-packages: failed to create local-pkgs dir", "err", err)
+				os.Exit(1)
+			}
+			dst := filepath.Join(localPkgsDir, importPath+".a")
+			if err := os.Symlink(archivePath, dst); err != nil && !os.IsExist(err) {
+				slog.Error("test-packages: failed to symlink local archive", "err", err, "path", importPath)
+				os.Exit(1)
+			}
+		}
+
+		opts = testrunner.Options{
+			ModuleRoot: m.ModuleRoot,
+			ImportCfg:  mergedCfg,
+			LocalDir:   localPkgsDir,
+			TrimPath:   tmpDir,
+			Tags:       strings.Join(m.Tags, ","),
+			GCFlags:    strings.Join(m.GCFlags, " "),
+			CheckFlags: strings.Join(m.CheckFlags, " "),
+		}
+	} else {
+		// Legacy mode: flags are authoritative.
+		if fs.NArg() != 1 || *importCfg == "" || *localDir == "" {
+			slog.Error("usage: go2nix test-packages [--manifest FILE | --import-cfg FILE --local-dir DIR] [--tags TAGS] [--gc-flags FLAGS] [--trim-path PATH] [--check-flags FLAGS] <module-root>")
+			os.Exit(1)
+		}
+		opts = testrunner.Options{
+			ModuleRoot: fs.Arg(0),
+			ImportCfg:  *importCfg,
+			LocalDir:   *localDir,
+			TrimPath:   *trimPath,
+			Tags:       *tags,
+			GCFlags:    *gcflags,
+			CheckFlags: *checkFlags,
+		}
 	}
 
 	if err := testrunner.Run(opts); err != nil {

--- a/go/go2nix/pkg/compile/manifest.go
+++ b/go/go2nix/pkg/compile/manifest.go
@@ -47,6 +47,40 @@ func LoadCompileManifest(path string) (*CompileManifest, error) {
 	return &m, nil
 }
 
+// ManifestKindTest is the kind value for test manifests.
+const ManifestKindTest = "test"
+
+// TestManifest is the JSON contract between Nix and go2nix test-packages.
+type TestManifest struct {
+	Version        int               `json:"version"`
+	Kind           string            `json:"kind"`
+	ImportcfgParts []string          `json:"importcfgParts"`
+	LocalArchives  map[string]string `json:"localArchives"`
+	ModuleRoot     string            `json:"moduleRoot"`
+	Tags           []string          `json:"tags"`
+	GCFlags        []string          `json:"gcflags"`
+	CheckFlags     []string          `json:"checkFlags"`
+}
+
+// LoadTestManifest reads and validates a test manifest from path.
+func LoadTestManifest(path string) (*TestManifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading test manifest: %w", err)
+	}
+	var m TestManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing test manifest: %w", err)
+	}
+	if m.Version != ManifestVersion {
+		return nil, fmt.Errorf("test manifest: unsupported version %d (expected %d)", m.Version, ManifestVersion)
+	}
+	if m.Kind != ManifestKindTest {
+		return nil, fmt.Errorf("test manifest: wrong kind %q (expected %q)", m.Kind, ManifestKindTest)
+	}
+	return &m, nil
+}
+
 // MergeImportcfg merges multiple importcfg files into a single file.
 // Each input file is read line by line; lines starting with "packagefile "
 // or "importmap " are included. Blank lines and comments are skipped.

--- a/go/go2nix/pkg/compile/manifest_test.go
+++ b/go/go2nix/pkg/compile/manifest_test.go
@@ -141,6 +141,61 @@ func TestMergeImportcfg_empty(t *testing.T) {
 	}
 }
 
+func TestLoadTestManifest(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		wantErr string
+	}{
+		{
+			name: "valid manifest",
+			json: `{"version":1,"kind":"test","importcfgParts":["/a/importcfg"],"localArchives":{"example.com/foo":"/nix/store/foo.a"},"moduleRoot":"/nix/store/src","tags":[],"gcflags":[],"checkFlags":["-v"]}`,
+		},
+		{
+			name:    "wrong kind",
+			json:    `{"version":1,"kind":"compile","importcfgParts":[],"localArchives":{},"moduleRoot":"/src","tags":[],"gcflags":[],"checkFlags":[]}`,
+			wantErr: `wrong kind "compile"`,
+		},
+		{
+			name:    "wrong version",
+			json:    `{"version":99,"kind":"test","importcfgParts":[],"localArchives":{},"moduleRoot":"/src","tags":[],"gcflags":[],"checkFlags":[]}`,
+			wantErr: "unsupported version 99",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "manifest.json")
+			if err := os.WriteFile(path, []byte(tt.json), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			m, err := LoadTestManifest(path)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if got := err.Error(); !contains(got, tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if m.ModuleRoot != "/nix/store/src" {
+				t.Errorf("moduleRoot = %q", m.ModuleRoot)
+			}
+			if len(m.LocalArchives) != 1 || m.LocalArchives["example.com/foo"] != "/nix/store/foo.a" {
+				t.Errorf("localArchives = %v", m.LocalArchives)
+			}
+			if len(m.CheckFlags) != 1 || m.CheckFlags[0] != "-v" {
+				t.Errorf("checkFlags = %v", m.CheckFlags)
+			}
+		})
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -455,6 +455,29 @@ let
     "checkFlags"
   ];
 
+  # Test manifest: only materialized when doCheck = true.
+  # Selects testDepsImportcfg when test-only deps exist, depsImportcfg otherwise.
+  hasTestDeps = doCheck
+    && goPackagesResult ? testPackages
+    && goPackagesResult.testPackages != { };
+
+  testManifestJSON = lib.optionalString doCheck (builtins.toJSON {
+    version = 1;
+    kind = "test";
+    importcfgParts =
+      if hasTestDeps
+      then [ "${testDepsImportcfg}/importcfg" ]
+      else [ "${depsImportcfg}/importcfg" ];
+    localArchives = builtins.mapAttrs (
+      importPath: pkg: "${pkg}/${importPath}.a"
+    ) localPackages;
+    moduleRoot = moduleRoot;
+    inherit tags;
+    gcflags =
+      if buildMode == "pie" then [ "-shared" ] ++ gcflags else gcflags;
+    checkFlags = checkFlags;
+  });
+
 in
 stdenv.mkDerivation (
   extraArgs
@@ -501,17 +524,6 @@ stdenv.mkDerivation (
     }
     // (if CGO_ENABLED != null then { inherit CGO_ENABLED; } else { })
     // (if pgoProfile != null then { goPgoProfile = "${pgoProfile}"; } else { })
-    // (if checkFlags != [] then { goCheckFlags = concatStringsSep " " checkFlags; } else { });
+    // (if doCheck then { inherit testManifestJSON; } else { });
   }
-  # Local package archives for checkPhase: structured attr becomes a bash
-  # associative array mapping import path -> store path of compiled .a file.
-  # Only included when doCheck is true to preserve the O(1) input-validation
-  # optimization from depsImportcfg — without this guard, every local package
-  # store path would be a direct dependency of the final derivation via string
-  # context, reintroducing the O(N) fan-in that the bundle was designed to avoid.
-  // (if doCheck then {
-    goLocalArchives = builtins.mapAttrs (
-      importPath: pkg: "${pkg}/${importPath}.a"
-    ) localPackages;
-  } else { })
 )

--- a/nix/dag/hooks/link-go-binary.sh
+++ b/nix/dag/hooks/link-go-binary.sh
@@ -195,51 +195,11 @@ linkGoBinaryInstallPhase() {
 linkGoBinaryCheckPhase() {
   runHook preCheck
 
-  # Reconstruct local-pkgs directory from goLocalArchives (structured attr).
-  # Each local package derivation produces ${pkg}/${importPath}.a; we symlink
-  # them into the flat directory layout that test-packages --local-dir expects.
-  local localdir="$NIX_BUILD_TOP/local-pkgs"
-  mkdir -p "$localdir"
-  for importPath in "${!goLocalArchives[@]}"; do
-    mkdir -p "$localdir/$(dirname "$importPath")"
-    ln -s "${goLocalArchives[$importPath]}" "$localdir/$importPath.a"
-  done
-
-  # Locate the test importcfg bundle. buildInputs contains depsImportcfg and
-  # (when doCheck with test-only deps) testDepsImportcfg. testDepsImportcfg is
-  # a strict superset, so we want the last importcfg found. If there's only
-  # depsImportcfg (no test-only deps), it's used as-is — still correct since
-  # it already contains all build + local packages.
-  local test_importcfg=""
-  for dep in "${buildInputs[@]}"; do
-    if [ -f "$dep/importcfg" ]; then
-      test_importcfg="$dep/importcfg"
-    fi
-  done
-  if [ -z "$test_importcfg" ]; then
-    echo "go2nix: no importcfg bundle found in buildInputs for check phase" >&2
-    exit 1
-  fi
-
-  # Build gcflags for test compilation, matching the build phase logic.
-  local test_gcflags="${goGcflags:-}"
-  local go_buildmode="@buildMode@"
-  if [ "$go_buildmode" = "pie" ]; then
-    test_gcflags="-shared${test_gcflags:+ $test_gcflags}"
-  fi
-  local -a testGcflagArgs=()
-  if [ -n "$test_gcflags" ]; then
-    testGcflagArgs=(--gc-flags "$test_gcflags")
-  fi
+  # Write test manifest JSON to a file for go2nix to read.
+  echo "$testManifestJSON" > "$NIX_BUILD_TOP/test-manifest.json"
 
   @go2nix@ test-packages \
-    --import-cfg "$test_importcfg" \
-    --local-dir "$localdir" \
-    --trim-path "$NIX_BUILD_TOP" \
-    @tagArg@ \
-    "${testGcflagArgs[@]}" \
-    ${goCheckFlags:+--check-flags "$goCheckFlags"} \
-    "$goModuleRoot"
+    --manifest "$NIX_BUILD_TOP/test-manifest.json"
 
   runHook postCheck
 }


### PR DESCRIPTION
## Summary

Second step of hook composition: move test configuration from shell into a typed JSON manifest.

- Add `TestManifest` struct with JSON reader, version/kind validation, and `ManifestKindTest` constant
- Add `--manifest` flag to `test-packages`: when set, manifest fields are authoritative; legacy flags preserved without it
- Go now owns importcfg merging for tests (replacing shell's `buildInputs` scan) and local-pkgs directory reconstruction (replacing shell's associative array iteration)
- Nix writes `testManifestJSON` in the app derivation env when `doCheck=true`, containing importcfg parts, local archives map, module root, tags, gcflags, and checkFlags
- Shell check phase simplified to: write JSON to file, call `go2nix test-packages --manifest`
- Remove `goLocalArchives` structured attr and `goCheckFlags` env var from the app derivation

Stacked on #13.