### PR TITLE
docs: fix inaccuracies after hook composition migration

### DIFF
--- a/docs/src/builder-api.md
+++ b/docs/src/builder-api.md
@@ -20,7 +20,6 @@ goEnv.buildGoApplicationExperimental {
   src = ./.;
   goLock = ./go2nix.toml;
   pname = "my-app";
-  version = "0.1.0";
 }
 ```
 
@@ -29,12 +28,12 @@ Requires `nixPackage` to be set in `mkGoEnv` and Nix >= 2.34 with
 
 ## Required attributes
 
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `src` | path | Source tree. For monorepos with `modRoot`, this should be the repository root. |
-| `goLock` | path | Path to `go2nix.toml` lockfile. |
-| `pname` | string | Package name for the output derivation. |
-| `version` | string | Package version. |
+| Attribute | Type | Modes | Description |
+|-----------|------|-------|-------------|
+| `src` | path | both | Source tree. For monorepos with `modRoot`, this should be the repository root. |
+| `goLock` | path | both | Path to `go2nix.toml` lockfile. |
+| `pname` | string | both | Package name for the output derivation. |
+| `version` | string | default only | Package version. The experimental builder does not accept this attribute. |
 
 ## Optional attributes
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -127,7 +127,8 @@ mode Nix builder inside a recursive-nix build.
 ## build-modinfo
 
 Generate a `modinfo` linker directive for embedding `debug/buildinfo`
-metadata into the final binary. Used internally by the link hook.
+metadata into the final binary. This is a standalone utility; the default
+mode's `link-binary` command generates modinfo internally.
 
 ```
 go2nix build-modinfo [flags] <module-root>

--- a/docs/src/go2nix-architecture.md
+++ b/docs/src/go2nix-architecture.md
@@ -141,7 +141,10 @@ Pure Nix utility functions:
 |------|------|-----------|-----|
 | Generation | MVS consistency | All modes | `go list -json -deps` resolves actual versions |
 | Nix eval | Package graph | Default only | `builtins.resolveGoPackages` runs `go list` at eval time |
-| Build time | Lockfile consistency | Both modes | `go2nix check --lockfile` validates against `go.mod` |
+| Build time | Lockfile consistency | Default only | `link-binary` validates lockfile against `go.mod` via `mvscheck.CheckLockfile` |
+
+The `go2nix check` subcommand can also be used standalone to verify a
+lockfile without building.
 
 ## Further reading
 

--- a/docs/src/lockfile-format.md
+++ b/docs/src/lockfile-format.md
@@ -64,12 +64,13 @@ conflict since each is uniquely keyed by `"path@version"`.
 |------|------|-----------|-----|
 | Generation | MVS consistency | All modes | `go list -json -deps` resolves actual versions |
 | Nix eval | Package graph | Default only | `builtins.resolveGoPackages` runs `go list` at eval time |
-| Build time | Lockfile consistency | Both modes | `go2nix check --lockfile` validates against `go.mod` |
+| Build time | Lockfile consistency | Default only | `link-binary` validates lockfile against `go.mod` via `mvscheck.CheckLockfile` |
 
-In the default mode, missing or mismatched packages are caught at eval time
-when `builtins.resolveGoPackages` runs `go list`. In the experimental mode,
-they are caught at build time when `go list` runs inside the recursive-nix
-wrapper.
+In the default mode, missing or mismatched modules are caught at build time
+when `link-binary` validates the lockfile. Stale package graph information
+is caught at eval time when `builtins.resolveGoPackages` runs `go list`.
+In the experimental mode, module mismatches surface at build time when
+`go list` or module fetching fails inside the recursive-nix sandbox.
 
 Run `go2nix check <dir>` or `go2nix check --lockfile <path> <dir>` to verify
 a lockfile without building.

--- a/docs/src/modes/default-mode.md
+++ b/docs/src/modes/default-mode.md
@@ -72,9 +72,14 @@ stdenv.mkDerivation {
   env = {
     goPackagePath = importPath;
     goPackageSrcDir = srcDir;
+    compileManifestJSON = mkCompileManifestJSON deps;
   };
 }
 ```
+
+The compile manifest is a JSON string declaring importcfg parts, build tags,
+gcflags, and PGO profile. The shell hook writes it to a file and passes it
+to `go2nix compile-package --manifest`.
 
 CGO packages (where `pkg.isCgo` is true) automatically get `stdenv.cc` added
 to `nativeBuildInputs`.
@@ -102,12 +107,15 @@ fine-grained package caching.
 
 ### 7. Application derivation
 
-The final derivation consumes `depsImportcfg` (and `testDepsImportcfg` when
-checks are enabled) and uses `goAppHook` to:
+The final derivation receives typed JSON manifests via environment variables
+and uses `goAppHook` (link-go-binary.sh) to invoke the Go CLI:
 
-1. Validate lockfile consistency
-1. Link the final binary
-1. Run tests when `doCheck = true`
+1. **Build phase** — writes `linkManifestJSON` to a file and calls
+   `go2nix link-binary --manifest`, which validates the lockfile, generates
+   modinfo, compiles main packages, and invokes the linker.
+2. **Check phase** — writes `testManifestJSON` to a file and calls
+   `go2nix test-packages --manifest`, which discovers testable local packages,
+   compiles test archives, and runs them.
 
 ## Package overrides
 

--- a/docs/src/modes/default-mode.md
+++ b/docs/src/modes/default-mode.md
@@ -27,11 +27,11 @@ import relationships change (only when modules are added or removed).
 
 ## Nix evaluation flow
 
-### 1. Module resolution (builtins.resolveGoModules)
+### 1. Lockfile parsing (builtins.fromTOML)
 
-Parses the TOML lockfile and returns `{ modules }`:
-
-- **modules**: Per-module metadata (path, version, hash, dirSuffix, fetchPath)
+The lockfile is parsed at eval time with `builtins.fromTOML`. Module metadata
+(path, version, hash) is read from the `[mod]` section, with `[replace]`
+entries applied to module fetch paths.
 
 ### 2. Package graph discovery (builtins.resolveGoPackages)
 

--- a/docs/src/modes/experimental-mode.md
+++ b/docs/src/modes/experimental-mode.md
@@ -87,7 +87,6 @@ goEnv.buildGoApplicationExperimental {
   src = ./.;
   goLock = ./go2nix.toml;
   pname = "my-app";
-  version = "0.1.0";
   packageOverrides = {
     "github.com/mattn/go-sqlite3" = {
       nativeBuildInputs = [ pkg-config sqlite ];
@@ -111,7 +110,6 @@ goEnv.buildGoApplicationExperimental {
   src = ./.;
   goLock = ./go2nix.toml;
   pname = "my-app";
-  version = "0.1.0";
   subPackages = [ "cmd/server" ];
   tags = [ "nethttpomithttp2" ];
   ldflags = [ "-s" "-w" ];


### PR DESCRIPTION
## Summary

- **cli-reference**: `build-modinfo` is now a standalone utility, not called by the link hook (`link-binary` handles modinfo internally)
- **default-mode**: add `compileManifestJSON` to package derivation example, describe the manifest-based link and test phases via `go2nix link-binary` and `go2nix test-packages`
- **builder-api**: `version` is required for default mode only; experimental mode does not accept it
- **experimental-mode**: remove `version` from examples (attribute is silently ignored)