### PR TITLE
feat: add link-binary command (hook composition step 3)

### DIFF
--- a/go/go2nix/cmd/go2nix/compile.go
+++ b/go/go2nix/cmd/go2nix/compile.go
@@ -58,16 +58,16 @@ func runCompilePackageCmd(args []string) {
 		}
 
 		opts = compile.Options{
-			ImportPath: *importPath,
-			PFlag:      *pFlag,
-			SrcDir:     *srcDir,
-			Output:     *output,
-			ImportCfg:  mergedCfg,
-			TrimPath:   *trimPath,
-			Tags:       strings.Join(m.Tags, ","),
-			GCFlags:    strings.Join(m.GCFlags, " "),
-			GoVersion:  *goVersion,
-			PGOProfile: pgo,
+			ImportPath:  *importPath,
+			PFlag:       *pFlag,
+			SrcDir:      *srcDir,
+			Output:      *output,
+			ImportCfg:   mergedCfg,
+			TrimPath:    *trimPath,
+			Tags:        strings.Join(m.Tags, ","),
+			GCFlagsList: m.GCFlags,
+			GoVersion:   *goVersion,
+			PGOProfile:  pgo,
 		}
 	} else {
 		// Legacy mode: flags are authoritative.

--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/numtide/go2nix/pkg/buildinfo"
+	"github.com/numtide/go2nix/pkg/compile"
+	"github.com/numtide/go2nix/pkg/lockfile"
+	"github.com/numtide/go2nix/pkg/mvscheck"
+)
+
+func runLinkBinaryCmd(args []string) {
+	fs := flag.NewFlagSet("link-binary", flag.ExitOnError)
+	manifestPath := fs.String("manifest", "", "path to link-manifest.json (required)")
+	output := fs.String("output", "", "output directory (binaries written to <output>/bin/)")
+	fs.Parse(args)
+
+	if *manifestPath == "" || *output == "" {
+		slog.Error("usage: go2nix link-binary --manifest FILE --output DIR")
+		os.Exit(1)
+	}
+
+	if err := linkBinary(*manifestPath, *output); err != nil {
+		slog.Error("link-binary failed", "err", err)
+		os.Exit(1)
+	}
+}
+
+func linkBinary(manifestPath, output string) error {
+	m, err := compile.LoadLinkManifest(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	tmpDir := os.Getenv("NIX_BUILD_TOP")
+	if tmpDir == "" {
+		tmpDir = os.TempDir()
+	}
+
+	// Step 1: Validate lockfile consistency.
+	if err := mvscheck.CheckLockfile(m.ModuleRoot, m.Lockfile); err != nil {
+		return fmt.Errorf("lockfile check: %w", err)
+	}
+
+	// Step 2: Extract module path from go.mod.
+	modulePath, err := extractModulePath(m.ModuleRoot)
+	if err != nil {
+		return err
+	}
+
+	// Step 3: Merge importcfg parts.
+	mergedCfg, err := compile.MergeImportcfg(m.ImportcfgParts, tmpDir)
+	if err != nil {
+		return fmt.Errorf("merging importcfg: %w", err)
+	}
+
+	// Add local archive entries to the merged importcfg.
+	{
+		f, err := os.OpenFile(mergedCfg, os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			return fmt.Errorf("opening merged importcfg: %w", err)
+		}
+		for importPath, archivePath := range m.LocalArchives {
+			fmt.Fprintf(f, "packagefile %s=%s\n", importPath, archivePath)
+		}
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("closing merged importcfg: %w", err)
+		}
+	}
+
+	// Step 4: Compute modinfo.
+	goVersion, err := goToolchainVersion()
+	if err != nil {
+		return fmt.Errorf("getting Go version: %w", err)
+	}
+
+	lock, err := lockfile.Read(m.Lockfile)
+	if err != nil {
+		return fmt.Errorf("reading lockfile: %w", err)
+	}
+
+	var deps []buildinfo.ModDep
+	for modKey := range lock.Mod {
+		modPath, version, ok := strings.Cut(modKey, "@")
+		if !ok {
+			continue
+		}
+		dep := buildinfo.ModDep{Path: modPath, Version: version}
+		if replacePath, ok := lock.Replace[modKey]; ok {
+			dep.Replace = &buildinfo.ModDep{Path: replacePath, Version: version}
+		}
+		deps = append(deps, dep)
+	}
+
+	modinfo, err := buildinfo.GenerateModinfo(m.ModuleRoot, goVersion, deps)
+	if err != nil {
+		return fmt.Errorf("generating modinfo: %w", err)
+	}
+
+	godebugDefault := buildinfo.DefaultGODEBUG(m.ModuleRoot)
+
+	// Step 5: Build link importcfg (compile importcfg + modinfo).
+	linkCfg := filepath.Join(tmpDir, "importcfg.link")
+	{
+		data, err := os.ReadFile(mergedCfg)
+		if err != nil {
+			return err
+		}
+		content := string(data)
+		if modinfo != "" {
+			content += modinfo + "\n"
+		}
+		if err := os.WriteFile(linkCfg, []byte(content), 0o644); err != nil {
+			return err
+		}
+	}
+
+	// Step 6: Determine build mode.
+	goos := ""
+	goarch := ""
+	if m.GOOS != nil {
+		goos = *m.GOOS
+	}
+	if m.GOARCH != nil {
+		goarch = *m.GOARCH
+	}
+	if goos == "" {
+		goos = compile.GoEnvVar("GOOS")
+	}
+	if goarch == "" {
+		goarch = compile.GoEnvVar("GOARCH")
+	}
+	buildMode := compile.DefaultBuildMode(goos, goarch)
+
+	// Build gcflags: PIE requires -shared, then append manifest gcflags.
+	var gcflagsList []string
+	if buildMode == "pie" {
+		gcflagsList = append(gcflagsList, "-shared")
+	}
+	gcflagsList = append(gcflagsList, m.GCFlags...)
+
+	tagsStr := strings.Join(m.Tags, ",")
+
+	var pgoProfile string
+	if m.PGOProfile != nil {
+		pgoProfile = *m.PGOProfile
+	}
+
+	// Resolve the linker binary before clearing GOROOT.
+	goToolDir, err := exec.Command("go", "env", "GOTOOLDIR").Output()
+	if err != nil {
+		return fmt.Errorf("go env GOTOOLDIR: %w", err)
+	}
+	goLinkTool := filepath.Join(strings.TrimSpace(string(goToolDir)), "link")
+
+	// Do not set GOROOT: the linker reads it from os.Getenv and embeds it
+	// as runtime.defaultGOROOT. Invoking the linker directly matches what
+	// `go build -trimpath` does internally.
+	os.Setenv("GOROOT", "")
+
+	// Step 7: Compile main packages and link.
+	mainDir := filepath.Join(tmpDir, "main-pkgs")
+	binDir := filepath.Join(output, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		return err
+	}
+
+	for _, sp := range m.SubPackages {
+		var importpath, srcdir, binname string
+
+		clean := strings.TrimPrefix(sp, "./")
+		if sp == "." || clean == "" {
+			importpath = modulePath
+			srcdir = m.ModuleRoot
+			binname = m.Pname
+			if binname == "" {
+				binname = filepath.Base(modulePath)
+			}
+		} else {
+			importpath = modulePath + "/" + clean
+			srcdir = filepath.Join(m.ModuleRoot, clean)
+			binname = filepath.Base(clean)
+		}
+
+		slog.Info("compiling main", "pkg", importpath)
+
+		mainArchive := filepath.Join(mainDir, importpath+".a")
+		if err := os.MkdirAll(filepath.Dir(mainArchive), 0o755); err != nil {
+			return err
+		}
+
+		if err := compile.CompileGoPackage(compile.Options{
+			ImportPath:  "main",
+			SrcDir:      srcdir,
+			Output:      mainArchive,
+			ImportCfg:   mergedCfg,
+			TrimPath:    tmpDir,
+			Tags:        tagsStr,
+			GCFlagsList: gcflagsList,
+			PGOProfile:  pgoProfile,
+		}); err != nil {
+			return fmt.Errorf("compiling main %s: %w", importpath, err)
+		}
+
+		// Detect CGO from compilation.
+		hasCgo := fileExists(filepath.Join(tmpDir, ".has_cgo"))
+		hasCxx := fileExists(filepath.Join(tmpDir, ".has_cxx"))
+
+		// Compute link flags.
+		var linkFlags []string
+		if hasCgo {
+			extld := os.Getenv("CC")
+			if hasCxx {
+				extld = os.Getenv("CXX")
+			}
+			if extld == "" {
+				return fmt.Errorf("cgo package requires CC (or CXX) but none is set")
+			}
+			linkFlags = append(linkFlags, "-extld", extld, "-linkmode", "external")
+		}
+
+		// Propagate sanitizer flags from gcflags to linker.
+		for _, flag := range m.GCFlags {
+			switch flag {
+			case "-race", "-msan", "-asan":
+				linkFlags = append(linkFlags, flag)
+			}
+		}
+
+		// GODEBUG default.
+		if godebugDefault != "" {
+			linkFlags = append(linkFlags, "-X=runtime.godebugDefault="+godebugDefault)
+		}
+
+		// Assemble linker command.
+		linkArgs := []string{
+			"-buildid=redacted",
+			"-buildmode=" + buildMode,
+			"-importcfg", linkCfg,
+		}
+		linkArgs = append(linkArgs, m.LDFlags...)
+		linkArgs = append(linkArgs, linkFlags...)
+		linkArgs = append(linkArgs, "-o", filepath.Join(binDir, binname))
+		linkArgs = append(linkArgs, mainArchive)
+
+		slog.Info("linking", "pkg", importpath, "bin", binname)
+		cmd := exec.Command(goLinkTool, linkArgs...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("linking %s: %w", importpath, err)
+		}
+	}
+
+	return nil
+}
+
+func extractModulePath(moduleRoot string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(moduleRoot, "go.mod"))
+	if err != nil {
+		return "", fmt.Errorf("reading go.mod: %w", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "module ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "module ")), nil
+		}
+	}
+	return "", fmt.Errorf("could not extract module path from %s/go.mod", moduleRoot)
+}
+
+func goToolchainVersion() (string, error) {
+	out, err := exec.Command("go", "env", "GOVERSION").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+

--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -244,7 +244,11 @@ func linkBinary(manifestPath, output string) error {
 			"-buildmode=" + buildMode,
 			"-importcfg", linkCfg,
 		}
-		linkArgs = append(linkArgs, m.LDFlags...)
+		// Each ldflag element may contain spaces (e.g. "-X main.Version=1.6")
+		// that need splitting into separate args for the linker binary.
+		for _, ldf := range m.LDFlags {
+			linkArgs = append(linkArgs, strings.Fields(ldf)...)
+		}
 		linkArgs = append(linkArgs, linkFlags...)
 		linkArgs = append(linkArgs, "-o", filepath.Join(binDir, binname))
 		linkArgs = append(linkArgs, mainArchive)

--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -244,11 +244,7 @@ func linkBinary(manifestPath, output string) error {
 			"-buildmode=" + buildMode,
 			"-importcfg", linkCfg,
 		}
-		// Each ldflag element may contain spaces (e.g. "-X main.Version=1.6")
-		// that need splitting into separate args for the linker binary.
-		for _, ldf := range m.LDFlags {
-			linkArgs = append(linkArgs, strings.Fields(ldf)...)
-		}
+		linkArgs = append(linkArgs, expandLDFlags(m.LDFlags)...)
 		linkArgs = append(linkArgs, linkFlags...)
 		linkArgs = append(linkArgs, "-o", filepath.Join(binDir, binname))
 		linkArgs = append(linkArgs, mainArchive)
@@ -290,5 +286,17 @@ func goToolchainVersion() (string, error) {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// expandLDFlags splits each ldflag element by whitespace into separate args.
+// Nix users write ldflags like ["-X main.Version=1.6"] (one string with a
+// space). When invoking the linker directly (not via `go build`), each token
+// must be a separate exec arg.
+func expandLDFlags(flags []string) []string {
+	var out []string
+	for _, f := range flags {
+		out = append(out, strings.Fields(f)...)
+	}
+	return out
 }
 

--- a/go/go2nix/cmd/go2nix/linkbinary_test.go
+++ b/go/go2nix/cmd/go2nix/linkbinary_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpandLDFlags(t *testing.T) {
+	tests := []struct {
+		name  string
+		flags []string
+		want  []string
+	}{
+		{
+			name:  "nil input",
+			flags: nil,
+			want:  nil,
+		},
+		{
+			name:  "empty list",
+			flags: []string{},
+			want:  nil,
+		},
+		{
+			name:  "single-token flags pass through",
+			flags: []string{"-s", "-w"},
+			want:  []string{"-s", "-w"},
+		},
+		{
+			name:  "multi-token flag is split",
+			flags: []string{"-X main.Version=1.6"},
+			want:  []string{"-X", "main.Version=1.6"},
+		},
+		{
+			name:  "equals form is not split",
+			flags: []string{"-X=main.Version=1.6"},
+			want:  []string{"-X=main.Version=1.6"},
+		},
+		{
+			name:  "mixed flags",
+			flags: []string{"-s", "-X main.Version=1.6", "-w", "-X main.Commit=abc"},
+			want:  []string{"-s", "-X", "main.Version=1.6", "-w", "-X", "main.Commit=abc"},
+		},
+		{
+			name:  "extra whitespace is collapsed",
+			flags: []string{"  -s  ", "  -X   main.Version=1.6  "},
+			want:  []string{"-s", "-X", "main.Version=1.6"},
+		},
+		{
+			name:  "empty string element is skipped",
+			flags: []string{"", "-s", ""},
+			want:  []string{"-s"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := expandLDFlags(tt.flags)
+			if !slicesEqual(got, tt.want) {
+				t.Errorf("expandLDFlags(%v) = %v, want %v", tt.flags, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractModulePath(t *testing.T) {
+	dir := t.TempDir()
+	gomod := filepath.Join(dir, "go.mod")
+
+	os.WriteFile(gomod, []byte("module example.com/myapp\n\ngo 1.21\n"), 0o644)
+	got, err := extractModulePath(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "example.com/myapp" {
+		t.Errorf("got %q, want %q", got, "example.com/myapp")
+	}
+
+	// Missing go.mod returns error.
+	_, err = extractModulePath(t.TempDir())
+	if err == nil {
+		t.Error("expected error for missing go.mod")
+	}
+
+	// go.mod without module directive returns error.
+	nomod := filepath.Join(t.TempDir(), "go.mod")
+	os.WriteFile(nomod, []byte("go 1.21\n"), 0o644)
+	_, err = extractModulePath(filepath.Dir(nomod))
+	if err == nil {
+		t.Error("expected error for go.mod without module directive")
+	}
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/go/go2nix/cmd/go2nix/main.go
+++ b/go/go2nix/cmd/go2nix/main.go
@@ -40,9 +40,11 @@ func main() {
 		runGenTestMainCmd(os.Args[2:])
 	case "test-packages":
 		runTestPackagesCmd(os.Args[2:])
+	case "link-binary":
+		runLinkBinaryCmd(os.Args[2:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
-		fmt.Fprintf(os.Stderr, "usage: go2nix <generate|list-files|list-packages|compile-package|compile-packages|check|resolve|build-modinfo|generate-test-main|test-packages> [flags]\n")
+		fmt.Fprintf(os.Stderr, "usage: go2nix <generate|list-files|list-packages|compile-package|compile-packages|check|resolve|build-modinfo|generate-test-main|test-packages|link-binary> [flags]\n")
 		os.Exit(1)
 	}
 }

--- a/go/go2nix/cmd/go2nix/testpkgs.go
+++ b/go/go2nix/cmd/go2nix/testpkgs.go
@@ -59,13 +59,13 @@ func runTestPackagesCmd(args []string) {
 		}
 
 		opts = testrunner.Options{
-			ModuleRoot: m.ModuleRoot,
-			ImportCfg:  mergedCfg,
-			LocalDir:   localPkgsDir,
-			TrimPath:   tmpDir,
-			Tags:       strings.Join(m.Tags, ","),
-			GCFlags:    strings.Join(m.GCFlags, " "),
-			CheckFlags: strings.Join(m.CheckFlags, " "),
+			ModuleRoot:     m.ModuleRoot,
+			ImportCfg:      mergedCfg,
+			LocalDir:       localPkgsDir,
+			TrimPath:       tmpDir,
+			Tags:           strings.Join(m.Tags, ","),
+			GCFlagsList:    m.GCFlags,
+			CheckFlagsList: m.CheckFlags,
 		}
 	} else {
 		// Legacy mode: flags are authoritative.

--- a/go/go2nix/pkg/compile/compile.go
+++ b/go/go2nix/pkg/compile/compile.go
@@ -21,8 +21,9 @@ type Options struct {
 	Output     string // output .a archive path
 	ImportCfg  string // path to importcfg file
 	TrimPath   string // path prefix to trim (defaults to $NIX_BUILD_TOP)
-	Tags       string // comma-separated build tags
-	GCFlags    string // extra flags for go tool compile (space-separated, e.g. "-race")
+	Tags       string   // comma-separated build tags
+	GCFlags    string   // extra flags for go tool compile (space-separated, legacy)
+	GCFlagsList []string // extra flags for go tool compile (pre-split, preferred over GCFlags)
 	GoVersion  string // Go language version for -lang flag (e.g., "1.21"); auto-detected from go.mod if empty
 	PGOProfile string // path to pprof CPU profile for PGO; empty disables PGO
 	GoFiles    []string          // explicit Go files to compile (bypasses ListFiles discovery; paths relative to SrcDir)

--- a/go/go2nix/pkg/compile/manifest.go
+++ b/go/go2nix/pkg/compile/manifest.go
@@ -47,6 +47,46 @@ func LoadCompileManifest(path string) (*CompileManifest, error) {
 	return &m, nil
 }
 
+// ManifestKindLink is the kind value for link manifests.
+const ManifestKindLink = "link"
+
+// LinkManifest is the JSON contract between Nix and go2nix link-binary.
+type LinkManifest struct {
+	Version        int               `json:"version"`
+	Kind           string            `json:"kind"`
+	ImportcfgParts []string          `json:"importcfgParts"`
+	LocalArchives  map[string]string `json:"localArchives"`
+	SubPackages    []string          `json:"subPackages"`
+	ModuleRoot     string            `json:"moduleRoot"`
+	Lockfile       string            `json:"lockfile"`
+	Pname          string            `json:"pname"`
+	GOOS           *string           `json:"goos"`
+	GOARCH         *string           `json:"goarch"`
+	LDFlags        []string          `json:"ldflags"`
+	GCFlags        []string          `json:"gcflags"`
+	Tags           []string          `json:"tags"`
+	PGOProfile     *string           `json:"pgoProfile"`
+}
+
+// LoadLinkManifest reads and validates a link manifest from path.
+func LoadLinkManifest(path string) (*LinkManifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading link manifest: %w", err)
+	}
+	var m LinkManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing link manifest: %w", err)
+	}
+	if m.Version != ManifestVersion {
+		return nil, fmt.Errorf("link manifest: unsupported version %d (expected %d)", m.Version, ManifestVersion)
+	}
+	if m.Kind != ManifestKindLink {
+		return nil, fmt.Errorf("link manifest: wrong kind %q (expected %q)", m.Kind, ManifestKindLink)
+	}
+	return &m, nil
+}
+
 // ManifestKindTest is the kind value for test manifests.
 const ManifestKindTest = "test"
 

--- a/go/go2nix/pkg/compile/manifest_test.go
+++ b/go/go2nix/pkg/compile/manifest_test.go
@@ -196,6 +196,100 @@ func TestLoadTestManifest(t *testing.T) {
 	}
 }
 
+func TestLoadLinkManifest(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		wantErr string
+	}{
+		{
+			name: "valid manifest",
+			json: `{"version":1,"kind":"link","importcfgParts":["/a/importcfg"],"localArchives":{"example.com/foo":"/nix/store/foo.a"},"subPackages":["./cmd/server"],"moduleRoot":"/nix/store/src","lockfile":"/nix/store/lockfile","pname":"myapp","goos":"linux","goarch":"amd64","ldflags":["-s","-w"],"gcflags":[],"tags":[],"pgoProfile":null}`,
+		},
+		{
+			name:    "wrong kind",
+			json:    `{"version":1,"kind":"compile","importcfgParts":[],"localArchives":{},"subPackages":["."],"moduleRoot":"/src","lockfile":"/lock","pname":"x","goos":null,"goarch":null,"ldflags":[],"gcflags":[],"tags":[],"pgoProfile":null}`,
+			wantErr: `wrong kind "compile"`,
+		},
+		{
+			name:    "wrong version",
+			json:    `{"version":99,"kind":"link","importcfgParts":[],"localArchives":{},"subPackages":["."],"moduleRoot":"/src","lockfile":"/lock","pname":"x","goos":null,"goarch":null,"ldflags":[],"gcflags":[],"tags":[],"pgoProfile":null}`,
+			wantErr: "unsupported version 99",
+		},
+		{
+			name:    "invalid json",
+			json:    `not json`,
+			wantErr: "parsing link manifest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "manifest.json")
+			if err := os.WriteFile(path, []byte(tt.json), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			m, err := LoadLinkManifest(path)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if got := err.Error(); !contains(got, tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if m.Pname != "myapp" {
+				t.Errorf("pname = %q", m.Pname)
+			}
+			if m.ModuleRoot != "/nix/store/src" {
+				t.Errorf("moduleRoot = %q", m.ModuleRoot)
+			}
+			if len(m.SubPackages) != 1 || m.SubPackages[0] != "./cmd/server" {
+				t.Errorf("subPackages = %v", m.SubPackages)
+			}
+			if len(m.LDFlags) != 2 || m.LDFlags[0] != "-s" || m.LDFlags[1] != "-w" {
+				t.Errorf("ldflags = %v", m.LDFlags)
+			}
+			if m.GOOS == nil || *m.GOOS != "linux" {
+				t.Errorf("goos = %v", m.GOOS)
+			}
+			if m.GOARCH == nil || *m.GOARCH != "amd64" {
+				t.Errorf("goarch = %v", m.GOARCH)
+			}
+			if m.PGOProfile != nil {
+				t.Errorf("pgoProfile = %v, want nil", m.PGOProfile)
+			}
+		})
+	}
+}
+
+func TestLoadLinkManifest_nullOptionals(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "manifest.json")
+	json := `{"version":1,"kind":"link","importcfgParts":[],"localArchives":{},"subPackages":["."],"moduleRoot":"/src","lockfile":"/lock","pname":"x","goos":null,"goarch":null,"ldflags":[],"gcflags":[],"tags":[],"pgoProfile":null}`
+	if err := os.WriteFile(path, []byte(json), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := LoadLinkManifest(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.GOOS != nil {
+		t.Errorf("goos should be nil, got %v", m.GOOS)
+	}
+	if m.GOARCH != nil {
+		t.Errorf("goarch should be nil, got %v", m.GOARCH)
+	}
+	if m.PGOProfile != nil {
+		t.Errorf("pgoProfile should be nil, got %v", m.PGOProfile)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }

--- a/go/go2nix/pkg/compile/util.go
+++ b/go/go2nix/pkg/compile/util.go
@@ -30,8 +30,8 @@ func envOrDefault(key, fallback string) string {
 	return fallback
 }
 
-// goEnvVar queries a single Go env variable, checking os.Getenv first.
-func goEnvVar(key string) string {
+// GoEnvVar queries a single Go env variable, checking os.Getenv first.
+func GoEnvVar(key string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
 	}
@@ -51,10 +51,13 @@ func goRoot() (string, error) {
 }
 
 func goEnv() (goos, goarch string) {
-	return goEnvVar("GOOS"), goEnvVar("GOARCH")
+	return GoEnvVar("GOOS"), GoEnvVar("GOARCH")
 }
 
 func extraGCFlags(opts Options) []string {
+	if len(opts.GCFlagsList) > 0 {
+		return opts.GCFlagsList
+	}
 	if opts.GCFlags == "" {
 		return nil
 	}
@@ -67,17 +70,17 @@ func asmArchDefines(goarch string) []string {
 	var defs []string
 	switch goarch {
 	case "386":
-		v := goEnvVar("GO386")
+		v := GoEnvVar("GO386")
 		if v != "" {
 			defs = append(defs, "-D", "GO386_"+v)
 		}
 	case "amd64":
-		v := goEnvVar("GOAMD64")
+		v := GoEnvVar("GOAMD64")
 		if v != "" {
 			defs = append(defs, "-D", "GOAMD64_"+v)
 		}
 	case "arm":
-		v := goEnvVar("GOARM")
+		v := GoEnvVar("GOARM")
 		switch {
 		case strings.Contains(v, "7"):
 			defs = append(defs, "-D", "GOARM_7")
@@ -89,22 +92,22 @@ func asmArchDefines(goarch string) []string {
 			defs = append(defs, "-D", "GOARM_5")
 		}
 	case "arm64":
-		v := goEnvVar("GOARM64")
+		v := GoEnvVar("GOARM64")
 		if strings.Contains(v, "lse") {
 			defs = append(defs, "-D", "GOARM64_LSE")
 		}
 	case "mips", "mipsle":
-		v := goEnvVar("GOMIPS")
+		v := GoEnvVar("GOMIPS")
 		if v != "" {
 			defs = append(defs, "-D", "GOMIPS_"+v)
 		}
 	case "mips64", "mips64le":
-		v := goEnvVar("GOMIPS64")
+		v := GoEnvVar("GOMIPS64")
 		if v != "" {
 			defs = append(defs, "-D", "GOMIPS64_"+v)
 		}
 	case "ppc64", "ppc64le":
-		v := goEnvVar("GOPPC64")
+		v := GoEnvVar("GOPPC64")
 		switch v {
 		case "power10":
 			defs = append(defs, "-D", "GOPPC64_power10")
@@ -116,7 +119,7 @@ func asmArchDefines(goarch string) []string {
 			defs = append(defs, "-D", "GOPPC64_power8")
 		}
 	case "riscv64":
-		v := goEnvVar("GORISCV64")
+		v := GoEnvVar("GORISCV64")
 		if v != "" {
 			defs = append(defs, "-D", "GORISCV64_"+v)
 		}

--- a/go/go2nix/pkg/compile/util_test.go
+++ b/go/go2nix/pkg/compile/util_test.go
@@ -36,6 +36,27 @@ func TestExtraGCFlags(t *testing.T) {
 	}
 }
 
+func TestExtraGCFlags_listPreferred(t *testing.T) {
+	// GCFlagsList takes precedence over GCFlags string.
+	list := []string{"-shared", "-X=main.version=hello world"}
+	got := extraGCFlags(Options{
+		GCFlags:     "-race",
+		GCFlagsList: list,
+	})
+	if len(got) != 2 || got[0] != "-shared" || got[1] != "-X=main.version=hello world" {
+		t.Errorf("got %v, want %v", got, list)
+	}
+}
+
+func TestExtraGCFlags_listWithSpaces(t *testing.T) {
+	// Verify flags containing spaces are preserved as single elements.
+	list := []string{"-X=main.msg=hello world"}
+	got := extraGCFlags(Options{GCFlagsList: list})
+	if len(got) != 1 || got[0] != "-X=main.msg=hello world" {
+		t.Errorf("got %v, want single element with space", got)
+	}
+}
+
 func TestDefaultBuildMode(t *testing.T) {
 	tests := []struct {
 		goos, goarch, want string

--- a/go/go2nix/pkg/testrunner/testrunner.go
+++ b/go/go2nix/pkg/testrunner/testrunner.go
@@ -21,13 +21,31 @@ import (
 
 // Options configures the test runner.
 type Options struct {
-	ModuleRoot string // path to module root (containing go.mod)
-	ImportCfg  string // path to importcfg (from build phase, has all packages)
-	LocalDir   string // directory with compiled local .a files
-	TrimPath   string // path prefix to trim
-	Tags       string // comma-separated build tags
-	GCFlags    string // extra compiler flags
-	CheckFlags string // flags to pass to test binaries (e.g., "-v -count=1")
+	ModuleRoot     string   // path to module root (containing go.mod)
+	ImportCfg      string   // path to importcfg (from build phase, has all packages)
+	LocalDir       string   // directory with compiled local .a files
+	TrimPath       string   // path prefix to trim
+	Tags           string   // comma-separated build tags
+	GCFlags        string   // extra compiler flags (space-separated, legacy)
+	GCFlagsList    []string // extra compiler flags (pre-split, preferred over GCFlags)
+	CheckFlags     string   // flags to pass to test binaries (space-separated, legacy)
+	CheckFlagsList []string // flags to pass to test binaries (pre-split, preferred over CheckFlags)
+}
+
+// gcFlags returns the effective GC flags, preferring the pre-split list.
+func (o Options) gcFlags() (string, []string) {
+	return o.GCFlags, o.GCFlagsList
+}
+
+// checkFlagsArgs returns the effective check flags as a slice.
+func (o Options) checkFlagsArgs() []string {
+	if len(o.CheckFlagsList) > 0 {
+		return o.CheckFlagsList
+	}
+	if o.CheckFlags != "" {
+		return strings.Fields(o.CheckFlags)
+	}
+	return nil
 }
 
 // Run discovers testable packages and runs their tests.
@@ -213,7 +231,8 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 			ImportCfg:  testImportCfg,
 			TrimPath:   opts.TrimPath,
 			Tags:       opts.Tags,
-			GCFlags:    opts.GCFlags,
+			GCFlags:     opts.GCFlags,
+			GCFlagsList: opts.GCFlagsList,
 			GoFiles:    goFiles,
 			EmbedCfg:   mergedEmbedCfg,
 		}); err != nil {
@@ -267,7 +286,8 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 				ImportCfg:  testImportCfg,
 				TrimPath:   opts.TrimPath,
 				Tags:       opts.Tags,
-				GCFlags:    opts.GCFlags,
+				GCFlags:     opts.GCFlags,
+			GCFlagsList: opts.GCFlagsList,
 			}); err != nil {
 				return fmt.Errorf("recompiling %s for test: %w", depIP, err)
 			}
@@ -312,7 +332,8 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 			ImportCfg:  testImportCfg,
 			TrimPath:   opts.TrimPath,
 			Tags:       opts.Tags,
-			GCFlags:    opts.GCFlags,
+			GCFlags:     opts.GCFlags,
+			GCFlagsList: opts.GCFlagsList,
 			GoFiles:    pkg.XTestGoFiles,
 			EmbedCfg:   pkg.XTestEmbedCfg,
 		}); err != nil {
@@ -396,10 +417,7 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 	}
 
 	// Step 6: Run tests
-	var testArgs []string
-	if opts.CheckFlags != "" {
-		testArgs = strings.Fields(opts.CheckFlags)
-	}
+	testArgs := opts.checkFlagsArgs()
 	testCmd := exec.Command(testBin, testArgs...)
 	testCmd.Dir = pkg.SrcDir
 	testCmd.Stdout = os.Stdout

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -461,6 +461,25 @@ let
     && goPackagesResult ? testPackages
     && goPackagesResult.testPackages != { };
 
+  linkManifestJSON = builtins.toJSON {
+    version = 1;
+    kind = "link";
+    importcfgParts = [ "${depsImportcfg}/importcfg" ];
+    localArchives = builtins.mapAttrs (
+      importPath: pkg: "${pkg}/${importPath}.a"
+    ) localPackages;
+    subPackages = normalizedSubPackages;
+    moduleRoot = moduleRoot;
+    lockfile = "${builtins.path { path = goLock; name = "go2nix-lockfile"; }}";
+    pname = pname;
+    goos = stdenv.hostPlatform.go.GOOS or null;
+    goarch = stdenv.hostPlatform.go.GOARCH or null;
+    ldflags = ldflags;
+    inherit tags;
+    gcflags = gcflags;
+    pgoProfile = if pgoProfile != null then "${pgoProfile}" else null;
+  };
+
   testManifestJSON = lib.optionalString doCheck (builtins.toJSON {
     version = 1;
     kind = "test";
@@ -515,15 +534,9 @@ stdenv.mkDerivation (
     };
 
     env = {
-      goModuleRoot = moduleRoot;
-      goSubPackages = concatStringsSep " " normalizedSubPackages;
-      goLdflags = ldflagsStr;
-      goGcflags = gcflagsStr;
-      goLockfile = "${builtins.path { path = goLock; name = "go2nix-lockfile"; }}";
-      goPname = pname;
+      inherit linkManifestJSON;
     }
     // (if CGO_ENABLED != null then { inherit CGO_ENABLED; } else { })
-    // (if pgoProfile != null then { goPgoProfile = "${pgoProfile}"; } else { })
     // (if doCheck then { inherit testManifestJSON; } else { });
   }
 )

--- a/nix/dag/hooks/default.nix
+++ b/nix/dag/hooks/default.nix
@@ -2,32 +2,13 @@
 #
 # Two composite hooks:
 #   goModuleHook  — compile a third-party Go package
-#   goAppHook     — compile local packages and link a binary
+#   goAppHook     — link a binary via go2nix link-binary
 {
   go,
   go2nix,
-  stdlib,
-  stdenv,
   makeSetupHook,
-  tagFlag,
 }:
 let
-  tagArg = if tagFlag == "" then "" else "--tags ${tagFlag}";
-  goos = stdenv.hostPlatform.go.GOOS;
-  # Match Go's internal/platform.DefaultPIE: PIE for darwin, windows, android, ios.
-  buildMode =
-    if
-      builtins.elem goos [
-        "darwin"
-        "windows"
-        "android"
-        "ios"
-      ]
-    then
-      "pie"
-    else
-      "exe";
-
   setupGoEnv = makeSetupHook {
     name = "go2nix-setup-go-env";
   } ./setup-go-env.sh;
@@ -37,9 +18,9 @@ in
 
   # Hook for compiling third-party Go packages.
   # Derivations using this hook must set:
-  #   env.goPackagePath   — import path
-  #   env.goPackageSrcDir — source directory
-  #   buildInputs         — dependency package derivations
+  #   env.goPackagePath        — import path
+  #   env.goPackageSrcDir      — source directory
+  #   env.compileManifestJSON  — compile manifest content (JSON string)
   goModuleHook = makeSetupHook {
     name = "go2nix-module-hook";
     propagatedBuildInputs = [
@@ -53,15 +34,8 @@ in
 
   # Hook for building and linking Go application binaries.
   # Derivations using this hook must set:
-  #   env.goModuleRoot  — path containing go.mod
-  #   env.goSubPackages — space-separated sub-packages (default: ".")
-  #   env.goLockfile    — path to go2nix.toml lockfile
-  #   env.goLdflags     — linker flags (optional)
-  #   env.goGcflags     — compiler flags (optional)
-  #   env.goPname       — binary name for "." package (optional)
-  #   buildInputs       — all third-party package derivations
-  #
-  # Note: goModulePath is extracted from go.mod at build time (see link-go-binary.sh).
+  #   env.linkManifestJSON — link manifest content (JSON string)
+  #   env.testManifestJSON — test manifest content (optional, when doCheck=true)
   goAppHook = makeSetupHook {
     name = "go2nix-app-hook";
     propagatedBuildInputs = [
@@ -69,10 +43,7 @@ in
       setupGoEnv
     ];
     substitutions = {
-      go = "${go}/bin/go";
       go2nix = "${go2nix}/bin/go2nix";
-      stdlib = "${stdlib}";
-      inherit tagArg buildMode;
     };
   } ./link-go-binary.sh;
 }

--- a/nix/dag/hooks/link-go-binary.sh
+++ b/nix/dag/hooks/link-go-binary.sh
@@ -1,184 +1,27 @@
 # shellcheck shell=bash
-# Atomic hook: compile local packages and link Go binaries.
+# Atomic hook: link Go binaries via go2nix link-binary.
 #
 # Expected environment variables (set via derivation `env`):
-#   goModuleRoot    — absolute path to module root (containing go.mod)
-#   goSubPackages   — space-separated list of sub-packages (default: ".")
-#   goLdflags       — extra linker flags (optional)
-#   goGcflags       — extra compiler flags (optional)
-#   goLockfile      — path to go2nix.toml lockfile
-#   goPname         — binary name for "." package (optional)
-#
-# Structured attrs (bash associative array, via __structuredAttrs):
-#   goLocalArchives — import path -> store path of compiled .a archive
-#                     Used by checkPhase to reconstruct a local-pkgs directory.
-#
-# Build-time dependencies discovered from $buildInputs:
-#   depsImportcfg      — importcfg for build (stdlib + build third-party + local)
-#   testDepsImportcfg  — importcfg for checks (superset: + test-only third-party)
-#                        Only present when doCheck = true and test-only deps exist.
+#   linkManifestJSON  — link manifest content (JSON string)
+#   testManifestJSON  — test manifest content (JSON string, only when doCheck=true)
 
 # Variables set by Nix stdenv / derivation env, not by this script.
 # shellcheck disable=SC2154
 linkGoBinaryConfigurePhase() {
   runHook preConfigure
-
-  # Validate lockfile consistency with go.mod.
-  @go2nix@ check --lockfile "$goLockfile" "$goModuleRoot"
-
-  # Extract module path from go.mod at build time (avoids Nix eval-time parsing).
-  goModulePath=$(awk '/^module /{print $2; exit}' "$goModuleRoot/go.mod")
-  if [ -z "$goModulePath" ]; then
-    echo "go2nix: could not extract module path from $goModuleRoot/go.mod" >&2
-    exit 1
-  fi
-  export goModulePath
-
-  # Build importcfg: use pre-built bundle (stdlib + all third-party + local deps).
-  # NOTE: modinfo is a linker-only directive (cmd/link) and must NOT be present
-  # during compilation (cmd/compile rejects unknown directives). It is appended
-  # to the importcfg in the build phase, before link.
-  # The bundle is passed as the sole buildInput (depsImportcfg derivation).
-  local importcfg_bundle=""
-  for dep in ${buildInputs[@]}; do
-    if [ -f "$dep/importcfg" ]; then
-      importcfg_bundle="$dep/importcfg"
-      break
-    fi
-  done
-  if [ -z "$importcfg_bundle" ]; then
-    echo "go2nix: no importcfg bundle found in buildInputs" >&2
-    exit 1
-  fi
-  cp "$importcfg_bundle" "$NIX_BUILD_TOP/importcfg"
-  chmod u+w "$NIX_BUILD_TOP/importcfg"
-
-  # Compute module info (modinfo) and GODEBUG defaults.
-  # build-modinfo outputs:
-  #   modinfo "..." — for go tool link importcfg
-  #   godebug <value> — for -X=runtime.godebugDefault= linker flag
-  local buildinfo_out
-  buildinfo_out=$(@go2nix@ build-modinfo --lockfile "$goLockfile" --go "@go@" "$goModuleRoot")
-  goModinfo=$(echo "$buildinfo_out" | grep '^modinfo ' || true)
-  goGodebugDefault=$(echo "$buildinfo_out" | sed -n 's/^godebug //p')
-
+  # No-op: link-binary handles lockfile validation and modinfo computation.
   runHook postConfigure
 }
 
 linkGoBinaryBuildPhase() {
   runHook preBuild
 
-  local maindir="$NIX_BUILD_TOP/main-pkgs"
-  mkdir -p "$maindir"
+  # Write link manifest JSON to a file for go2nix to read.
+  echo "$linkManifestJSON" > "$NIX_BUILD_TOP/link-manifest.json"
 
-  # Build mode is computed at Nix eval time from stdenv.hostPlatform.go.GOOS
-  # (see hooks/default.nix), matching Go's internal/platform.DefaultPIE.
-  local go_buildmode="@buildMode@"
-
-  # Build gcflags argument array (empty if unset, avoids quoting issues).
-  local gcflags_val="${goGcflags:-}"
-  if [ "$go_buildmode" = "pie" ]; then
-    gcflags_val="-shared${gcflags_val:+ $gcflags_val}"
-  fi
-  local -a gcflagArgs=()
-  if [ -n "$gcflags_val" ]; then
-    gcflagArgs=(--gc-flags "$gcflags_val")
-  fi
-
-  local -a pgoArgs=()
-  if [ -n "${goPgoProfile:-}" ]; then
-    pgoArgs=(--pgo-profile "$goPgoProfile")
-  fi
-
-  # Resolve the linker binary before clearing GOROOT.
-  local goLinkTool
-  goLinkTool="$(@go@ env GOTOOLDIR)/link"
-
-  # Do not set GOROOT: the linker reads it from os.Getenv (buildcfg/cfg.go:23)
-  # and embeds it as runtime.defaultGOROOT (cmd/link main.go:180-186).
-  # We cannot use `go tool link` because the go command re-exports GOROOT
-  # from its binary path (cmd/go/main.go:305-311), overriding any empty value.
-  # Invoking the linker directly matches what `go build -trimpath` does
-  # internally (gc.go:676-678).
-  export GOROOT=""
-
-  # Compute link-time flags (invariant across sub-packages).
-  local linkflags=""
-  if [ -f "$NIX_BUILD_TOP/.has_cgo" ]; then
-    # Use CXX when C++ files are present, matching Go's setextld (gc.go).
-    local extld="${CC:-}"
-    if [ -f "$NIX_BUILD_TOP/.has_cxx" ]; then
-      extld="${CXX:-}"
-    fi
-    if [ -z "$extld" ]; then
-      echo "go2nix: cgo package requires CC (or CXX) but none is set" >&2
-      exit 1
-    fi
-    linkflags="-extld $extld -linkmode external"
-  fi
-
-  # Propagate sanitizer flags (-race, -msan, -asan) from gcflags to the
-  # linker, matching cmd/go behavior (init.go forcedLdflags).
-  local sanitizer_linkflags=""
-  for flag in ${goGcflags:-}; do
-    case "$flag" in
-    -race | -msan | -asan) sanitizer_linkflags="$sanitizer_linkflags $flag" ;;
-    esac
-  done
-
-  # GODEBUG default from go.mod's go directive (gc.go:624-626).
-  local godebug_linkflag=""
-  if [ -n "${goGodebugDefault:-}" ]; then
-    godebug_linkflag="-X=runtime.godebugDefault=$goGodebugDefault"
-  fi
-
-  # Build linker importcfg: compile importcfg + modinfo (linker-only directive).
-  cp "$NIX_BUILD_TOP/importcfg" "$NIX_BUILD_TOP/importcfg.link"
-  if [ -n "${goModinfo:-}" ]; then
-    echo "$goModinfo" >>"$NIX_BUILD_TOP/importcfg.link"
-  fi
-
-  # Pass 2: compile main packages and link.
-  mkdir -p "$NIX_BUILD_TOP/staging/bin"
-
-  for sp in ${goSubPackages:-.}; do
-    local importpath srcdir binname
-
-    if [ "$sp" = "." ]; then
-      importpath="$goModulePath"
-      srcdir="$goModuleRoot"
-      binname="${goPname:-$(basename "$goModulePath")}"
-    else
-      importpath="$goModulePath/$sp"
-      srcdir="$goModuleRoot/$sp"
-      binname="$(basename "$sp")"
-    fi
-
-    echo "Compiling main: $importpath"
-    @go2nix@ compile-package \
-      --import-cfg "$NIX_BUILD_TOP/importcfg" \
-      --import-path "main" \
-      --src-dir "$srcdir" \
-      --output "$maindir/$importpath.a" \
-      --trim-path "$NIX_BUILD_TOP" \
-      @tagArg@ \
-      "${gcflagArgs[@]}" \
-      "${pgoArgs[@]}"
-
-    # Word splitting is intentional: goLdflags, linkflags,
-    # sanitizer_linkflags, and godebug_linkflag contain space-separated flags.
-    # shellcheck disable=SC2086
-    "$goLinkTool" \
-      -buildid=redacted \
-      -buildmode="$go_buildmode" \
-      -importcfg "$NIX_BUILD_TOP/importcfg.link" \
-      ${goLdflags:-} \
-      $linkflags \
-      $sanitizer_linkflags \
-      $godebug_linkflag \
-      -o "$NIX_BUILD_TOP/staging/bin/$binname" \
-      "$maindir/$importpath.a"
-  done
+  @go2nix@ link-binary \
+    --manifest "$NIX_BUILD_TOP/link-manifest.json" \
+    --output "$NIX_BUILD_TOP/staging"
 
   runHook postBuild
 }


### PR DESCRIPTION
## Summary

- Adds new `go2nix link-binary --manifest` command that absorbs lockfile validation, modinfo generation, main-package compilation, and linker invocation from shell hooks
- Introduces `LinkManifest` type with JSON loader/validation, alongside compile and test manifests from earlier steps
- Reduces `link-go-binary.sh` hooks to thin manifest-write + CLI-call wrappers
- Fixes flag round-tripping: `GCFlagsList`/`CheckFlagsList` fields preserve array semantics end-to-end (no whitespace join/split that breaks flags containing spaces like `-X=main.version=hello world`)
- Nix `dag/default.nix` now generates `linkManifestJSON` and `testManifestJSON` at eval time

Depends on #14 (step 2: test manifest)