### PR TITLE
feat: add golangci-lint with lint fixes

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: golangci-lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/golangci-lint.yml"
+      - ".golangci.yml"
+      - "go/go2nix/**"
+      - "packages/go2nix-testgen/**"
+  pull_request:
+    paths:
+      - ".github/workflows/golangci-lint.yml"
+      - ".golangci.yml"
+      - "go/go2nix/**"
+      - "packages/go2nix-testgen/**"
+
+permissions:
+  contents: read
+
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - go/go2nix
+          - packages/go2nix-testgen
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: ${{ matrix.module }}/go.mod
+
+      - name: Run golangci-lint (${{ matrix.module }})
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11.3
+          working-directory: ${{ matrix.module }}
+          args: --config=${{ github.workspace }}/.golangci.yml ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,39 @@
+version: "2"
+
+run:
+  timeout: 5m
+  relative-path-mode: cfg
+  tests: true
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+linters:
+  default: standard
+  enable:
+    - bodyclose
+    - contextcheck
+    - errorlint
+    - gocritic
+    - misspell
+    - nilerr
+    - nolintlint
+    - rowserrcheck
+    - unconvert
+    - unparam
+    - wastedassign
+  exclusions:
+    generated: strict
+    warn-unused: true
+    paths:
+      - tests/fixtures/
+      - packages/go2nix-nix-plugin/tests/fixtures/
+
+formatters:
+  enable:
+    - gci
+    - gofumpt
+  exclusions:
+    generated: strict
+    warn-unused: true

--- a/devshell.nix
+++ b/devshell.nix
@@ -2,6 +2,7 @@
 pkgs.mkShell {
   packages = [
     pkgs.go_1_26
+    pkgs.golangci-lint
     pkgs.time
     pkgs.mdbook
   ];

--- a/go/go2nix/cmd/go2nix/checklockfile.go
+++ b/go/go2nix/cmd/go2nix/checklockfile.go
@@ -11,7 +11,7 @@ import (
 func runCheckLockfileCmd(args []string) {
 	fs := flag.NewFlagSet("check", flag.ExitOnError)
 	lockfilePath := fs.String("lockfile", "go2nix.toml", "path to go2nix.toml lockfile")
-	fs.Parse(args)
+	_ = fs.Parse(args)
 
 	dir := "."
 	if fs.NArg() > 0 {

--- a/go/go2nix/cmd/go2nix/compile.go
+++ b/go/go2nix/cmd/go2nix/compile.go
@@ -20,7 +20,7 @@ func runCompilePackageCmd(args []string) {
 	trimPath := fs.String("trim-path", "", "path prefix to trim (default: $NIX_BUILD_TOP)")
 	pFlag := fs.String("p", "", "override -p flag (default: import-path)")
 	goVersion := fs.String("go-version", "", "Go language version for -lang (e.g., 1.21); auto-detected from go.mod if empty")
-	fs.Parse(args)
+	_ = fs.Parse(args)
 
 	if *manifest == "" || *importPath == "" || *srcDir == "" || *output == "" {
 		slog.Error("usage: go2nix compile-package --manifest FILE --import-path PATH --src-dir DIR --output FILE [--importcfg-output FILE]")

--- a/go/go2nix/cmd/go2nix/generate.go
+++ b/go/go2nix/cmd/go2nix/generate.go
@@ -13,7 +13,7 @@ func runGenerateCmd(args []string) {
 	fs := flag.NewFlagSet("generate", flag.ExitOnError)
 	output := fs.String("o", "go2nix.toml", "output lockfile path")
 	jobs := fs.Int("j", runtime.NumCPU(), "max parallel hash invocations")
-	fs.Parse(args)
+	_ = fs.Parse(args)
 
 	dirs := fs.Args()
 	if len(dirs) == 0 {

--- a/go/go2nix/cmd/go2nix/gentestmain.go
+++ b/go/go2nix/cmd/go2nix/gentestmain.go
@@ -15,7 +15,7 @@ func runGenTestMainCmd(args []string) {
 	testFiles := fs.String("test-files", "", "comma-separated absolute paths to internal _test.go files")
 	xtestFiles := fs.String("xtest-files", "", "comma-separated absolute paths to external _test.go files")
 	output := fs.String("output", "", "output file path (default: stdout)")
-	fs.Parse(args)
+	_ = fs.Parse(args)
 
 	if *importPath == "" {
 		slog.Error("usage: go2nix generate-test-main --import-path PATH [--test-files FILES] [--xtest-files FILES] [--output FILE]")
@@ -44,6 +44,6 @@ func runGenTestMainCmd(args []string) {
 			os.Exit(1)
 		}
 	} else {
-		os.Stdout.Write(src)
+		_, _ = os.Stdout.Write(src)
 	}
 }

--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -19,7 +19,7 @@ func runLinkBinaryCmd(args []string) {
 	fs := flag.NewFlagSet("link-binary", flag.ExitOnError)
 	manifestPath := fs.String("manifest", "", "path to link-manifest.json (required)")
 	output := fs.String("output", "", "output directory (binaries written to <output>/bin/)")
-	fs.Parse(args)
+	_ = fs.Parse(args)
 
 	if *manifestPath == "" || *output == "" {
 		slog.Error("usage: go2nix link-binary --manifest FILE --output DIR")
@@ -67,7 +67,9 @@ func linkBinary(manifestPath, output string) error {
 			return fmt.Errorf("opening merged importcfg: %w", err)
 		}
 		for importPath, archivePath := range m.LocalArchives {
-			fmt.Fprintf(f, "packagefile %s=%s\n", importPath, archivePath)
+			if _, err := fmt.Fprintf(f, "packagefile %s=%s\n", importPath, archivePath); err != nil {
+				return fmt.Errorf("writing importcfg entry: %w", err)
+			}
 		}
 		if err := f.Close(); err != nil {
 			return fmt.Errorf("closing merged importcfg: %w", err)
@@ -162,7 +164,7 @@ func linkBinary(manifestPath, output string) error {
 	// Do not set GOROOT: the linker reads it from os.Getenv and embeds it
 	// as runtime.defaultGOROOT. Invoking the linker directly matches what
 	// `go build -trimpath` does internally.
-	os.Setenv("GOROOT", "")
+	_ = os.Setenv("GOROOT", "")
 
 	// Step 7: Compile main packages and link.
 	mainDir := filepath.Join(tmpDir, "main-pkgs")

--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -299,4 +299,3 @@ func expandLDFlags(flags []string) []string {
 	}
 	return out
 }
-

--- a/go/go2nix/cmd/go2nix/linkbinary_test.go
+++ b/go/go2nix/cmd/go2nix/linkbinary_test.go
@@ -68,7 +68,9 @@ func TestExtractModulePath(t *testing.T) {
 	dir := t.TempDir()
 	gomod := filepath.Join(dir, "go.mod")
 
-	os.WriteFile(gomod, []byte("module example.com/myapp\n\ngo 1.21\n"), 0o644)
+	if err := os.WriteFile(gomod, []byte("module example.com/myapp\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	got, err := extractModulePath(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -85,7 +87,9 @@ func TestExtractModulePath(t *testing.T) {
 
 	// go.mod without module directive returns error.
 	nomod := filepath.Join(t.TempDir(), "go.mod")
-	os.WriteFile(nomod, []byte("go 1.21\n"), 0o644)
+	if err = os.WriteFile(nomod, []byte("go 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	_, err = extractModulePath(filepath.Dir(nomod))
 	if err == nil {
 		t.Error("expected error for go.mod without module directive")

--- a/go/go2nix/cmd/go2nix/listfiles.go
+++ b/go/go2nix/cmd/go2nix/listfiles.go
@@ -12,7 +12,7 @@ import (
 func runListFilesCmd(args []string) {
 	fs := flag.NewFlagSet("list-files", flag.ExitOnError)
 	tagsFlag := fs.String("tags", "", "comma-separated build tags")
-	fs.Parse(args)
+	_ = fs.Parse(args)
 	if fs.NArg() != 1 {
 		slog.Error("usage: go2nix list-files [-tags=...] <package-dir>")
 		os.Exit(1)

--- a/go/go2nix/cmd/go2nix/listpkgs.go
+++ b/go/go2nix/cmd/go2nix/listpkgs.go
@@ -12,7 +12,7 @@ import (
 func runListPackagesCmd(args []string) {
 	fs := flag.NewFlagSet("list-packages", flag.ExitOnError)
 	tagsFlag := fs.String("tags", "", "comma-separated build tags")
-	fs.Parse(args)
+	_ = fs.Parse(args)
 	if fs.NArg() != 1 {
 		slog.Error("usage: go2nix list-packages [-tags=...] <module-root>")
 		os.Exit(1)

--- a/go/go2nix/cmd/go2nix/modinfo.go
+++ b/go/go2nix/cmd/go2nix/modinfo.go
@@ -16,7 +16,7 @@ func runModinfoCmd(args []string) {
 	fs := flag.NewFlagSet("build-modinfo", flag.ExitOnError)
 	lockfilePath := fs.String("lockfile", "", "path to go2nix.toml lockfile")
 	goBin := fs.String("go", "", "path to go binary (default: from PATH)")
-	fs.Parse(args)
+	_ = fs.Parse(args)
 
 	moduleRoot := fs.Arg(0)
 	if moduleRoot == "" || *lockfilePath == "" {

--- a/go/go2nix/cmd/go2nix/resolve.go
+++ b/go/go2nix/cmd/go2nix/resolve.go
@@ -32,7 +32,7 @@ func runResolveCmd(args []string) {
 	netrcFile := fs.String("netrc-file", "", "path to .netrc file for private module authentication")
 	nixJobs := fs.Int("nix-jobs", 0, "max concurrent nix derivation add calls (0 = auto)")
 	output := fs.String("output", "", "$out path")
-	fs.Parse(args)
+	_ = fs.Parse(args)
 
 	if *src == "" || *lockfilePath == "" || *system == "" || *goBin == "" ||
 		*stdlibPath == "" || *nixBin == "" || *pname == "" || *output == "" {

--- a/go/go2nix/cmd/go2nix/testpkgs.go
+++ b/go/go2nix/cmd/go2nix/testpkgs.go
@@ -14,7 +14,7 @@ import (
 func runTestPackagesCmd(args []string) {
 	fs := flag.NewFlagSet("test-packages", flag.ExitOnError)
 	manifest := fs.String("manifest", "", "path to test-manifest.json (required)")
-	fs.Parse(args)
+	_ = fs.Parse(args)
 
 	if *manifest == "" {
 		slog.Error("usage: go2nix test-packages --manifest FILE")

--- a/go/go2nix/pkg/buildinfo/buildinfo.go
+++ b/go/go2nix/pkg/buildinfo/buildinfo.go
@@ -109,7 +109,7 @@ func readGoSum(path string) map[string]string {
 	if err != nil {
 		return result
 	}
-	defer f.Close()
+	defer f.Close() //nolint:errcheck
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {

--- a/go/go2nix/pkg/compile/cgo.go
+++ b/go/go2nix/pkg/compile/cgo.go
@@ -236,7 +236,9 @@ func compileCgo(opts Options, files gofiles.PkgFiles, embedFlag string) error {
 	}
 
 	// Step 5: pack C/C++ objects, assembly objects, and .syso files.
-	allOFiles := append(compiledOFiles, asmOFiles...)
+	allOFiles := make([]string, 0, len(compiledOFiles)+len(asmOFiles))
+	allOFiles = append(allOFiles, compiledOFiles...)
+	allOFiles = append(allOFiles, asmOFiles...)
 	for _, s := range files.SysoFiles {
 		allOFiles = append(allOFiles, filepath.Join(opts.SrcDir, s))
 	}

--- a/go/go2nix/pkg/compile/cgo.go
+++ b/go/go2nix/pkg/compile/cgo.go
@@ -340,7 +340,7 @@ func compileCFiles(cc, cxx, cgowork, srcDir, uid string, files gofiles.PkgFiles,
 func cgoTestLinkAndDynimport(cc, cgowork string, opts Options, uid string, compiledOFiles, cgoFlagsLDFLAGS, cgoLdflags, cgoCflags []string) error {
 	cgoMainC := filepath.Join(cgowork, "_cgo_main.c")
 	if _, err := os.Stat(cgoMainC); err != nil {
-		return nil // no _cgo_main.c means cgo didn't generate one
+		return nil //nolint:nilerr // missing _cgo_main.c is expected, not an error
 	}
 
 	mainO := filepath.Join(cgowork, "_cgo_main_"+uid+".o")
@@ -369,7 +369,7 @@ func cgoTestLinkAndDynimport(cc, cgowork string, opts Options, uid string, compi
 		}
 		if err2 := runIn("", cc, append(linkArgs, flag)...); err2 != nil {
 			slog.Debug("cgo test link failed (no dynamic imports)", "err", err)
-			return nil // non-fatal: just means no dynamic imports
+			return nil //nolint:nilerr // test link failure is non-fatal, just means no dynamic imports
 		}
 	}
 	if _, err := os.Stat(testLinkO); err == nil {

--- a/go/go2nix/pkg/compile/cgo.go
+++ b/go/go2nix/pkg/compile/cgo.go
@@ -35,7 +35,7 @@ func compileCgo(opts Options, files gofiles.PkgFiles, embedFlag string) error {
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(cgowork)
+	defer os.RemoveAll(cgowork) //nolint:errcheck
 
 	cc := envOrDefault("CC", "gcc")
 	cxx := envOrDefault("CXX", "g++")

--- a/go/go2nix/pkg/compile/compile.go
+++ b/go/go2nix/pkg/compile/compile.go
@@ -15,18 +15,18 @@ import (
 
 // Options configures a package compilation.
 type Options struct {
-	ImportPath string // Go import path (e.g., "github.com/foo/bar")
-	PFlag      string // -p flag for go tool compile (defaults to ImportPath)
-	SrcDir     string // directory containing source files
-	Output     string // output .a archive path
-	ImportCfg  string // path to importcfg file
-	TrimPath   string // path prefix to trim (defaults to $NIX_BUILD_TOP)
-	Tags        string   // comma-separated build tags
-	GCFlagsList []string // extra flags for go tool compile
-	GoVersion  string // Go language version for -lang flag (e.g., "1.21"); auto-detected from go.mod if empty
-	PGOProfile string // path to pprof CPU profile for PGO; empty disables PGO
-	GoFiles    []string          // explicit Go files to compile (bypasses ListFiles discovery; paths relative to SrcDir)
-	EmbedCfg   *gofiles.EmbedCfg // explicit embed config (used with GoFiles to pass pre-resolved embed metadata)
+	ImportPath  string            // Go import path (e.g., "github.com/foo/bar")
+	PFlag       string            // -p flag for go tool compile (defaults to ImportPath)
+	SrcDir      string            // directory containing source files
+	Output      string            // output .a archive path
+	ImportCfg   string            // path to importcfg file
+	TrimPath    string            // path prefix to trim (defaults to $NIX_BUILD_TOP)
+	Tags        string            // comma-separated build tags
+	GCFlagsList []string          // extra flags for go tool compile
+	GoVersion   string            // Go language version for -lang flag (e.g., "1.21"); auto-detected from go.mod if empty
+	PGOProfile  string            // path to pprof CPU profile for PGO; empty disables PGO
+	GoFiles     []string          // explicit Go files to compile (bypasses ListFiles discovery; paths relative to SrcDir)
+	EmbedCfg    *gofiles.EmbedCfg // explicit embed config (used with GoFiles to pass pre-resolved embed metadata)
 
 	// Resolved once by CompilePackage; avoids repeated go env subprocesses.
 	goroot        string

--- a/go/go2nix/pkg/compile/manifest.go
+++ b/go/go2nix/pkg/compile/manifest.go
@@ -132,7 +132,7 @@ func MergeImportcfg(parts []string, tmpDir string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("creating merged importcfg: %w", err)
 	}
-	defer f.Close()
+	defer f.Close() //nolint:errcheck
 
 	w := bufio.NewWriter(f)
 	for _, part := range parts {
@@ -144,15 +144,17 @@ func MergeImportcfg(parts []string, tmpDir string) (string, error) {
 		for scanner.Scan() {
 			line := scanner.Text()
 			if strings.HasPrefix(line, "packagefile ") || strings.HasPrefix(line, "importmap ") {
-				w.WriteString(line)
-				w.WriteByte('\n')
+				_, _ = w.WriteString(line)
+				_ = w.WriteByte('\n')
 			}
 		}
 		if err := scanner.Err(); err != nil {
-			pf.Close()
+			_ = pf.Close()
 			return "", fmt.Errorf("reading importcfg part %s: %w", part, err)
 		}
-		pf.Close()
+		if err := pf.Close(); err != nil {
+			return "", fmt.Errorf("closing importcfg part %s: %w", part, err)
+		}
 	}
 
 	if err := w.Flush(); err != nil {

--- a/go/go2nix/pkg/compile/util_test.go
+++ b/go/go2nix/pkg/compile/util_test.go
@@ -9,7 +9,9 @@ import (
 func TestEnvOrDefault(t *testing.T) {
 	key := "GO2NIX_TEST_ENV_OR_DEFAULT"
 
-	os.Unsetenv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatal(err)
+	}
 	if got := envOrDefault(key, "fallback"); got != "fallback" {
 		t.Errorf("unset: got %q, want %q", got, "fallback")
 	}
@@ -86,7 +88,9 @@ func TestLangVersion(t *testing.T) {
 func TestFindGoVersion(t *testing.T) {
 	// Create a module root with go.mod.
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/foo\n\ngo 1.21.3\n"), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/foo\n\ngo 1.21.3\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	// From the module root itself.
 	if got := findGoVersion(dir); got != "1.21" {
@@ -95,7 +99,9 @@ func TestFindGoVersion(t *testing.T) {
 
 	// From a sub-package directory.
 	subdir := filepath.Join(dir, "pkg", "bar")
-	os.MkdirAll(subdir, 0o755)
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if got := findGoVersion(subdir); got != "1.21" {
 		t.Errorf("subdir: got %q, want %q", got, "1.21")
 	}
@@ -111,13 +117,17 @@ func TestExtractPackageName(t *testing.T) {
 	dir := t.TempDir()
 
 	main := filepath.Join(dir, "main.go")
-	os.WriteFile(main, []byte("package main\n"), 0o644)
+	if err := os.WriteFile(main, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if got := extractPackageName(main); got != "main" {
 		t.Errorf("main.go: got %q, want %q", got, "main")
 	}
 
 	lib := filepath.Join(dir, "lib.go")
-	os.WriteFile(lib, []byte("package mylib\n"), 0o644)
+	if err := os.WriteFile(lib, []byte("package mylib\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if got := extractPackageName(lib); got != "mylib" {
 		t.Errorf("lib.go: got %q, want %q", got, "mylib")
 	}
@@ -129,7 +139,9 @@ func TestExtractPackageName(t *testing.T) {
 
 	// Invalid syntax falls back to "main".
 	bad := filepath.Join(dir, "bad.go")
-	os.WriteFile(bad, []byte("not valid go {{{"), 0o644)
+	if err := os.WriteFile(bad, []byte("not valid go {{{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if got := extractPackageName(bad); got != "main" {
 		t.Errorf("invalid syntax: got %q, want %q", got, "main")
 	}

--- a/go/go2nix/pkg/gofiles/gofiles.go
+++ b/go/go2nix/pkg/gofiles/gofiles.go
@@ -177,10 +177,10 @@ func ResolveEmbedCfg(dir string, patterns []string) (*EmbedCfg, error) {
 						return err
 					}
 					relPath, err := filepath.Rel(dir, path)
-				if err != nil {
-					return fmt.Errorf("computing relative path for %s: %w", path, err)
-				}
-				rel := filepath.ToSlash(relPath)
+					if err != nil {
+						return fmt.Errorf("computing relative path for %s: %w", path, err)
+					}
+					rel := filepath.ToSlash(relPath)
 					name := d.Name()
 
 					if path != file && (isBadEmbedName(name) || ((name[0] == '.' || name[0] == '_') && !all)) {
@@ -299,7 +299,6 @@ func isBadEmbedName(name string) bool {
 	}
 	return false
 }
-
 
 func nonNil(s []string) []string {
 	if s == nil {

--- a/go/go2nix/pkg/gofiles/gofiles_test.go
+++ b/go/go2nix/pkg/gofiles/gofiles_test.go
@@ -233,7 +233,9 @@ func TestResolveEmbedCfg_IrregularFileRejected(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "real.txt"), "real")
 	// Create a symlink — should be rejected as irregular.
-	os.Symlink("real.txt", filepath.Join(dir, "link.txt"))
+	if err := os.Symlink("real.txt", filepath.Join(dir, "link.txt")); err != nil {
+		t.Fatal(err)
+	}
 
 	_, err := ResolveEmbedCfg(dir, []string{"link.txt"})
 	if err == nil {

--- a/go/go2nix/pkg/golist/golist.go
+++ b/go/go2nix/pkg/golist/golist.go
@@ -27,11 +27,11 @@ type Pkg struct {
 	FFiles         []string `json:"FFiles"` // .f, .F, .for, .f90 Fortran source files
 	SFiles         []string `json:"SFiles"`
 	HFiles         []string `json:"HFiles"`
-	SysoFiles      []string `json:"SysoFiles"`      // .syso system object files
-	SwigFiles      []string `json:"SwigFiles"`      // .swig files
-	SwigCXXFiles   []string `json:"SwigCXXFiles"`   // .swigcxx files
-	EmbedPatterns  []string `json:"EmbedPatterns"`   // //go:embed patterns
-	EmbedFiles     []string `json:"EmbedFiles"`      // resolved files matching embed patterns
+	SysoFiles      []string `json:"SysoFiles"`     // .syso system object files
+	SwigFiles      []string `json:"SwigFiles"`     // .swig files
+	SwigCXXFiles   []string `json:"SwigCXXFiles"`  // .swigcxx files
+	EmbedPatterns  []string `json:"EmbedPatterns"` // //go:embed patterns
+	EmbedFiles     []string `json:"EmbedFiles"`    // resolved files matching embed patterns
 	Standard       bool     `json:"Standard"`
 	DepOnly        bool     `json:"DepOnly"`
 	Imports        []string `json:"Imports"`

--- a/go/go2nix/pkg/localpkgs/localpkgs_test.go
+++ b/go/go2nix/pkg/localpkgs/localpkgs_test.go
@@ -248,9 +248,13 @@ func indexOf(s []string, v string) int {
 
 func TestListLocalPackagesIncludesTestFiles(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.21\n"), 0o644)
-	os.WriteFile(filepath.Join(dir, "foo.go"), []byte("package test\n\nfunc Add(a, b int) int { return a + b }\n"), 0o644)
-	os.WriteFile(filepath.Join(dir, "foo_test.go"), []byte(`package test
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "foo.go"), []byte("package test\n\nfunc Add(a, b int) int { return a + b }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "foo_test.go"), []byte(`package test
 
 import "testing"
 
@@ -259,7 +263,9 @@ func TestAdd(t *testing.T) {
 		t.Fatal("wrong")
 	}
 }
-`), 0o644)
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	pkgs, err := ListLocalPackages(dir, "")
 	if err != nil {

--- a/go/go2nix/pkg/lockfilegen/generate.go
+++ b/go/go2nix/pkg/lockfilegen/generate.go
@@ -130,7 +130,7 @@ func removeReadOnly(dir string) {
 	// Go module cache dirs are read-only; chmod before removal.
 	// Errors are logged rather than returned since this is called
 	// via defer and cleanup failure is non-fatal.
-	filepath.WalkDir(dir, func(path string, _ fs.DirEntry, walkErr error) error {
+	if err := filepath.WalkDir(dir, func(path string, _ fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -138,7 +138,9 @@ func removeReadOnly(dir string) {
 			slog.Debug("chmod failed during cleanup", "path", path, "err", err)
 		}
 		return nil
-	})
+	}); err != nil {
+		slog.Debug("walkdir failed during cleanup", "dir", dir, "err", err)
+	}
 	if err := os.RemoveAll(dir); err != nil {
 		slog.Warn("failed to remove temp dir", "dir", dir, "err", err)
 	}

--- a/go/go2nix/pkg/mvscheck/mvscheck.go
+++ b/go/go2nix/pkg/mvscheck/mvscheck.go
@@ -61,7 +61,7 @@ func CheckLockfile(dir string, lockfilePath string) error {
 		sort.Strings(missing)
 		return fmt.Errorf(
 			"go.mod requires modules not found in lockfile %s:\n  %s\n\n"+
-				"The lockfile is stale. Run `go mod tidy && go2nix generate` to update it.",
+				"the lockfile is stale; run `go mod tidy && go2nix generate` to update it",
 			lockfilePath,
 			strings.Join(missing, "\n  "),
 		)

--- a/go/go2nix/pkg/nixdrv/derivation_test.go
+++ b/go/go2nix/pkg/nixdrv/derivation_test.go
@@ -32,21 +32,27 @@ func TestDerivationJSON(t *testing.T) {
 
 	// Check name
 	var name string
-	json.Unmarshal(got["name"], &name)
+	if err := json.Unmarshal(got["name"], &name); err != nil {
+		t.Fatalf("unmarshal name: %v", err)
+	}
 	if name != "hello" {
 		t.Errorf("name = %q, want %q", name, "hello")
 	}
 
 	// Check version
 	var version int
-	json.Unmarshal(got["version"], &version)
+	if err := json.Unmarshal(got["version"], &version); err != nil {
+		t.Fatalf("unmarshal version: %v", err)
+	}
 	if version != 4 {
 		t.Errorf("version = %d, want 4", version)
 	}
 
 	// Check inputs has srcs and drvs
 	var inputs map[string]json.RawMessage
-	json.Unmarshal(got["inputs"], &inputs)
+	if err := json.Unmarshal(got["inputs"], &inputs); err != nil {
+		t.Fatalf("unmarshal inputs: %v", err)
+	}
 	for _, field := range []string{"srcs", "drvs"} {
 		if _, ok := inputs[field]; !ok {
 			t.Errorf("missing inputs field %q", field)

--- a/go/go2nix/pkg/nixdrv/derivation_test.go
+++ b/go/go2nix/pkg/nixdrv/derivation_test.go
@@ -138,7 +138,7 @@ func TestDerivationSortedKeys(t *testing.T) {
 	if aIdx == -1 || mIdx == -1 || zIdx == -1 {
 		t.Fatalf("missing env keys in JSON: %s", s)
 	}
-	if !(aIdx < mIdx && mIdx < zIdx) {
+	if aIdx >= mIdx || mIdx >= zIdx {
 		t.Errorf("env keys not sorted: AAA@%d, MMM@%d, ZZZ@%d", aIdx, mIdx, zIdx)
 	}
 }

--- a/go/go2nix/pkg/nixdrv/drvpath.go
+++ b/go/go2nix/pkg/nixdrv/drvpath.go
@@ -117,13 +117,11 @@ func convertOutput(o *Output) (*gonixdrv.Output, error) {
 	gno := &gonixdrv.Output{}
 
 	// Determine the ATerm hashAlgorithm prefix from the method.
-	methodPrefix := ""
+	var methodPrefix string
 	switch o.Method {
 	case "nar":
 		methodPrefix = "r:"
-	case "flat":
-		methodPrefix = ""
-	case "text":
+	case "flat", "text":
 		methodPrefix = ""
 	case "":
 		// Input-addressed output (has path, no method)

--- a/go/go2nix/pkg/resolve/resolve.go
+++ b/go/go2nix/pkg/resolve/resolve.go
@@ -388,7 +388,7 @@ func registerDerivationsParallel(
 	nix *nixdrv.NixTool,
 	sorted []*ResolvedPkg,
 	drvs []*nixdrv.Derivation,
-	graph map[string]*ResolvedPkg,
+	_ map[string]*ResolvedPkg,
 	concurrency int,
 ) error {
 	// Compute topo level for each package.
@@ -758,7 +758,7 @@ func buildFinalDrv(
 // Returns the .drv path and the Derivation for parallel registration.
 func buildLinkDrv(
 	cfg Config,
-	graph map[string]*ResolvedPkg,
+	_ map[string]*ResolvedPkg,
 	sorted []*ResolvedPkg,
 	mainPkg *ResolvedPkg,
 	numMains int,

--- a/go/go2nix/pkg/resolve/resolve.go
+++ b/go/go2nix/pkg/resolve/resolve.go
@@ -16,15 +16,14 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/mod/module"
-	"golang.org/x/sync/errgroup"
-
 	"github.com/nix-community/go-nix/pkg/storepath"
 	"github.com/numtide/go2nix/pkg/buildinfo"
 	"github.com/numtide/go2nix/pkg/compile"
 	"github.com/numtide/go2nix/pkg/golist"
 	"github.com/numtide/go2nix/pkg/lockfile"
 	"github.com/numtide/go2nix/pkg/nixdrv"
+	"golang.org/x/mod/module"
+	"golang.org/x/sync/errgroup"
 )
 
 // Config holds all configuration for the resolve flow.

--- a/go/go2nix/pkg/resolve/resolve.go
+++ b/go/go2nix/pkg/resolve/resolve.go
@@ -159,7 +159,7 @@ func Resolve(cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("setting up GOMODCACHE: %w", err)
 	}
-	defer os.RemoveAll(gomodcache)
+	defer os.RemoveAll(gomodcache) //nolint:errcheck
 	slog.Info("GOMODCACHE set up", "elapsed", time.Since(t))
 
 	// Step 5: Discover packages
@@ -468,7 +468,7 @@ func setupGOMODCACHE(fodPaths map[string]*storepath.StorePath) (string, error) {
 		})
 	}
 	if err := g.Wait(); err != nil {
-		os.RemoveAll(gomodcache)
+		_ = os.RemoveAll(gomodcache)
 		return "", fmt.Errorf("merging FODs: %w", err)
 	}
 	return gomodcache, nil
@@ -639,7 +639,7 @@ func setupPkgSource(
 		if err != nil {
 			return fmt.Errorf("creating filtered source for %s: %w", pkg.ImportPath, err)
 		}
-		defer os.RemoveAll(filteredDir)
+		defer os.RemoveAll(filteredDir) //nolint:errcheck
 
 		name := "gosrc-" + nixdrv.SanitizeName(pkg.ImportPath)
 		pkgStorePath, err := nix.StoreAdd(name, filteredDir)
@@ -1112,7 +1112,7 @@ func createFilteredPkgDir(pkgDir string, pkg *ResolvedPkg) (string, error) {
 	// Copy source files (basenames).
 	for _, f := range files {
 		if err := linkOrCopyFile(filepath.Join(pkgDir, f), filepath.Join(tmpDir, f)); err != nil {
-			os.RemoveAll(tmpDir)
+			_ = os.RemoveAll(tmpDir)
 			return "", fmt.Errorf("copying %s: %w", f, err)
 		}
 	}
@@ -1121,11 +1121,11 @@ func createFilteredPkgDir(pkgDir string, pkg *ResolvedPkg) (string, error) {
 	for _, f := range pkg.EmbedFiles {
 		dst := filepath.Join(tmpDir, f)
 		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			os.RemoveAll(tmpDir)
+			_ = os.RemoveAll(tmpDir)
 			return "", fmt.Errorf("creating dir for embed file %s: %w", f, err)
 		}
 		if err := linkOrCopyFile(filepath.Join(pkgDir, f), dst); err != nil {
-			os.RemoveAll(tmpDir)
+			_ = os.RemoveAll(tmpDir)
 			return "", fmt.Errorf("copying embed file %s: %w", f, err)
 		}
 	}

--- a/go/go2nix/pkg/resolve/resolve_test.go
+++ b/go/go2nix/pkg/resolve/resolve_test.go
@@ -162,17 +162,29 @@ func TestDiscoverInputPaths(t *testing.T) {
 	pkgC := filepath.Join(root, "pkgC")
 
 	// pkgA: bin + pkgconfig + propagated-build-inputs → pkgB
-	os.MkdirAll(filepath.Join(pkgA, "bin"), 0o755)
-	os.MkdirAll(filepath.Join(pkgA, "lib", "pkgconfig"), 0o755)
-	os.MkdirAll(filepath.Join(pkgA, "nix-support"), 0o755)
-	os.WriteFile(filepath.Join(pkgA, "nix-support", "propagated-build-inputs"),
-		[]byte(pkgB), 0o644)
+	if err := os.MkdirAll(filepath.Join(pkgA, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(pkgA, "lib", "pkgconfig"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(pkgA, "nix-support"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgA, "nix-support", "propagated-build-inputs"),
+		[]byte(pkgB), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	// pkgB: pkgconfig only
-	os.MkdirAll(filepath.Join(pkgB, "lib", "pkgconfig"), 0o755)
+	if err := os.MkdirAll(filepath.Join(pkgB, "lib", "pkgconfig"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	// pkgC: bin only
-	os.MkdirAll(filepath.Join(pkgC, "bin"), 0o755)
+	if err := os.MkdirAll(filepath.Join(pkgC, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	result := discoverInputPaths([]string{pkgA, pkgC})
 
@@ -208,13 +220,21 @@ func TestDiscoverInputPathsCyclic(t *testing.T) {
 	pkgX := filepath.Join(root, "pkgX")
 	pkgY := filepath.Join(root, "pkgY")
 
-	os.MkdirAll(filepath.Join(pkgX, "nix-support"), 0o755)
-	os.WriteFile(filepath.Join(pkgX, "nix-support", "propagated-build-inputs"),
-		[]byte(pkgY), 0o644)
+	if err := os.MkdirAll(filepath.Join(pkgX, "nix-support"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgX, "nix-support", "propagated-build-inputs"),
+		[]byte(pkgY), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
-	os.MkdirAll(filepath.Join(pkgY, "nix-support"), 0o755)
-	os.WriteFile(filepath.Join(pkgY, "nix-support", "propagated-build-inputs"),
-		[]byte(pkgX), 0o644)
+	if err := os.MkdirAll(filepath.Join(pkgY, "nix-support"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgY, "nix-support", "propagated-build-inputs"),
+		[]byte(pkgX), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	result := discoverInputPaths([]string{pkgX})
 	if len(result.All) != 2 {

--- a/go/go2nix/pkg/testmain/testmain_test.go
+++ b/go/go2nix/pkg/testmain/testmain_test.go
@@ -10,14 +10,16 @@ import (
 func TestGenerateBasic(t *testing.T) {
 	dir := t.TempDir()
 	testFile := filepath.Join(dir, "foo_test.go")
-	os.WriteFile(testFile, []byte(`package foo
+	if err := os.WriteFile(testFile, []byte(`package foo
 
 import "testing"
 
 func TestAdd(t *testing.T) {}
 func BenchmarkAdd(b *testing.B) {}
 func FuzzAdd(f *testing.F) {}
-`), 0o644)
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	got, err := Generate(Options{
 		ImportPath:  "example.com/foo",
@@ -48,12 +50,14 @@ func FuzzAdd(f *testing.F) {}
 func TestGenerateExternal(t *testing.T) {
 	dir := t.TempDir()
 	testFile := filepath.Join(dir, "foo_ext_test.go")
-	os.WriteFile(testFile, []byte(`package foo_test
+	if err := os.WriteFile(testFile, []byte(`package foo_test
 
 import "testing"
 
 func TestExternal(t *testing.T) {}
-`), 0o644)
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	got, err := Generate(Options{
 		ImportPath:   "example.com/foo",
@@ -75,7 +79,7 @@ func TestExternal(t *testing.T) {}
 func TestGenerateTestMain(t *testing.T) {
 	dir := t.TempDir()
 	testFile := filepath.Join(dir, "main_test.go")
-	os.WriteFile(testFile, []byte(`package foo
+	if err := os.WriteFile(testFile, []byte(`package foo
 
 import (
 	"os"
@@ -87,7 +91,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestFoo(t *testing.T) {}
-`), 0o644)
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	got, err := Generate(Options{
 		ImportPath:  "example.com/foo",
@@ -112,7 +118,7 @@ func TestFoo(t *testing.T) {}
 func TestGenerateExamples(t *testing.T) {
 	dir := t.TempDir()
 	testFile := filepath.Join(dir, "example_test.go")
-	os.WriteFile(testFile, []byte(`package foo
+	if err := os.WriteFile(testFile, []byte(`package foo
 
 import "fmt"
 
@@ -120,7 +126,9 @@ func ExampleHello() {
 	fmt.Println("hello")
 	// Output: hello
 }
-`), 0o644)
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	got, err := Generate(Options{
 		ImportPath:  "example.com/foo",
@@ -159,20 +167,24 @@ func TestGenerateEmpty(t *testing.T) {
 func TestGenerateMixed(t *testing.T) {
 	dir := t.TempDir()
 	intFile := filepath.Join(dir, "foo_test.go")
-	os.WriteFile(intFile, []byte(`package foo
+	if err := os.WriteFile(intFile, []byte(`package foo
 
 import "testing"
 
 func TestInternal(t *testing.T) {}
-`), 0o644)
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	extFile := filepath.Join(dir, "foo_ext_test.go")
-	os.WriteFile(extFile, []byte(`package foo_test
+	if err := os.WriteFile(extFile, []byte(`package foo_test
 
 import "testing"
 
 func TestExternal(t *testing.T) {}
-`), 0o644)
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	got, err := Generate(Options{
 		ImportPath:   "example.com/foo",

--- a/go/go2nix/pkg/testrunner/testrunner.go
+++ b/go/go2nix/pkg/testrunner/testrunner.go
@@ -210,15 +210,15 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 		goFiles := append(append([]string{}, pkg.GoFiles...), pkg.CgoFiles...)
 		goFiles = append(goFiles, pkg.TestGoFiles...)
 		if err := compile.CompileGoPackage(compile.Options{
-			ImportPath: pkg.ImportPath,
-			SrcDir:     mergedDir,
-			Output:     internalArchive,
-			ImportCfg:  testImportCfg,
-			TrimPath:   opts.TrimPath,
-			Tags:       opts.Tags,
+			ImportPath:  pkg.ImportPath,
+			SrcDir:      mergedDir,
+			Output:      internalArchive,
+			ImportCfg:   testImportCfg,
+			TrimPath:    opts.TrimPath,
+			Tags:        opts.Tags,
 			GCFlagsList: opts.GCFlagsList,
-			GoFiles:    goFiles,
-			EmbedCfg:   mergedEmbedCfg,
+			GoFiles:     goFiles,
+			EmbedCfg:    mergedEmbedCfg,
 		}); err != nil {
 			return fmt.Errorf("compiling internal test: %w", err)
 		}
@@ -264,12 +264,12 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 			recompArchive := filepath.Join(testDir, "recomp-"+sanitize(depIP)+".a")
 			slog.Info("recompiling for test", "pkg", depIP, "because", pkg.ImportPath)
 			if err := compile.CompileGoPackage(compile.Options{
-				ImportPath: depIP,
-				SrcDir:     depPkg.SrcDir,
-				Output:     recompArchive,
-				ImportCfg:  testImportCfg,
-				TrimPath:   opts.TrimPath,
-				Tags:       opts.Tags,
+				ImportPath:  depIP,
+				SrcDir:      depPkg.SrcDir,
+				Output:      recompArchive,
+				ImportCfg:   testImportCfg,
+				TrimPath:    opts.TrimPath,
+				Tags:        opts.Tags,
 				GCFlagsList: opts.GCFlagsList,
 			}); err != nil {
 				return fmt.Errorf("recompiling %s for test: %w", depIP, err)
@@ -309,15 +309,15 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 		// Explicit file list: _test.go files would be classified as
 		// TestGoFiles/XTestGoFiles by ImportDir, not GoFiles.
 		if err := compile.CompileGoPackage(compile.Options{
-			ImportPath: pkg.ImportPath + "_test",
-			SrcDir:     xtestDir,
-			Output:     externalArchive,
-			ImportCfg:  testImportCfg,
-			TrimPath:   opts.TrimPath,
-			Tags:       opts.Tags,
+			ImportPath:  pkg.ImportPath + "_test",
+			SrcDir:      xtestDir,
+			Output:      externalArchive,
+			ImportCfg:   testImportCfg,
+			TrimPath:    opts.TrimPath,
+			Tags:        opts.Tags,
 			GCFlagsList: opts.GCFlagsList,
-			GoFiles:    pkg.XTestGoFiles,
-			EmbedCfg:   pkg.XTestEmbedCfg,
+			GoFiles:     pkg.XTestGoFiles,
+			EmbedCfg:    pkg.XTestEmbedCfg,
 		}); err != nil {
 			return fmt.Errorf("compiling external test: %w", err)
 		}
@@ -360,15 +360,15 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 	// Explicit file: _testmain.go starts with _ and would be ignored by ImportDir.
 	testMainArchive := filepath.Join(testDir, "testmain.a")
 	if err := compile.CompileGoPackage(compile.Options{
-		ImportPath: pkg.ImportPath + ".test",
-		PFlag:      "main",
-		SrcDir:     testDir,
-		Output:     testMainArchive,
-		ImportCfg:  testImportCfg,
-		TrimPath:   opts.TrimPath,
-		Tags:       opts.Tags,
+		ImportPath:  pkg.ImportPath + ".test",
+		PFlag:       "main",
+		SrcDir:      testDir,
+		Output:      testMainArchive,
+		ImportCfg:   testImportCfg,
+		TrimPath:    opts.TrimPath,
+		Tags:        opts.Tags,
 		GCFlagsList: opts.GCFlagsList,
-		GoFiles:    []string{"_testmain.go"},
+		GoFiles:     []string{"_testmain.go"},
 	}); err != nil {
 		return fmt.Errorf("compiling test main: %w", err)
 	}

--- a/packages/go2nix-testgen/cmd/torture.go
+++ b/packages/go2nix-testgen/cmd/torture.go
@@ -705,9 +705,9 @@ func generateLibSource(baseDir string, mod ModuleDef) error {
 	}
 	for _, d := range deps {
 		if d.Alias != "" {
-			buf.WriteString(fmt.Sprintf("\t%s %q\n", d.Alias, d.Path))
+			fmt.Fprintf(&buf, "\t%s %q\n", d.Alias, d.Path)
 		} else {
-			buf.WriteString(fmt.Sprintf("\t%q\n", d.Path))
+			fmt.Fprintf(&buf, "\t%q\n", d.Path)
 		}
 	}
 	buf.WriteString(")\n\n")
@@ -720,7 +720,7 @@ func generateLibSource(baseDir string, mod ModuleDef) error {
 	for _, dep := range mod.LocalDeps {
 		for _, m := range multiModules {
 			if m.Name == dep {
-				buf.WriteString(fmt.Sprintf("\tif err := %s.Run(); err != nil {\n\t\treturn err\n\t}\n", m.PkgName))
+				fmt.Fprintf(&buf, "\tif err := %s.Run(); err != nil {\n\t\treturn err\n\t}\n", m.PkgName)
 				break
 			}
 		}


### PR DESCRIPTION
## Summary

- Add `.golangci.yml` config, GitHub Actions CI workflow, and devshell integration for golangci-lint
- Fix all existing lint issues across the codebase: import ordering (gci), formatting (gofumpt), wasted assignments, error return checks (errcheck), unused parameters (unparam), nilerr suppressions, and more