### PR TITLE
refactor: remove unused localReplaces from plugin output

### DIFF
--- a/docs/src/modes/default-mode.md
+++ b/docs/src/modes/default-mode.md
@@ -42,7 +42,6 @@ time and returns a package graph:
 - **localPackages**: Local package metadata (dir, localImports, thirdPartyImports, isCgo)
 - **modulePath**: Main module import path
 - **replacements**: Module replacement mappings from `go.mod` `replace` directives
-- **localReplaces**: Filesystem replace directives for local modules
 - **testPackages**: Test-only third-party package metadata when `doCheck = true`
 
 Replace directives are applied to module `fetchPath` and `dirSuffix` fields

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -587,7 +587,7 @@ stdenv.mkDerivation (
         depsImportcfg
         mainSrc
         ;
-      inherit (goPackagesResult) localReplaces modulePath;
+      inherit (goPackagesResult) modulePath;
     }
     // lib.optionalAttrs doCheck {
       inherit testPackages testDepsImportcfg;

--- a/packages/go2nix-nix-plugin/plugin/resolveGoPackages.cc
+++ b/packages/go2nix-nix-plugin/plugin/resolveGoPackages.cc
@@ -112,7 +112,7 @@ static RegisterPrimOp rp(PrimOp {
     Returns `moduleHashes` in the output (default: false)
 
   Returns: { packages, localPackages, modulePath, replacements, testPackages,
-    localReplaces, moduleHashes (when resolveHashes=true) }
+    moduleHashes (when resolveHashes=true) }
 )",
 #ifdef NIX_PRIMOP_HAS_IMPL
     .impl = prim_resolveGoPackages,

--- a/packages/go2nix-nix-plugin/rust/src/lib.rs
+++ b/packages/go2nix-nix-plugin/rust/src/lib.rs
@@ -22,7 +22,7 @@ use std::ffi::{CStr, CString};
 ///
 /// Input JSON: `{ "go": "...", "src": "...", "tags": [], "doCheck": false, ... }`
 /// Output JSON: `{ "packages": {...}, "localPackages": {...}, "modulePath": "...",
-///   "replacements": {...}, "testPackages": {...}, "localReplaces": {...} }`
+///   "replacements": {...}, "testPackages": {...} }`
 ///
 /// Returns 0 on success, non-zero on error. Caller must free `*out` / `*err_out`
 /// with `go2nix_free_string`.

--- a/packages/go2nix-nix-plugin/rust/src/resolve.rs
+++ b/packages/go2nix-nix-plugin/rust/src/resolve.rs
@@ -350,7 +350,6 @@ pub(crate) struct PackageGraph {
     local_packages: Vec<LocalPkgData>,
     third_party_paths: BTreeSet<String>,
     replacements: BTreeMap<String, (String, String)>,
-    local_replaces: BTreeMap<String, String>,
     module_path: String,
     test_packages: Vec<PkgData>,
     test_only_paths: BTreeSet<String>,
@@ -362,7 +361,6 @@ pub(crate) fn parse_go_packages(stdout: &[u8]) -> Result<PackageGraph> {
     let mut third_party_paths = BTreeSet::new();
     let mut local_paths = BTreeSet::new();
     let mut replacements: BTreeMap<String, (String, String)> = BTreeMap::new();
-    let mut local_replaces: BTreeMap<String, String> = BTreeMap::new();
     let mut module_path = String::new();
 
     // Raw local package data collected during first pass; imports are
@@ -399,13 +397,6 @@ pub(crate) fn parse_go_packages(stdout: &[u8]) -> Result<PackageGraph> {
         let is_local = module.main || (!replace_path.is_empty() && replace_version.is_empty());
 
         if is_local {
-            // Collect local replace directives (not main module).
-            if !module.main && !replace_path.is_empty() {
-                local_replaces
-                    .entry(module.path.clone())
-                    .or_insert(replace_path);
-            }
-
             // Capture main module path from first main-module package.
             if module.main && module_path.is_empty() {
                 module_path = module.path.clone();
@@ -496,7 +487,6 @@ pub(crate) fn parse_go_packages(stdout: &[u8]) -> Result<PackageGraph> {
         local_packages,
         third_party_paths,
         replacements,
-        local_replaces,
         module_path,
         test_packages: Vec::new(),
         test_only_paths: BTreeSet::new(),
@@ -645,7 +635,6 @@ struct JsonOutput {
     local_packages: BTreeMap<String, JsonLocalPkg>,
     module_path: String,
     replacements: BTreeMap<String, JsonReplacement>,
-    local_replaces: BTreeMap<String, String>,
     test_packages: BTreeMap<String, JsonPkg>,
     /// NAR hashes for modules, keyed by "path@version".
     /// Only populated when resolveHashes is true.
@@ -793,7 +782,6 @@ pub(crate) fn package_graph_to_json(
         local_packages,
         module_path: graph.module_path.clone(),
         replacements,
-        local_replaces: graph.local_replaces.clone(),
         test_packages,
         module_hashes,
     };
@@ -941,20 +929,6 @@ mod tests {
         let (path, version) = &graph.replacements["github.com/old/pkg@v2.0.0"];
         assert_eq!(path, "github.com/new/pkg");
         assert_eq!(version, "v2.0.0");
-    }
-
-    #[test]
-    fn parse_collects_local_replaces() {
-        // A local replace: Replace with empty version means filesystem path.
-        let input = format!(
-            r#"{{"ImportPath":"github.com/local/mod/pkg","Dir":"/replace/pkg","Module":{{"Path":"github.com/local/mod","Version":"","Replace":{{"Path":"../local-mod","Version":""}}}},"Imports":[]}}"#
-        );
-        let graph = parse_go_packages(input.as_bytes()).unwrap();
-        assert!(graph.packages.is_empty()); // local, not third-party
-        assert_eq!(
-            graph.local_replaces["github.com/local/mod"],
-            "../local-mod"
-        );
     }
 
     #[test]

--- a/packages/go2nix-nix-plugin/tests/eval-test.nix
+++ b/packages/go2nix-nix-plugin/tests/eval-test.nix
@@ -51,7 +51,6 @@ pkgs.runCommand "go2nix-nix-plugin-eval-test"
           inherit pkgCount localPkgCount testPkgCount;
           modulePath = r.modulePath;
           hasReplMap = builtins.isAttrs r.replacements;
-          hasLocalRepl = builtins.isAttrs r.localReplaces;
           hasDrvName = builtins.hasAttr \"drvName\" sample;
           hasImports = builtins.hasAttr \"imports\" sample;
           hasModKey = builtins.hasAttr \"modKey\" sample;
@@ -73,7 +72,7 @@ pkgs.runCommand "go2nix-nix-plugin-eval-test"
     modulePath=$(echo "$result" | jq -r .modulePath)
     [ -n "$modulePath" ] || { echo "FAIL: modulePath is empty"; exit 1; }
 
-    for f in hasReplMap hasLocalRepl hasDrvName hasImports hasModKey hasSubdir hasLocalDir hasLocalImports hasThirdPartyImports; do
+    for f in hasReplMap hasDrvName hasImports hasModKey hasSubdir hasLocalDir hasLocalImports hasThirdPartyImports; do
       val=$(echo "$result" | jq -r ".$f")
       [ "$val" = "true" ] || { echo "FAIL: $f = $val"; exit 1; }
     done


### PR DESCRIPTION
## Summary

- Remove `localReplaces` field from the Rust plugin JSON output, C++ shim docs, Nix DAG passthru, and eval tests
- Local replace packages are already fully handled through `localPackages`, which contains resolved directory and import metadata from `go list`
- The `localReplaces` field was only exposed in passthru for introspection but never consumed by the build