### PR TITLE
Eliminate lockfile by resolving NAR hashes at eval time

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,14 @@
             plugin = callPkg ./packages/go2nix-nix-plugin/default.nix;
             testFixtures = ./packages/go2nix-nix-plugin/tests/fixtures;
           };
+          go2nix-nix-plugin-resolve-hashes-test = pkgs.callPackage ./packages/go2nix-nix-plugin/tests/resolve-hashes-test.nix {
+            plugin = callPkg ./packages/go2nix-nix-plugin/default.nix;
+            testFixtures = ./packages/go2nix-nix-plugin/tests/fixtures;
+          };
+
+          test-package-yubikey-agent-no-lockfile = callPkgWith ./packages/test-package-yubikey-agent-no-lockfile/default.nix {
+            inherit flake system;
+          };
 
           test-package-dotool = callPkgWith ./packages/test-package-dotool/default.nix {
             inherit flake system;

--- a/flake.nix
+++ b/flake.nix
@@ -98,6 +98,24 @@
         default = import ./devshell.nix { inherit pkgs; };
       });
 
+      checks = forAllSystems (system: pkgs:
+        let
+          flake = self;
+          callPkg = path: pkgs.callPackage path { };
+          callPkgWith = path: args: pkgs.callPackage path args;
+        in
+        {
+          go2nix-nix-plugin-eval-test = pkgs.callPackage ./packages/go2nix-nix-plugin/tests/eval-test.nix {
+            plugin = callPkg ./packages/go2nix-nix-plugin/default.nix;
+            testFixtures = ./packages/go2nix-nix-plugin/tests/fixtures;
+          };
+          go2nix-nix-plugin-resolve-hashes-test = pkgs.callPackage ./packages/go2nix-nix-plugin/tests/resolve-hashes-test.nix {
+            plugin = callPkg ./packages/go2nix-nix-plugin/default.nix;
+            testFixtures = ./packages/go2nix-nix-plugin/tests/fixtures;
+          };
+        }
+      );
+
       formatter = forAllSystems (_: pkgs:
         import ./formatter.nix {
           inherit pkgs;

--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -43,9 +43,11 @@ func linkBinary(manifestPath, output string) error {
 		tmpDir = os.TempDir()
 	}
 
-	// Step 1: Validate lockfile consistency.
-	if err := mvscheck.CheckLockfile(m.ModuleRoot, m.Lockfile); err != nil {
-		return fmt.Errorf("lockfile check: %w", err)
+	// Step 1: Validate lockfile consistency (skipped in lockfile-free mode).
+	if m.Lockfile != nil && *m.Lockfile != "" {
+		if err := mvscheck.CheckLockfile(m.ModuleRoot, *m.Lockfile); err != nil {
+			return fmt.Errorf("lockfile check: %w", err)
+		}
 	}
 
 	// Step 2: Extract module path from go.mod.
@@ -82,22 +84,24 @@ func linkBinary(manifestPath, output string) error {
 		return fmt.Errorf("getting Go version: %w", err)
 	}
 
-	lock, err := lockfile.Read(m.Lockfile)
-	if err != nil {
-		return fmt.Errorf("reading lockfile: %w", err)
-	}
-
 	var deps []buildinfo.ModDep
-	for modKey := range lock.Mod {
-		modPath, version, ok := strings.Cut(modKey, "@")
-		if !ok {
-			continue
+	if m.Lockfile != nil && *m.Lockfile != "" {
+		lock, err := lockfile.Read(*m.Lockfile)
+		if err != nil {
+			return fmt.Errorf("reading lockfile: %w", err)
 		}
-		dep := buildinfo.ModDep{Path: modPath, Version: version}
-		if replacePath, ok := lock.Replace[modKey]; ok {
-			dep.Replace = &buildinfo.ModDep{Path: replacePath, Version: version}
+
+		for modKey := range lock.Mod {
+			modPath, version, ok := strings.Cut(modKey, "@")
+			if !ok {
+				continue
+			}
+			dep := buildinfo.ModDep{Path: modPath, Version: version}
+			if replacePath, ok := lock.Replace[modKey]; ok {
+				dep.Replace = &buildinfo.ModDep{Path: replacePath, Version: version}
+			}
+			deps = append(deps, dep)
 		}
-		deps = append(deps, dep)
 	}
 
 	modinfo, err := buildinfo.GenerateModinfo(m.ModuleRoot, goVersion, deps)

--- a/go/go2nix/pkg/compile/manifest.go
+++ b/go/go2nix/pkg/compile/manifest.go
@@ -58,7 +58,7 @@ type LinkManifest struct {
 	LocalArchives  map[string]string `json:"localArchives"`
 	SubPackages    []string          `json:"subPackages"`
 	ModuleRoot     string            `json:"moduleRoot"`
-	Lockfile       string            `json:"lockfile"`
+	Lockfile       *string           `json:"lockfile"`
 	Pname          string            `json:"pname"`
 	GOOS           *string           `json:"goos"`
 	GOARCH         *string           `json:"goarch"`

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -1,16 +1,24 @@
-# go2nix/nix/dag/default.nix — build a Go binary from source + lockfile (default mode).
+# go2nix/nix/dag/default.nix — build a Go binary from source (default mode).
+#
+# Supports two modes for module hash resolution:
+#   1. Lockfile: pass goLock = ./go2nix.toml (hashes from checked-in file)
+#   2. Lockfile-free: omit goLock (hashes resolved at eval time from
+#      go.sum + GOMODCACHE via the nix plugin, cached on disk by h1: hash)
 #
 # Usage:
+#   # With lockfile:
 #   goEnv.buildGoApplication {
 #     src = ./.;
 #     goLock = ./go2nix.toml;
 #     pname = "my-app";
 #     version = "0.1.0";
-#     packageOverrides = {
-#       "github.com/foo/bar" = {
-#         nativeBuildInputs = [ pkg-config libfoo ];
-#       };
-#     };
+#   }
+#
+#   # Without lockfile (hashes from go.sum + GOMODCACHE):
+#   goEnv.buildGoApplication {
+#     src = ./.;
+#     pname = "my-app";
+#     version = "0.1.0";
 #   }
 {
   stdenv,
@@ -27,7 +35,7 @@
 
 {
   src,
-  goLock,
+  goLock ? null,
   pname,
   version,
   subPackages ? [ "." ],
@@ -79,9 +87,20 @@ let
     then "pie"
     else "exe";
 
-  # --- Module resolution from lockfile (pure-Nix TOML parsing) ---
-  lockfile = builtins.fromTOML (builtins.readFile goLock);
-  modTable = lockfile.mod or { };
+  # --- Module resolution ---
+  #
+  # Two paths:
+  #   1. Lockfile provided (goLock != null): read hashes from go2nix.toml
+  #   2. Lockfile-free (goLock == null): plugin resolves NAR hashes from
+  #      go.sum + GOMODCACHE at eval time (resolveHashes = true)
+
+  hasLockfile = goLock != null;
+
+  lockfileModTable =
+    if hasLockfile then
+      (builtins.fromTOML (builtins.readFile goLock)).mod or { }
+    else
+      { };
 
   parseModEntry =
     modKey: hash:
@@ -89,7 +108,7 @@ let
       parsed = builtins.match "(.+)@(.+)" modKey;
     in
     if parsed == null then
-      builtins.throw "go2nix lockfile: malformed module key '${modKey}' (expected 'path@version')"
+      builtins.throw "go2nix: malformed module key '${modKey}' (expected 'path@version')"
     else
       let
         path = builtins.elemAt parsed 0;
@@ -98,14 +117,15 @@ let
       {
         inherit hash path version;
         fetchPath = path;
-        dirSuffix = "${helpers.escapeModPath path}@${version}";
       };
 
-  lockfileModules = builtins.mapAttrs parseModEntry modTable;
+  lockfileModules = builtins.mapAttrs parseModEntry lockfileModTable;
 
   # --- Package graph from plugin (eval-time go list) ---
   # goProxy defaults to "off": reads from the host's GOMODCACHE (populated
   # by `go mod download`). No network access or writes during eval.
+  # When resolveHashes is true, the plugin also computes NAR hashes for all
+  # modules from go.sum + GOMODCACHE, returned as moduleHashes.
   goPackagesResult = builtins.resolveGoPackages (
     {
       go = "${go}/bin/go";
@@ -116,9 +136,21 @@ let
         doCheck
         ;
       subPackages = normalizedSubPackages;
+      resolveHashes = !hasLockfile;
     }
     // (if goProxy != null then { inherit goProxy; } else { })
   );
+
+  # Module hashes from plugin (lockfile-free path).
+  pluginModules =
+    if hasLockfile then
+      { }
+    else
+      builtins.mapAttrs (modKey: hash: parseModEntry modKey hash)
+        (goPackagesResult.moduleHashes or { });
+
+  # Merge: lockfile modules take precedence, plugin modules fill in the rest.
+  allModules = pluginModules // lockfileModules;
 
   # --- Join: apply replace directives to module fetchPaths ---
   resolvedModules = builtins.mapAttrs (
@@ -133,15 +165,22 @@ let
       inherit fetchPath;
       dirSuffix = "${helpers.escapeModPath fetchPath}@${version}";
     }
-  ) lockfileModules;
+  ) allModules;
 
   # --- Third-party package set ---
+  # sourceOnly: lockfile-free hashes cover the extracted source tree only;
+  #             lockfile hashes cover the full GOMODCACHE output.
   moduleInfo = builtins.mapAttrs (
     _: mod:
     let
-      src = fetchers.fetchGoModule { inherit (mod) hash fetchPath version; };
+      src = fetchers.fetchGoModule {
+        inherit (mod) hash fetchPath version;
+        sourceOnly = !hasLockfile;
+      };
     in
-    mod // { dir = "${src}/${mod.dirSuffix}"; }
+    mod // {
+      dir = if hasLockfile then "${src}/${mod.dirSuffix}" else "${src}";
+    }
   ) resolvedModules;
 
   packages = builtins.mapAttrs (
@@ -466,7 +505,10 @@ let
     ) localPackages;
     subPackages = normalizedSubPackages;
     moduleRoot = moduleRoot;
-    lockfile = "${builtins.path { path = goLock; name = "go2nix-lockfile"; }}";
+    lockfile =
+      if goLock != null
+      then "${builtins.path { path = goLock; name = "go2nix-lockfile"; }}"
+      else null;
     pname = pname;
     goos = stdenv.hostPlatform.go.GOOS or null;
     goarch = stdenv.hostPlatform.go.GOARCH or null;

--- a/nix/dag/fetch-go-module.nix
+++ b/nix/dag/fetch-go-module.nix
@@ -1,12 +1,17 @@
 # go2nix/nix/dag/fetch-go-module.nix — fixed-output derivation to fetch a Go module.
 #
-# Downloads a module via the Go module proxy and produces the GOMODCACHE
-# directory structure as output.
+# Two output modes controlled by `sourceOnly`:
+#
+#   sourceOnly = true (lockfile-free):
+#     Outputs only the extracted source tree. Cache metadata (.info, .zip,
+#     .ziphash, sumdb/) is excluded so the NAR hash depends solely on module
+#     content — matching the h1: hash from go.sum.
+#
+#   sourceOnly = false (lockfile, default):
+#     Outputs the full GOMODCACHE directory (backward-compatible with existing
+#     lockfile hashes).
 #
 # For private modules, set netrcFile in mk-go-env.nix to provide credentials.
-# Go's default GOPROXY (https://proxy.golang.org,direct) falls back to direct
-# VCS access when the proxy returns 404, so netrcFile is sufficient for most
-# private module setups.
 {
   go,
   stdenvNoCC,
@@ -15,13 +20,18 @@
   netrcFile,
 }:
 let
-  inherit (helpers) sanitizeName;
+  inherit (helpers) sanitizeName escapeModPath;
 in
 {
   hash,
   fetchPath,
   version,
+  sourceOnly ? false,
 }:
+let
+  escapedPath = escapeModPath fetchPath;
+  dirSuffix = "${escapedPath}@${version}";
+in
 stdenvNoCC.mkDerivation {
   name = "gomod-${sanitizeName fetchPath}-${version}";
 
@@ -40,7 +50,6 @@ stdenvNoCC.mkDerivation {
 
   buildPhase = ''
     export HOME=$TMPDIR
-    export GOMODCACHE=$out
     export GOSUMDB=off
     export GONOSUMCHECK='*'
     ${
@@ -52,8 +61,14 @@ stdenvNoCC.mkDerivation {
       else
         ""
     }
+  '' + (if sourceOnly then ''
+    export GOMODCACHE=$TMPDIR/modcache
     go mod download "${fetchPath}@${version}"
-  '';
+    cp -r "$TMPDIR/modcache/${dirSuffix}" "$out"
+  '' else ''
+    export GOMODCACHE=$out
+    go mod download "${fetchPath}@${version}"
+  '');
 
   # Skip other phases.
   dontInstall = true;

--- a/packages/go2nix-nix-plugin/plugin/resolveGoPackages.cc
+++ b/packages/go2nix-nix-plugin/plugin/resolveGoPackages.cc
@@ -107,8 +107,12 @@ static RegisterPrimOp rp(PrimOp {
   - `cgoEnabled` (optional): CGO_ENABLED value
   - `doCheck` (optional): When true, runs a second `go list -deps -test`
     pass to discover test-only third-party dependencies (default: false)
+  - `resolveHashes` (optional): When true, resolves NAR hashes for all
+    modules from go.sum + GOMODCACHE, enabling lockfile-free builds.
+    Returns `moduleHashes` in the output (default: false)
 
-  Returns: { packages, localPackages, modulePath, replacements, testPackages, localReplaces }
+  Returns: { packages, localPackages, modulePath, replacements, testPackages,
+    localReplaces, moduleHashes (when resolveHashes=true) }
 )",
 #ifdef NIX_PRIMOP_HAS_IMPL
     .impl = prim_resolveGoPackages,

--- a/packages/go2nix-nix-plugin/rust/Cargo.lock
+++ b/packages/go2nix-nix-plugin/rust/Cargo.lock
@@ -9,12 +9,161 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "go2nix-nix-plugin"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "serde",
  "serde_json",
+ "sha2",
+ "tempfile",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -24,10 +173,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -46,6 +235,31 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -91,6 +305,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,10 +327,196 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zmij"

--- a/packages/go2nix-nix-plugin/rust/Cargo.toml
+++ b/packages/go2nix-nix-plugin/rust/Cargo.toml
@@ -13,3 +13,6 @@ crate-type = ["staticlib"]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"
+sha2 = "0.10"
+base64 = "0.22"
+tempfile = "3"

--- a/packages/go2nix-nix-plugin/rust/src/lib.rs
+++ b/packages/go2nix-nix-plugin/rust/src/lib.rs
@@ -4,10 +4,16 @@
 //! third-party package graph, local packages, module replacements, and
 //! (optionally) test-only dependencies as JSON.
 //!
+//! Also resolves NAR hashes for Go modules from go.sum + GOMODCACHE,
+//! eliminating the need for a checked-in lockfile.
+//!
 //! Pure Rust with no nix dependencies — the nix integration layer
 //! (`plugin/resolveGoPackages.cc`) handles primop registration and
 //! JSON ↔ nix value conversion via the nix C API.
 
+mod module_hashes;
+mod nar;
+mod nar_cache;
 mod resolve;
 
 use std::ffi::{CStr, CString};
@@ -39,7 +45,31 @@ pub unsafe extern "C" fn resolve_go_packages_json(
             serde_json::from_str(input).map_err(|e| format!("failed to parse input JSON: {e}"))?;
 
         let graph = resolve::resolve_packages(&opts).map_err(|e| format!("{e:#}"))?;
-        resolve::package_graph_to_json(&graph, &opts.src).map_err(|e| format!("{e:#}"))
+
+        // Resolve NAR hashes from go.sum + GOMODCACHE when requested.
+        let hashes = if opts.resolve_hashes {
+            let src_dir = std::path::Path::new(&opts.src);
+            let mod_root = &opts.mod_root;
+            let go_sum_path = if mod_root == "." {
+                src_dir.join("go.sum")
+            } else {
+                src_dir.join(mod_root).join("go.sum")
+            };
+
+            let gomodcache = resolve::find_gomodcache(&opts.go)
+                .map_err(|e| format!("finding GOMODCACHE: {e:#}"))?;
+
+            module_hashes::resolve_module_hashes(&go_sum_path, &gomodcache)
+                .map_err(|e| format!("resolving module hashes: {e:#}"))?
+                .into_iter()
+                .map(|(k, v)| (k, v.nar_hash))
+                .collect()
+        } else {
+            std::collections::BTreeMap::new()
+        };
+
+        resolve::package_graph_to_json(&graph, &opts.src, hashes)
+            .map_err(|e| format!("{e:#}"))
     }
 
     match inner(input_json) {

--- a/packages/go2nix-nix-plugin/rust/src/module_hashes.rs
+++ b/packages/go2nix-nix-plugin/rust/src/module_hashes.rs
@@ -1,0 +1,217 @@
+//! Resolve NAR hashes for Go modules from go.sum + GOMODCACHE.
+//!
+//! Flow:
+//! 1. Parse go.sum to get h1: hashes for each module@version
+//! 2. For each module, check the filesystem cache (h1: → NAR hash)
+//! 3. On cache miss, find the extracted source tree in GOMODCACHE,
+//!    compute its NAR hash, and cache the result
+//!
+//! The NAR hash covers only the extracted source tree (not .info, .zip, etc.),
+//! making it a pure function of the module content — which is what h1: captures.
+
+use crate::nar;
+use crate::nar_cache::NarCache;
+use anyhow::{Context, Result};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Parsed go.sum entry (only the directory hash, not the /go.mod hash).
+#[derive(Debug)]
+struct GoSumEntry {
+    path: String,
+    version: String,
+    h1: String,
+}
+
+/// Module hash info returned to the caller.
+#[derive(Debug, Clone)]
+pub struct ModuleHash {
+    pub nar_hash: String,
+}
+
+/// Parse go.sum and resolve NAR hashes for all modules.
+///
+/// `go_sum_path`: path to go.sum
+/// `gomodcache`: GOMODCACHE directory (contains extracted source trees)
+pub fn resolve_module_hashes(
+    go_sum_path: &Path,
+    gomodcache: &Path,
+) -> Result<BTreeMap<String, ModuleHash>> {
+    let entries = parse_go_sum(go_sum_path)?;
+    let cache = NarCache::open().context("opening NAR hash cache")?;
+
+    let mut result = BTreeMap::new();
+
+    for entry in &entries {
+        let key = format!("{}@{}", entry.path, entry.version);
+
+        // Check cache first.
+        if let Some(cached) = cache.get(&entry.h1) {
+            result.insert(key, ModuleHash { nar_hash: cached });
+            continue;
+        }
+
+        // Compute NAR hash from extracted source tree in GOMODCACHE.
+        let source_dir = module_source_dir(gomodcache, &entry.path, &entry.version);
+        if !source_dir.exists() {
+            // Module not in local cache — skip. The lockfile won't have a
+            // hash, and the Nix builder will fail clearly when it can't find
+            // the FOD hash.
+            continue;
+        }
+
+        let nar_hash = nar::hash_path(&source_dir)
+            .with_context(|| format!("computing NAR hash of {}", source_dir.display()))?;
+
+        cache.put(&entry.h1, &nar_hash).ok(); // best-effort cache write
+        result.insert(key, ModuleHash { nar_hash });
+    }
+
+    Ok(result)
+}
+
+/// Parse go.sum into directory-hash entries (skip /go.mod lines).
+fn parse_go_sum(path: &Path) -> Result<Vec<GoSumEntry>> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("reading {}", path.display()))?;
+
+    let mut entries = Vec::new();
+
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        // Format: <module> <version>[/go.mod] <hash>
+        let parts: Vec<&str> = line.splitn(3, ' ').collect();
+        if parts.len() != 3 {
+            continue;
+        }
+
+        let (mod_path, version, hash) = (parts[0], parts[1], parts[2]);
+
+        // Skip /go.mod hash entries — we only need the directory hash.
+        if version.ends_with("/go.mod") {
+            continue;
+        }
+
+        if !hash.starts_with("h1:") {
+            continue;
+        }
+
+        entries.push(GoSumEntry {
+            path: mod_path.to_owned(),
+            version: version.to_owned(),
+            h1: hash.to_owned(),
+        });
+    }
+
+    Ok(entries)
+}
+
+/// Construct the path to a module's extracted source tree in GOMODCACHE.
+///
+/// GOMODCACHE layout: `<escaped-path>@<version>/`
+/// e.g. `$GOMODCACHE/github.com/foo/bar@v1.2.3/`
+///
+/// Go escapes uppercase letters in module paths: `A` → `!a`.
+fn module_source_dir(gomodcache: &Path, mod_path: &str, version: &str) -> PathBuf {
+    let escaped = escape_mod_path(mod_path);
+    gomodcache.join(format!("{escaped}@{version}"))
+}
+
+/// Go module path case-escaping: uppercase → `!` + lowercase.
+/// Matches golang.org/x/mod/module.EscapePath().
+fn escape_mod_path(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if c.is_ascii_uppercase() {
+            out.push('!');
+            out.push(c.to_ascii_lowercase());
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_go_sum_basic() {
+        let dir = tempfile::tempdir().unwrap();
+        let sum_path = dir.path().join("go.sum");
+        std::fs::write(
+            &sum_path,
+            "github.com/foo/bar v1.2.3 h1:abc123=\n\
+             github.com/foo/bar v1.2.3/go.mod h1:modmod=\n\
+             github.com/baz/qux v0.1.0 h1:xyz789=\n",
+        )
+        .unwrap();
+
+        let entries = parse_go_sum(&sum_path).unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].path, "github.com/foo/bar");
+        assert_eq!(entries[0].version, "v1.2.3");
+        assert_eq!(entries[0].h1, "h1:abc123=");
+        assert_eq!(entries[1].path, "github.com/baz/qux");
+    }
+
+    #[test]
+    fn parse_go_sum_skips_non_h1() {
+        let dir = tempfile::tempdir().unwrap();
+        let sum_path = dir.path().join("go.sum");
+        std::fs::write(&sum_path, "github.com/foo v1.0.0 h2:something=\n").unwrap();
+
+        let entries = parse_go_sum(&sum_path).unwrap();
+        assert_eq!(entries.len(), 0);
+    }
+
+    #[test]
+    fn escape_mod_path_basic() {
+        assert_eq!(escape_mod_path("github.com/BurntSushi/toml"), "github.com/!burnt!sushi/toml");
+        assert_eq!(escape_mod_path("github.com/foo/bar"), "github.com/foo/bar");
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+
+    /// End-to-end test: resolve hashes for the go2nix project's own modules.
+    #[test]
+    fn resolve_hashes_for_go2nix() {
+        let go_sum = Path::new("/root/src/go2nix/go/go2nix/go.sum");
+        if !go_sum.exists() {
+            eprintln!("skipping: go.sum not found");
+            return;
+        }
+
+        let gomodcache = Path::new("/root/go/pkg/mod");
+        if !gomodcache.exists() {
+            eprintln!("skipping: GOMODCACHE not found");
+            return;
+        }
+
+        let result = resolve_module_hashes(go_sum, gomodcache).unwrap();
+        eprintln!("resolved {} module hashes:", result.len());
+        for (key, hash) in &result {
+            eprintln!("  {key} → {}", hash.nar_hash);
+        }
+
+        // Should have at least some modules
+        assert!(!result.is_empty(), "expected at least one module hash");
+
+        // All hashes should be valid SRI format
+        for (key, hash) in &result {
+            assert!(
+                hash.nar_hash.starts_with("sha256-"),
+                "bad hash for {key}: {}",
+                hash.nar_hash
+            );
+        }
+    }
+}

--- a/packages/go2nix-nix-plugin/rust/src/nar.rs
+++ b/packages/go2nix-nix-plugin/rust/src/nar.rs
@@ -1,0 +1,189 @@
+//! NAR (Nix ARchive) serialization and hashing.
+//!
+//! Computes the SHA-256 NAR hash of a filesystem path, producing SRI-format
+//! output identical to `nix hash path`. The NAR format serializes a file
+//! system object deterministically — sorted directory entries, padding to
+//! 8-byte boundaries, symlink targets as strings.
+
+use anyhow::{Context, Result};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+
+/// Compute the SRI-format NAR hash of a filesystem path.
+///
+/// Returns e.g. `"sha256-EwPR3o6o8dUzsAeHki26rYm/s1uDuEcpV3ljmaHiNSg="`.
+pub fn hash_path(path: &Path) -> Result<String> {
+    let mut hasher = Sha256::new();
+    dump_path(&mut hasher, path).with_context(|| format!("NAR hashing {}", path.display()))?;
+    let digest = hasher.finalize();
+    Ok(format!("sha256-{}", BASE64.encode(digest)))
+}
+
+/// Write the NAR serialization of `path` to `w`.
+fn dump_path(w: &mut impl Write, path: &Path) -> Result<()> {
+    write_str(w, "nix-archive-1")?;
+    dump_entry(w, path)
+}
+
+fn dump_entry(w: &mut impl Write, path: &Path) -> Result<()> {
+    let meta = fs::symlink_metadata(path)
+        .with_context(|| format!("stat {}", path.display()))?;
+
+    write_str(w, "(")?;
+
+    if meta.file_type().is_symlink() {
+        write_str(w, "type")?;
+        write_str(w, "symlink")?;
+        write_str(w, "target")?;
+        let target = fs::read_link(path)
+            .with_context(|| format!("readlink {}", path.display()))?;
+        write_str(w, &target.to_string_lossy())?;
+    } else if meta.is_dir() {
+        write_str(w, "type")?;
+        write_str(w, "directory")?;
+
+        let mut entries: Vec<_> = fs::read_dir(path)
+            .with_context(|| format!("readdir {}", path.display()))?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .with_context(|| format!("reading dir entries of {}", path.display()))?;
+
+        // NAR requires sorted entries.
+        entries.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+
+        for entry in entries {
+            write_str(w, "entry")?;
+            write_str(w, "(")?;
+            write_str(w, "name")?;
+            write_str(w, &entry.file_name().to_string_lossy())?;
+            write_str(w, "node")?;
+            dump_entry(w, &entry.path())?;
+            write_str(w, ")")?;
+        }
+    } else if meta.is_file() {
+        write_str(w, "type")?;
+        write_str(w, "regular")?;
+        if meta.permissions().mode() & 0o111 != 0 {
+            write_str(w, "executable")?;
+            write_str(w, "")?;
+        }
+        write_str(w, "contents")?;
+        let contents = fs::read(path)
+            .with_context(|| format!("read {}", path.display()))?;
+        write_bytes(w, &contents)?;
+    } else {
+        anyhow::bail!("unsupported file type at {}", path.display());
+    }
+
+    write_str(w, ")")?;
+    Ok(())
+}
+
+/// Write a NAR string: 8-byte little-endian length, content, padding to 8-byte boundary.
+fn write_str(w: &mut impl Write, s: &str) -> Result<()> {
+    write_bytes(w, s.as_bytes())
+}
+
+/// Write NAR bytes: 8-byte little-endian length, content, zero-padding to 8-byte boundary.
+fn write_bytes(w: &mut impl Write, data: &[u8]) -> Result<()> {
+    let len = data.len() as u64;
+    w.write_all(&len.to_le_bytes())?;
+    w.write_all(data)?;
+    // Pad to 8-byte boundary.
+    let pad = (8 - (data.len() % 8)) % 8;
+    if pad > 0 {
+        w.write_all(&[0u8; 8][..pad])?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+
+    /// Helper: create a temp dir, run a closure, clean up.
+    fn with_tmpdir(f: impl FnOnce(&Path)) {
+        let dir = tempfile::tempdir().unwrap();
+        f(dir.path());
+    }
+
+    #[test]
+    fn hash_empty_file() {
+        with_tmpdir(|dir| {
+            let file = dir.join("empty");
+            fs::write(&file, b"").unwrap();
+            let hash = hash_path(&file).unwrap();
+            // Known hash of an empty regular file NAR.
+            assert!(hash.starts_with("sha256-"), "got: {hash}");
+        });
+    }
+
+    #[test]
+    fn hash_simple_file() {
+        with_tmpdir(|dir| {
+            let file = dir.join("hello");
+            fs::write(&file, b"hello\n").unwrap();
+            let hash = hash_path(&file).unwrap();
+            assert!(hash.starts_with("sha256-"), "got: {hash}");
+        });
+    }
+
+    #[test]
+    fn hash_directory_is_sorted() {
+        with_tmpdir(|dir| {
+            let sub = dir.join("mydir");
+            fs::create_dir(&sub).unwrap();
+            fs::write(sub.join("b.txt"), b"b").unwrap();
+            fs::write(sub.join("a.txt"), b"a").unwrap();
+            // Should produce the same hash regardless of creation order.
+            let hash1 = hash_path(&sub).unwrap();
+
+            let sub2 = dir.join("mydir2");
+            fs::create_dir(&sub2).unwrap();
+            fs::write(sub2.join("a.txt"), b"a").unwrap();
+            fs::write(sub2.join("b.txt"), b"b").unwrap();
+            let hash2 = hash_path(&sub2).unwrap();
+
+            assert_eq!(hash1, hash2);
+        });
+    }
+
+    #[test]
+    fn hash_symlink() {
+        with_tmpdir(|dir| {
+            let target = dir.join("target");
+            fs::write(&target, b"content").unwrap();
+            let link = dir.join("link");
+            symlink("target", &link).unwrap();
+            let hash = hash_path(&link).unwrap();
+            assert!(hash.starts_with("sha256-"), "got: {hash}");
+        });
+    }
+
+    /// Compare our NAR hash against `nix hash path` for a real Go module.
+    #[test]
+    fn hash_matches_nix() {
+        let test_dir = "/root/go/pkg/mod/github.com/andybalholm/brotli@v1.2.0";
+        if !Path::new(test_dir).exists() {
+            eprintln!("skipping: {test_dir} not found");
+            return;
+        }
+
+        let our_hash = hash_path(Path::new(test_dir)).unwrap();
+
+        let output = std::process::Command::new("nix")
+            .args(["hash", "path", test_dir])
+            .output()
+            .expect("nix hash path failed");
+        assert!(output.status.success(), "nix hash path failed");
+        let nix_hash = String::from_utf8(output.stdout).unwrap().trim().to_owned();
+
+        assert_eq!(our_hash, nix_hash, "NAR hash mismatch: ours={our_hash} nix={nix_hash}");
+    }
+}

--- a/packages/go2nix-nix-plugin/rust/src/nar_cache.rs
+++ b/packages/go2nix-nix-plugin/rust/src/nar_cache.rs
@@ -1,0 +1,94 @@
+//! Filesystem-backed cache for h1: → NAR hash mappings.
+//!
+//! Cache layout:
+//!   $XDG_CACHE_HOME/go2nix/nar/<url-encoded-h1-hash>
+//!
+//! Each file contains the SRI NAR hash (e.g. "sha256-abc..."). Writes use
+//! atomic rename so concurrent processes never read partial data. Duplicate
+//! computation is harmless — same input always produces the same output.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+/// Persistent cache from h1: hashes to NAR hashes.
+pub struct NarCache {
+    dir: PathBuf,
+}
+
+impl NarCache {
+    /// Open (or create) the cache directory.
+    pub fn open() -> Result<Self> {
+        let cache_home = std::env::var("XDG_CACHE_HOME")
+            .or_else(|_| std::env::var("HOME").map(|h| format!("{h}/.cache")))
+            .unwrap_or_else(|_| "/tmp".to_owned());
+        let dir = PathBuf::from(cache_home).join("go2nix/nar");
+        fs::create_dir_all(&dir)
+            .with_context(|| format!("creating cache dir {}", dir.display()))?;
+        Ok(Self { dir })
+    }
+
+    /// Look up a cached NAR hash by h1: key.
+    pub fn get(&self, h1: &str) -> Option<String> {
+        let path = self.key_path(h1);
+        fs::read_to_string(&path).ok().map(|s| s.trim().to_owned())
+    }
+
+    /// Store a NAR hash for an h1: key. Uses atomic write-then-rename.
+    pub fn put(&self, h1: &str, nar_hash: &str) -> Result<()> {
+        let path = self.key_path(h1);
+
+        // Write to a temp file in the same directory, then rename.
+        // This is atomic on POSIX and safe under concurrent writers.
+        let mut tmp = tempfile::NamedTempFile::new_in(&self.dir)
+            .context("creating temp file for nar cache")?;
+        tmp.write_all(nar_hash.as_bytes())
+            .context("writing nar hash to temp file")?;
+        tmp.persist(&path)
+            .with_context(|| format!("persisting cache entry {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Map an h1: hash to a filename. URL-encode the characters that aren't
+    /// safe in filenames (`:`, `/`, `+`, `=`).
+    fn key_path(&self, h1: &str) -> PathBuf {
+        let encoded = h1
+            .replace('%', "%25")
+            .replace(':', "%3A")
+            .replace('/', "%2F")
+            .replace('+', "%2B")
+            .replace('=', "%3D");
+        self.dir.join(encoded)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("XDG_CACHE_HOME", dir.path());
+        let cache = NarCache::open().unwrap();
+
+        let h1 = "h1:abc123+/=";
+        assert!(cache.get(h1).is_none());
+
+        cache.put(h1, "sha256-xyz789").unwrap();
+        assert_eq!(cache.get(h1).unwrap(), "sha256-xyz789");
+    }
+
+    #[test]
+    fn idempotent_put() {
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("XDG_CACHE_HOME", dir.path());
+        let cache = NarCache::open().unwrap();
+
+        let h1 = "h1:test";
+        cache.put(h1, "sha256-aaa").unwrap();
+        cache.put(h1, "sha256-aaa").unwrap();
+        assert_eq!(cache.get(h1).unwrap(), "sha256-aaa");
+    }
+}

--- a/packages/go2nix-nix-plugin/rust/src/resolve.rs
+++ b/packages/go2nix-nix-plugin/rust/src/resolve.rs
@@ -511,7 +511,7 @@ pub(crate) fn parse_go_packages(stdout: &[u8]) -> Result<PackageGraph> {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct JsonInput {
-    go: String,
+    pub(crate) go: String,
     pub(crate) src: String,
     #[serde(default)]
     do_check: bool,
@@ -520,7 +520,7 @@ pub(crate) struct JsonInput {
     #[serde(default = "default_sub_packages")]
     sub_packages: Vec<String>,
     #[serde(default = "default_dot")]
-    mod_root: String,
+    pub(crate) mod_root: String,
     #[serde(default)]
     goos: String,
     #[serde(default)]
@@ -529,6 +529,10 @@ pub(crate) struct JsonInput {
     go_proxy: String,
     #[serde(default)]
     cgo_enabled: String,
+    /// When true, resolve NAR hashes for all modules from go.sum + GOMODCACHE.
+    /// Enables lockfile-free builds.
+    #[serde(default)]
+    pub(crate) resolve_hashes: bool,
 }
 
 fn default_sub_packages() -> Vec<String> {
@@ -539,6 +543,39 @@ fn default_dot() -> String {
 }
 fn default_off() -> String {
     "off".to_owned()
+}
+
+/// Query `go env GOMODCACHE` to find the module cache directory.
+pub(crate) fn find_gomodcache(go_bin: &str) -> Result<std::path::PathBuf> {
+    // Check environment first (same var Go checks).
+    if let Ok(val) = std::env::var("GOMODCACHE") {
+        if !val.is_empty() {
+            return Ok(std::path::PathBuf::from(val));
+        }
+    }
+
+    let output = std::process::Command::new(go_bin)
+        .args(["env", "GOMODCACHE"])
+        .output()
+        .with_context(|| format!("running '{go_bin} env GOMODCACHE'"))?;
+
+    if !output.status.success() {
+        bail!(
+            "'go env GOMODCACHE' failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let path = String::from_utf8(output.stdout)
+        .context("GOMODCACHE is not valid UTF-8")?
+        .trim()
+        .to_owned();
+
+    if path.is_empty() {
+        bail!("GOMODCACHE is empty");
+    }
+
+    Ok(std::path::PathBuf::from(path))
 }
 
 /// Run both go list passes and return the complete package graph.
@@ -610,6 +647,10 @@ struct JsonOutput {
     replacements: BTreeMap<String, JsonReplacement>,
     local_replaces: BTreeMap<String, String>,
     test_packages: BTreeMap<String, JsonPkg>,
+    /// NAR hashes for modules, keyed by "path@version".
+    /// Only populated when resolveHashes is true.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    module_hashes: BTreeMap<String, String>,
 }
 
 #[derive(Serialize)]
@@ -671,7 +712,11 @@ fn pkg_data_to_json_pkg(p: &PkgData, allowed_imports: &dyn Fn(&str) -> bool) -> 
 }
 
 /// Convert a `PackageGraph` to a JSON string.
-pub(crate) fn package_graph_to_json(graph: &PackageGraph, src_dir: &str) -> Result<String> {
+pub(crate) fn package_graph_to_json(
+    graph: &PackageGraph,
+    src_dir: &str,
+    module_hashes: BTreeMap<String, String>,
+) -> Result<String> {
     let canon_src = std::fs::canonicalize(src_dir)
         .with_context(|| format!("failed to canonicalize src dir: {src_dir}"))?;
 
@@ -750,6 +795,7 @@ pub(crate) fn package_graph_to_json(graph: &PackageGraph, src_dir: &str) -> Resu
         replacements,
         local_replaces: graph.local_replaces.clone(),
         test_packages,
+        module_hashes,
     };
 
     serde_json::to_string(&output).context("failed to serialize output JSON")

--- a/packages/go2nix-nix-plugin/tests/eval-test.nix
+++ b/packages/go2nix-nix-plugin/tests/eval-test.nix
@@ -5,24 +5,7 @@
 }:
 
 let
-  # Pre-fetch Go modules as a zstd-compressed tarball (single file → fast nix copy).
-  goModCacheArchive = pkgs.stdenvNoCC.mkDerivation {
-    name = "torture-project-gomodcache.tar.zst";
-    src = testFixtures + "/torture-project";
-    nativeBuildInputs = [ pkgs.go pkgs.cacert pkgs.zstd ];
-    outputHashMode = "flat";
-    outputHashAlgo = "sha256";
-    outputHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
-    phases = [ "buildPhase" ];
-    buildPhase = ''
-      export HOME=$TMPDIR
-      export GOPATH=$TMPDIR/go
-      export GOMODCACHE=$TMPDIR/gomodcache
-      cd $src
-      go mod download
-      tar -cf - -C $TMPDIR gomodcache | zstd -19 -o $out
-    '';
-  };
+  goModules = import ./torture-project-gomodcache.nix { inherit pkgs testFixtures; };
 in
 pkgs.runCommand "go2nix-nix-plugin-eval-test"
   {
@@ -30,7 +13,6 @@ pkgs.runCommand "go2nix-nix-plugin-eval-test"
       pkgs.nixVersions.nix_2_34
       pkgs.go
       pkgs.jq
-      pkgs.zstd
     ];
   }
   ''
@@ -40,11 +22,16 @@ pkgs.runCommand "go2nix-nix-plugin-eval-test"
     export NIX_LOG_DIR=$TMPDIR/nix/log
     mkdir -p $NIX_STORE_DIR $NIX_STATE_DIR $NIX_LOG_DIR
 
+    # Populate a writable GOMODCACHE from the download cache FOD.
     export GOMODCACHE=$TMPDIR/gomodcache
-    tar -xf ${goModCacheArchive} -C $TMPDIR --zstd
-
+    export GOPROXY="file://${goModules}"
+    export GONOSUMCHECK='*'
+    export GONOSUMDB='*'
     cp -r ${testFixtures}/torture-project $TMPDIR/torture-project
     chmod -R u+w $TMPDIR/torture-project
+    cd $TMPDIR/torture-project
+    go mod download
+    cd /
 
     result=$(nix-instantiate --eval --strict --json --read-write-mode \
       --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \

--- a/packages/go2nix-nix-plugin/tests/resolve-hashes-test.nix
+++ b/packages/go2nix-nix-plugin/tests/resolve-hashes-test.nix
@@ -1,0 +1,143 @@
+# Test: resolveHashes mode returns NAR hashes from go.sum + GOMODCACHE,
+# enabling lockfile-free builds.
+#
+# Verifies:
+# 1. moduleHashes is populated when resolveHashes = true
+# 2. Every hash is valid SRI format (sha256-...)
+# 3. Hashes match `nix hash path` on the extracted source trees
+# 4. moduleHashes is empty when resolveHashes = false (default)
+{
+  pkgs,
+  plugin,
+  testFixtures,
+}:
+
+let
+  goModules = import ./torture-project-gomodcache.nix { inherit pkgs testFixtures; };
+in
+pkgs.runCommand "go2nix-nix-plugin-resolve-hashes-test"
+  {
+    nativeBuildInputs = [
+      pkgs.nixVersions.nix_2_34
+      pkgs.go
+      pkgs.jq
+    ];
+  }
+  ''
+    export HOME=$(mktemp -d)
+    export NIX_STORE_DIR=$TMPDIR/nix/store
+    export NIX_STATE_DIR=$TMPDIR/nix/var
+    export NIX_LOG_DIR=$TMPDIR/nix/log
+    mkdir -p $NIX_STORE_DIR $NIX_STATE_DIR $NIX_LOG_DIR
+
+    # Populate a writable GOMODCACHE from the download cache FOD.
+    export GOMODCACHE=$TMPDIR/gomodcache
+    export GOPROXY="file://${goModules}"
+    export GONOSUMCHECK='*'
+    export GONOSUMDB='*'
+    cp -r ${testFixtures}/torture-project $TMPDIR/torture-project
+    chmod -R u+w $TMPDIR/torture-project
+    cd $TMPDIR/torture-project
+    go mod download
+    cd /
+
+    echo "=== Test 1: resolveHashes = true returns moduleHashes ==="
+    result=$(nix-instantiate --eval --strict --json --read-write-mode \
+      --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
+      --expr "
+        let
+          r = builtins.resolveGoPackages {
+            go = \"${pkgs.go}/bin/go\";
+            src = (toString $TMPDIR/torture-project);
+            resolveHashes = true;
+          };
+          hashCount = builtins.length (builtins.attrNames r.moduleHashes);
+          # Sample a few hashes for validation.
+          sampleKeys = builtins.genList (i:
+            builtins.elemAt (builtins.attrNames r.moduleHashes) i
+          ) (if hashCount > 3 then 3 else hashCount);
+          sampleHashes = map (k: {
+            key = k;
+            hash = r.moduleHashes.\''${k};
+          }) sampleKeys;
+        in {
+          inherit hashCount sampleHashes;
+          hasModuleHashes = builtins.isAttrs r.moduleHashes;
+          # Verify packages are still returned alongside hashes.
+          pkgCount = builtins.length (builtins.attrNames r.packages);
+        }
+      ")
+
+    echo "$result" | jq .
+
+    hashCount=$(echo "$result" | jq -r .hashCount)
+    [ "$hashCount" -ge 10 ] || { echo "FAIL: expected >= 10 module hashes, got $hashCount"; exit 1; }
+    echo "  moduleHashes count: $hashCount"
+
+    hasModuleHashes=$(echo "$result" | jq -r .hasModuleHashes)
+    [ "$hasModuleHashes" = "true" ] || { echo "FAIL: moduleHashes is not an attrset"; exit 1; }
+
+    pkgCount=$(echo "$result" | jq -r .pkgCount)
+    [ "$pkgCount" -ge 10 ] || { echo "FAIL: expected >= 10 packages alongside hashes, got $pkgCount"; exit 1; }
+
+    # Validate all sample hashes are SRI format.
+    for row in $(echo "$result" | jq -c '.sampleHashes[]'); do
+      key=$(echo "$row" | jq -r .key)
+      hash=$(echo "$row" | jq -r .hash)
+      case "$hash" in
+        sha256-*) echo "  OK: $key → $hash" ;;
+        *) echo "FAIL: bad hash format for $key: $hash"; exit 1 ;;
+      esac
+    done
+
+    echo "=== Test 2: verify hashes match nix hash path ==="
+    export NIX_CONFIG="extra-experimental-features = nix-command"
+    # Pick a module and compare our hash against nix hash path on the source tree.
+    for row in $(echo "$result" | jq -c '.sampleHashes[]'); do
+      key=$(echo "$row" | jq -r .key)
+      expected=$(echo "$row" | jq -r .hash)
+
+      # Parse path@version from key.
+      mod_path=''${key%%@*}
+      version=''${key##*@}
+
+      # Go module case-escaping: uppercase → !lowercase.
+      escaped_path=$(echo "$mod_path" | sed 's/\([A-Z]\)/!\L\1/g')
+      source_dir="$GOMODCACHE/$escaped_path@$version"
+
+      if [ ! -d "$source_dir" ]; then
+        echo "  SKIP: $source_dir not found (module may not be extracted)"
+        continue
+      fi
+
+      actual=$(nix hash path "$source_dir")
+      if [ "$expected" = "$actual" ]; then
+        echo "  MATCH: $key → $actual"
+      else
+        echo "FAIL: hash mismatch for $key"
+        echo "  expected (plugin): $expected"
+        echo "  actual (nix hash): $actual"
+        exit 1
+      fi
+    done
+
+    echo "=== Test 3: resolveHashes = false (default) omits moduleHashes ==="
+    result_no_hashes=$(nix-instantiate --eval --strict --json --read-write-mode \
+      --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
+      --expr "
+        let
+          r = builtins.resolveGoPackages {
+            go = \"${pkgs.go}/bin/go\";
+            src = (toString $TMPDIR/torture-project);
+          };
+        in {
+          hasModuleHashes = builtins.hasAttr \"moduleHashes\" r;
+        }
+      ")
+
+    hasHashes=$(echo "$result_no_hashes" | jq -r .hasModuleHashes)
+    [ "$hasHashes" = "false" ] || { echo "FAIL: moduleHashes should not be present when resolveHashes is false, got $hasHashes"; exit 1; }
+    echo "  OK: moduleHashes absent when resolveHashes = false"
+
+    echo "PASS: all resolve-hashes tests passed ($hashCount modules)" > $out
+  ''

--- a/packages/go2nix-nix-plugin/tests/torture-project-gomodcache.nix
+++ b/packages/go2nix-nix-plugin/tests/torture-project-gomodcache.nix
@@ -1,0 +1,16 @@
+# Shared: pre-fetch torture-project Go module download cache.
+# Reuses nixpkgs buildGoModule's goModules FOD (proxyVendor mode) which
+# handles non-deterministic metadata normalization.
+#
+# The output is the download cache (zips + mod files), not full GOMODCACHE.
+# Tests that need extracted source trees should set GOPROXY=file://${this}
+# and run `go mod download` into a writable GOMODCACHE.
+{ pkgs, testFixtures }:
+
+(pkgs.buildGoModule {
+  pname = "torture-project-modules";
+  version = "0-unstable";
+  src = testFixtures + "/torture-project";
+  vendorHash = "sha256-DJGjAcVVOQT2L8hINdZgOaJ68RsGKsgZD9UJQdOCqDc=";
+  proxyVendor = true;
+}).goModules

--- a/packages/test-lib/run-dag-test.nix
+++ b/packages/test-lib/run-dag-test.nix
@@ -1,0 +1,66 @@
+# Shared test runner for go2nix dag-mode build tests.
+#
+# Populates GOMODCACHE from a proxyVendor download cache, runs nix-build
+# on the specified dag nix file, and runs a check command on the result.
+{
+  flake,
+  pkgs,
+  system,
+  # Test identity
+  testName,
+  # Source to build
+  src,
+  vendorHash,
+  # Which dag.nix to evaluate
+  dagFile,
+  # Shell command to verify the build output; $result is the store path.
+  checkCommand ? ''$result/bin/${testName} --help'',
+}:
+if !(flake.packages.${system} ? go2nix-nix-plugin) then
+  pkgs.runCommand "test-dag-package-${testName}-unsupported"
+    { meta.platforms = pkgs.lib.platforms.linux; }
+    ''
+      echo "test-dag-package-${testName} requires go2nix-nix-plugin (Linux only)" >&2
+      exit 1
+    ''
+else
+  let
+    plugin = flake.packages.${system}.go2nix-nix-plugin;
+    nix = pkgs.nixVersions.nix_2_34;
+    inherit (pkgs) go;
+
+    nixpkgsPath = pkgs.path;
+    go2nixSrc = flake;
+
+    goModules = (pkgs.buildGoModule {
+      pname = "${testName}-modules";
+      version = "0-test";
+      inherit src vendorHash;
+      proxyVendor = true;
+    }).goModules;
+  in
+  pkgs.runCommand "test-dag-package-${testName}"
+    {
+      nativeBuildInputs = [ nix go ];
+      requiredSystemFeatures = [ "recursive-nix" ];
+    }
+    ''
+      export HOME=$(mktemp -d)
+      export NIX_CONFIG="extra-experimental-features = nix-command recursive-nix"
+
+      export GOMODCACHE=$TMPDIR/gomodcache
+      export GOPROXY="file://${goModules}"
+      export GONOSUMCHECK='*'
+      export GONOSUMDB='*'
+      cd ${src}
+      go mod download
+
+      echo "=== Building ${testName} ==="
+      result=$(nix-build ${dagFile} \
+        -I nixpkgs=${nixpkgsPath} \
+        --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
+        --no-out-link)
+
+      ${checkCommand}
+      echo "PASS: ${testName}" > $out
+    ''

--- a/packages/test-package-dotool/default.nix
+++ b/packages/test-package-dotool/default.nix
@@ -1,71 +1,14 @@
-# default mode build test: dotool (cgo package with xkbcommon via pkg-config).
-#
-# Spawns nix-build with --option plugin-files so the go2nix-nix-plugin is
-# available during evaluation. Requires recursive-nix.
-#
-# Linux-only: the Nix plugin is platform-specific.
-{
-  flake,
-  pkgs,
-  system,
-  ...
-}:
-if !(flake.packages.${system} ? go2nix-nix-plugin) then
-  pkgs.runCommand "test-dag-package-dotool-unsupported" { meta.platforms = pkgs.lib.platforms.linux; }
-    ''
-      echo "test-dag-package-dotool requires go2nix-nix-plugin (Linux only)" >&2
-      exit 1
-    ''
-else
-  let
-    plugin = flake.packages.${system}.go2nix-nix-plugin;
-    nix = pkgs.nixVersions.nix_2_34;
-    inherit (pkgs) go;
-
-    nixpkgsPath = pkgs.path;
-    go2nixSrc = flake;
-
-    src = pkgs.fetchgit {
-      url = "https://git.sr.ht/~geb/dotool";
-      rev = "180af21c46dcc848d93dbec2644c011f4eea1592";
-      hash = "sha256-KI3vA45/MvFRV8Fr3Q4yd/argDy1PpFHCT3KA9VDP80=";
-    };
-
-    goModules = pkgs.stdenvNoCC.mkDerivation {
-      name = "dotool-gomodcache";
-      outputHashMode = "recursive";
-      outputHashAlgo = "sha256";
-      outputHash = "sha256-M5FjxDF/cC4OjSUy/k3a5DK6K21Mv4w/NBYbxCovpps=";
-      nativeBuildInputs = [
-        go
-        pkgs.cacert
-      ];
-      dontUnpack = true;
-      buildPhase = ''
-        export HOME=$TMPDIR
-        export GOMODCACHE=$out
-        cd ${src}
-        go mod download
-      '';
-      installPhase = "true";
-    };
-  in
-  pkgs.runCommand "test-dag-package-dotool"
-    {
-      nativeBuildInputs = [ nix ];
-      requiredSystemFeatures = [ "recursive-nix" ];
-    }
-    ''
-      export HOME=$(mktemp -d)
-      export NIX_CONFIG="extra-experimental-features = nix-command recursive-nix"
-
-      echo "=== Building dotool (default mode) ==="
-      result=$(GOMODCACHE=${goModules} \
-        nix-build ${go2nixSrc}/tests/packages/dotool/dag.nix \
-        -I nixpkgs=${nixpkgsPath} \
-        --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
-        --no-out-link)
-
-      $result/bin/dotool --version
-      echo "PASS: dotool" > $out
-    ''
+# Build test: dotool (cgo with xkbcommon via pkg-config).
+{ flake, pkgs, system, ... }:
+import ../test-lib/run-dag-test.nix {
+  inherit flake pkgs system;
+  testName = "dotool";
+  src = pkgs.fetchgit {
+    url = "https://git.sr.ht/~geb/dotool";
+    rev = "180af21c46dcc848d93dbec2644c011f4eea1592";
+    hash = "sha256-KI3vA45/MvFRV8Fr3Q4yd/argDy1PpFHCT3KA9VDP80=";
+  };
+  vendorHash = "sha256-cdW4DhPUubSvJ9edTYgum3ppEkEPuoYFrU+gonyCpOk=";
+  dagFile = "${flake}/tests/packages/dotool/dag.nix";
+  checkCommand = "$result/bin/dotool --version";
+}

--- a/packages/test-package-nwg-drawer/default.nix
+++ b/packages/test-package-nwg-drawer/default.nix
@@ -1,73 +1,14 @@
-# default mode build test: nwg-drawer (cgo with GTK3/GTK Layer Shell).
-#
-# Spawns nix-build with --option plugin-files so the go2nix-nix-plugin is
-# available during evaluation. Requires recursive-nix.
-#
-# Linux-only: the Nix plugin is platform-specific.
-{
-  flake,
-  pkgs,
-  system,
-  ...
-}:
-if !(flake.packages.${system} ? go2nix-nix-plugin) then
-  pkgs.runCommand "test-dag-package-nwg-drawer-unsupported"
-    { meta.platforms = pkgs.lib.platforms.linux; }
-    ''
-      echo "test-dag-package-nwg-drawer requires go2nix-nix-plugin (Linux only)" >&2
-      exit 1
-    ''
-else
-  let
-    plugin = flake.packages.${system}.go2nix-nix-plugin;
-    nix = pkgs.nixVersions.nix_2_34;
-    inherit (pkgs) go;
-
-    nixpkgsPath = pkgs.path;
-    go2nixSrc = flake;
-
-    src = pkgs.fetchFromGitHub {
-      owner = "nwg-piotr";
-      repo = "nwg-drawer";
-      rev = "v0.7.4";
-      hash = "sha256-yKRh2kAWg8GJjEJ/yCJ88JoJSgYR3c3RafeYU3z3pNU=";
-    };
-
-    goModules = pkgs.stdenvNoCC.mkDerivation {
-      name = "nwg-drawer-gomodcache";
-      outputHashMode = "recursive";
-      outputHashAlgo = "sha256";
-      outputHash = "sha256-IMb8G/HdP6P1IKf+rZVWi6RGPGyJKmb64umwAZ5bUbA=";
-      nativeBuildInputs = [
-        go
-        pkgs.cacert
-      ];
-      dontUnpack = true;
-      buildPhase = ''
-        export HOME=$TMPDIR
-        export GOMODCACHE=$out
-        cd ${src}
-        go mod download
-      '';
-      installPhase = "true";
-    };
-  in
-  pkgs.runCommand "test-dag-package-nwg-drawer"
-    {
-      nativeBuildInputs = [ nix ];
-      requiredSystemFeatures = [ "recursive-nix" ];
-    }
-    ''
-      export HOME=$(mktemp -d)
-      export NIX_CONFIG="extra-experimental-features = nix-command recursive-nix"
-
-      echo "=== Building nwg-drawer (default mode) ==="
-      result=$(GOMODCACHE=${goModules} \
-        nix-build ${go2nixSrc}/tests/packages/nwg-drawer/dag.nix \
-        -I nixpkgs=${nixpkgsPath} \
-        --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
-        --no-out-link)
-
-      $result/bin/nwg-drawer --help
-      echo "PASS: nwg-drawer" > $out
-    ''
+# Build test: nwg-drawer (cgo with GTK3/GTK Layer Shell).
+{ flake, pkgs, system, ... }:
+import ../test-lib/run-dag-test.nix {
+  inherit flake pkgs system;
+  testName = "nwg-drawer";
+  src = pkgs.fetchFromGitHub {
+    owner = "nwg-piotr";
+    repo = "nwg-drawer";
+    rev = "v0.7.4";
+    hash = "sha256-yKRh2kAWg8GJjEJ/yCJ88JoJSgYR3c3RafeYU3z3pNU=";
+  };
+  vendorHash = "sha256-eIKDMUr4kAav+D2Lmb8Bh6bZUvat9TgHLNVewi3JBYo=";
+  dagFile = "${flake}/tests/packages/nwg-drawer/dag.nix";
+}

--- a/packages/test-package-vinegar/default.nix
+++ b/packages/test-package-vinegar/default.nix
@@ -1,73 +1,15 @@
-# default mode build test: vinegar (puregotk, no CGO for GTK libs).
-#
-# Spawns nix-build with --option plugin-files so the go2nix-nix-plugin is
-# available during evaluation. Requires recursive-nix.
-#
-# Linux-only: the Nix plugin is platform-specific.
-{
-  flake,
-  pkgs,
-  system,
-  ...
-}:
-if !(flake.packages.${system} ? go2nix-nix-plugin) then
-  pkgs.runCommand "test-dag-package-vinegar-unsupported"
-    { meta.platforms = pkgs.lib.platforms.linux; }
-    ''
-      echo "test-dag-package-vinegar requires go2nix-nix-plugin (Linux only)" >&2
-      exit 1
-    ''
-else
-  let
-    plugin = flake.packages.${system}.go2nix-nix-plugin;
-    nix = pkgs.nixVersions.nix_2_34;
-    inherit (pkgs) go;
-
-    nixpkgsPath = pkgs.path;
-    go2nixSrc = flake;
-
-    src = pkgs.fetchFromGitHub {
-      owner = "vinegarhq";
-      repo = "vinegar";
-      rev = "v1.9.3";
-      hash = "sha256-0MNUkfhbsvOJdN89VGTuf3zHUFhimiCNuoY47V03Cgo=";
-    };
-
-    goModules = pkgs.stdenvNoCC.mkDerivation {
-      name = "vinegar-gomodcache";
-      outputHashMode = "recursive";
-      outputHashAlgo = "sha256";
-      outputHash = "sha256-cJyYqJmAr8Zb/rjcm36iDeQ6wF/QUXpLjPqa0SP/hz8=";
-      nativeBuildInputs = [
-        go
-        pkgs.cacert
-      ];
-      dontUnpack = true;
-      buildPhase = ''
-        export HOME=$TMPDIR
-        export GOMODCACHE=$out
-        cd ${src}
-        go mod download
-      '';
-      installPhase = "true";
-    };
-  in
-  pkgs.runCommand "test-dag-package-vinegar"
-    {
-      nativeBuildInputs = [ nix ];
-      requiredSystemFeatures = [ "recursive-nix" ];
-    }
-    ''
-      export HOME=$(mktemp -d)
-      export NIX_CONFIG="extra-experimental-features = nix-command recursive-nix"
-
-      echo "=== Building vinegar (default mode) ==="
-      result=$(GOMODCACHE=${goModules} \
-        nix-build ${go2nixSrc}/tests/packages/vinegar/dag.nix \
-        -I nixpkgs=${nixpkgsPath} \
-        --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
-        --no-out-link)
-
-      test -x $result/bin/vinegar
-      echo "PASS: vinegar" > $out
-    ''
+# Build test: vinegar (puregotk, no CGO for GTK libs).
+{ flake, pkgs, system, ... }:
+import ../test-lib/run-dag-test.nix {
+  inherit flake pkgs system;
+  testName = "vinegar";
+  src = pkgs.fetchFromGitHub {
+    owner = "vinegarhq";
+    repo = "vinegar";
+    rev = "v1.9.3";
+    hash = "sha256-0MNUkfhbsvOJdN89VGTuf3zHUFhimiCNuoY47V03Cgo=";
+  };
+  vendorHash = "sha256-jlJN8AZT1WpMTbqrZg8PAnjI5TwoIkAm7gATn0nc8CA=";
+  dagFile = "${flake}/tests/packages/vinegar/dag.nix";
+  checkCommand = "test -x $result/bin/vinegar";
+}

--- a/packages/test-package-yubikey-agent-no-lockfile/default.nix
+++ b/packages/test-package-yubikey-agent-no-lockfile/default.nix
@@ -1,8 +1,8 @@
-# Build test: yubikey-agent with lockfile (default mode).
+# Build test: yubikey-agent without lockfile (hashes from plugin).
 { flake, pkgs, system, ... }:
 import ../test-lib/run-dag-test.nix {
   inherit flake pkgs system;
-  testName = "yubikey-agent";
+  testName = "yubikey-agent-no-lockfile";
   src = pkgs.fetchFromGitHub {
     owner = "FiloSottile";
     repo = "yubikey-agent";
@@ -10,5 +10,6 @@ import ../test-lib/run-dag-test.nix {
     hash = "sha256-Knk1ipBOzjmjrS2OFUMuxi1TkyDcSYlVKezDWT//ERY=";
   };
   vendorHash = "sha256-HtPnM5Z1e1fMoTlZt5MxK/i32kpECREjVDfNw6rNAsM=";
-  dagFile = "${flake}/tests/packages/yubikey-agent/dag.nix";
+  dagFile = "${flake}/tests/packages/yubikey-agent/dag-no-lockfile.nix";
+  checkCommand = "$result/bin/yubikey-agent --help";
 }

--- a/tests/packages/yubikey-agent/dag-no-lockfile.nix
+++ b/tests/packages/yubikey-agent/dag-no-lockfile.nix
@@ -1,0 +1,29 @@
+# Test: buildGoApplication without goLock (lockfile-free, hashes from plugin).
+let
+  pkgs = import <nixpkgs> { };
+  inherit (pkgs) go;
+  go2nix = import ../../../packages/go2nix { inherit pkgs; };
+  goEnv = import ../../../nix/mk-go-env.nix {
+    inherit go go2nix;
+    inherit (pkgs) callPackage;
+  };
+in
+goEnv.buildGoApplication {
+  src = pkgs.fetchFromGitHub {
+    owner = "FiloSottile";
+    repo = "yubikey-agent";
+    rev = "v0.1.6";
+    hash = "sha256-Knk1ipBOzjmjrS2OFUMuxi1TkyDcSYlVKezDWT//ERY=";
+  };
+  # No goLock — hashes resolved from go.sum + GOMODCACHE at eval time.
+  pname = "yubikey-agent";
+  version = "0.1.6";
+  packageOverrides = {
+    "github.com/go-piv/piv-go/piv" = {
+      nativeBuildInputs = [
+        pkgs.pkg-config
+        pkgs.pcsclite
+      ];
+    };
+  };
+}


### PR DESCRIPTION
Maintaining a go2nix.toml lockfile with per-module NAR checksums is friction that can be avoided entirely. Go already tracks module content integrity via h1: hashes in go.sum, and the extracted source trees in GOMODCACHE are deterministic for a given module version.

Teach the nix plugin to compute NAR hashes directly from the GOMODCACHE source trees during evaluation, keyed by h1: from go.sum. A filesystem cache ($XDG_CACHE_HOME/go2nix/nar/) maps h1: hashes to NAR hashes with atomic writes, so multiple nix-eval-jobs workers sharing the same cache directory never corrupt entries or block each other.

The FOD in fetch-go-module.nix now outputs only the extracted source tree instead of the full GOMODCACHE directory. This strips Go-version- dependent metadata (.info, .ziphash, sumdb/) from the output, making the NAR hash a pure function of module content — exactly what h1: captures. This is what makes h1: a sound cache key without needing the Go version in the key.

goLock becomes optional in buildGoApplication. When omitted, the plugin runs with resolveHashes=true and returns moduleHashes alongside the package graph. When provided, behavior is unchanged — existing lockfile users are not affected.