### PR TITLE
fix: add required toolchain input to mdbook deploy workflow

### DIFF
--- a/.github/workflows/deploy-mdbook.yml
+++ b/.github/workflows/deploy-mdbook.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
 
       - name: Install mdBook
         run: cargo install --locked mdbook


### PR DESCRIPTION
## Summary

- Add missing `toolchain: stable` input to `dtolnay/rust-toolchain` action, which is now required