### PR TITLE
fix: pin nix version to 2.34 across the project

### DIFF
--- a/packages/benchmark-build-cross-app-isolation/default.nix
+++ b/packages/benchmark-build-cross-app-isolation/default.nix
@@ -97,7 +97,7 @@ in
 pkgs.writeShellApplication {
   name = "benchmark-build-cross-app-isolation";
   runtimeInputs = [
-    pkgs.nixVersions.latest
+    pkgs.nixVersions.nix_2_34
     pkgs.hyperfine
     pkgs.coreutils
     go

--- a/packages/benchmark-build/default.nix
+++ b/packages/benchmark-build/default.nix
@@ -95,7 +95,7 @@ let
       goEnv = go2nixLib.mkGoEnv {
         go = pkgs.go_1_26;
         go2nix = import ${go2nixSrc}/packages/go2nix { inherit pkgs; };
-        nixPackage = pkgs.nixVersions.latest;
+        nixPackage = pkgs.nixVersions.nix_2_34;
         inherit (pkgs) callPackage;
       };
     in
@@ -112,7 +112,7 @@ in
 pkgs.writeShellApplication {
   name = "benchmark-build";
   runtimeInputs = [
-    pkgs.nixVersions.latest
+    pkgs.nixVersions.nix_2_34
     pkgs.coreutils
     pkgs.hyperfine
     pkgs.jq

--- a/packages/benchmark-eval/default.nix
+++ b/packages/benchmark-eval/default.nix
@@ -77,7 +77,7 @@ let
       goEnv = go2nixLib.mkGoEnv {
         go = pkgs.go_1_26;
         go2nix = import ${go2nixSrc}/packages/go2nix { inherit pkgs; };
-        nixPackage = pkgs.nixVersions.latest;
+        nixPackage = pkgs.nixVersions.nix_2_34;
         inherit (pkgs) callPackage;
       };
     in
@@ -94,7 +94,7 @@ in
 pkgs.writeShellApplication {
   name = "benchmark-eval";
   runtimeInputs = [
-    pkgs.nixVersions.latest
+    pkgs.nixVersions.nix_2_34
     pkgs.hyperfine
     pkgs.coreutils
     go

--- a/packages/go2nix-nix-plugin/plugin/CMakeLists.txt
+++ b/packages/go2nix-nix-plugin/plugin/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(go2nix-nix-plugin)
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(NIX REQUIRED nix-expr>=2.32 nix-store>=2.32)
+pkg_check_modules(NIX REQUIRED nix-expr>=2.34 nix-store>=2.34)
 
 find_package(nlohmann_json REQUIRED)
 

--- a/packages/go2nix-testgen/default.nix
+++ b/packages/go2nix-testgen/default.nix
@@ -17,7 +17,7 @@ if !(flake.packages.${system} ? go2nix-nix-plugin) then
 else
   let
     plugin = flake.packages.${system}.go2nix-nix-plugin;
-    nix = pkgs.nixVersions.latest;
+    nix = pkgs.nixVersions.nix_2_34;
     nixpkgsPath = pkgs.path;
     go2nixSrc = flake;
   in

--- a/packages/test-fixture-modroot-nested/default.nix
+++ b/packages/test-fixture-modroot-nested/default.nix
@@ -17,7 +17,7 @@ if !(flake.packages.${system} ? go2nix-nix-plugin) then
 else
   let
     plugin = flake.packages.${system}.go2nix-nix-plugin;
-    nix = pkgs.nixVersions.latest;
+    nix = pkgs.nixVersions.nix_2_34;
 
     nixpkgsPath = pkgs.path;
     go2nixSrc = flake;

--- a/packages/test-fixture-test-helper-pkg/default.nix
+++ b/packages/test-fixture-test-helper-pkg/default.nix
@@ -17,7 +17,7 @@ if !(flake.packages.${system} ? go2nix-nix-plugin) then
 else
   let
     plugin = flake.packages.${system}.go2nix-nix-plugin;
-    nix = pkgs.nixVersions.latest;
+    nix = pkgs.nixVersions.nix_2_34;
 
     nixpkgsPath = pkgs.path;
     go2nixSrc = flake;

--- a/packages/test-fixture-testify-basic/default.nix
+++ b/packages/test-fixture-testify-basic/default.nix
@@ -17,7 +17,7 @@ if !(flake.packages.${system} ? go2nix-nix-plugin) then
 else
   let
     plugin = flake.packages.${system}.go2nix-nix-plugin;
-    nix = pkgs.nixVersions.latest;
+    nix = pkgs.nixVersions.nix_2_34;
     inherit (pkgs) go;
 
     nixpkgsPath = pkgs.path;

--- a/packages/test-fixture-torture-app-full/default.nix
+++ b/packages/test-fixture-torture-app-full/default.nix
@@ -18,7 +18,7 @@ if !(flake.packages.${system} ? go2nix-nix-plugin) then
 else
   let
     plugin = flake.packages.${system}.go2nix-nix-plugin;
-    nix = pkgs.nixVersions.latest;
+    nix = pkgs.nixVersions.nix_2_34;
     go = pkgs.go_1_26;
 
     nixpkgsPath = pkgs.path;

--- a/packages/test-fixture-xtest-local-dep/default.nix
+++ b/packages/test-fixture-xtest-local-dep/default.nix
@@ -17,7 +17,7 @@ if !(flake.packages.${system} ? go2nix-nix-plugin) then
 else
   let
     plugin = flake.packages.${system}.go2nix-nix-plugin;
-    nix = pkgs.nixVersions.latest;
+    nix = pkgs.nixVersions.nix_2_34;
 
     nixpkgsPath = pkgs.path;
     go2nixSrc = flake;

--- a/packages/test-package-dotool/default.nix
+++ b/packages/test-package-dotool/default.nix
@@ -19,7 +19,7 @@ if !(flake.packages.${system} ? go2nix-nix-plugin) then
 else
   let
     plugin = flake.packages.${system}.go2nix-nix-plugin;
-    nix = pkgs.nixVersions.latest;
+    nix = pkgs.nixVersions.nix_2_34;
     inherit (pkgs) go;
 
     nixpkgsPath = pkgs.path;

--- a/packages/test-package-nwg-drawer/default.nix
+++ b/packages/test-package-nwg-drawer/default.nix
@@ -20,7 +20,7 @@ if !(flake.packages.${system} ? go2nix-nix-plugin) then
 else
   let
     plugin = flake.packages.${system}.go2nix-nix-plugin;
-    nix = pkgs.nixVersions.latest;
+    nix = pkgs.nixVersions.nix_2_34;
     inherit (pkgs) go;
 
     nixpkgsPath = pkgs.path;

--- a/packages/test-package-vinegar/default.nix
+++ b/packages/test-package-vinegar/default.nix
@@ -20,7 +20,7 @@ if !(flake.packages.${system} ? go2nix-nix-plugin) then
 else
   let
     plugin = flake.packages.${system}.go2nix-nix-plugin;
-    nix = pkgs.nixVersions.latest;
+    nix = pkgs.nixVersions.nix_2_34;
     inherit (pkgs) go;
 
     nixpkgsPath = pkgs.path;

--- a/packages/test-package-yubikey-agent/default.nix
+++ b/packages/test-package-yubikey-agent/default.nix
@@ -20,7 +20,7 @@ if !(flake.packages.${system} ? go2nix-nix-plugin) then
 else
   let
     plugin = flake.packages.${system}.go2nix-nix-plugin;
-    nix = pkgs.nixVersions.latest;
+    nix = pkgs.nixVersions.nix_2_34;
     inherit (pkgs) go;
 
     nixpkgsPath = pkgs.path;

--- a/tests/packages/dotool/dynamic.nix
+++ b/tests/packages/dotool/dynamic.nix
@@ -10,7 +10,7 @@ let
   goEnv = import ../../../nix/mk-go-env.nix {
     inherit go go2nix;
     inherit (pkgs) callPackage;
-    nixPackage = pkgs.nixVersions.git;
+    nixPackage = pkgs.nixVersions.nix_2_34;
   };
 in
 goEnv.buildGoApplicationExperimental {

--- a/tests/packages/nwg-drawer/dynamic.nix
+++ b/tests/packages/nwg-drawer/dynamic.nix
@@ -10,7 +10,7 @@ let
   goEnv = import ../../../nix/mk-go-env.nix {
     inherit go go2nix;
     inherit (pkgs) callPackage;
-    nixPackage = pkgs.nixVersions.git;
+    nixPackage = pkgs.nixVersions.nix_2_34;
   };
 
   # All GTK-related nativeBuildInputs needed by gotk4 cgo packages.

--- a/tests/packages/yubikey-agent/dynamic.nix
+++ b/tests/packages/yubikey-agent/dynamic.nix
@@ -10,7 +10,7 @@ let
   goEnv = import ../../../nix/mk-go-env.nix {
     inherit go go2nix;
     inherit (pkgs) callPackage;
-    nixPackage = pkgs.nixVersions.git;
+    nixPackage = pkgs.nixVersions.nix_2_34;
   };
 in
 goEnv.buildGoApplicationExperimental {


### PR DESCRIPTION
## Summary

- Bump required `nix-expr` and `nix-store` pkg-config versions from 2.32 to 2.34 in CMakeLists.txt
- Replace all `nixVersions.latest` and `nixVersions.git` with `nixVersions.nix_2_34` for explicit version pinning