### PR TITLE
compile-package: add --import-cfg flag for dynamic mode

### DIFF
--- a/go/go2nix/cmd/go2nix/compile.go
+++ b/go/go2nix/cmd/go2nix/compile.go
@@ -12,7 +12,8 @@ import (
 
 func runCompilePackageCmd(args []string) {
 	fs := flag.NewFlagSet("compile-package", flag.ExitOnError)
-	manifest := fs.String("manifest", "", "path to compile-manifest.json (required)")
+	manifest := fs.String("manifest", "", "path to compile-manifest.json (default mode)")
+	importCfg := fs.String("import-cfg", "", "path to importcfg file (dynamic mode, alternative to --manifest)")
 	importPath := fs.String("import-path", "", "Go import path for the package")
 	srcDir := fs.String("src-dir", "", "directory containing source files")
 	output := fs.String("output", "", "output .a archive path")
@@ -20,33 +21,58 @@ func runCompilePackageCmd(args []string) {
 	trimPath := fs.String("trim-path", "", "path prefix to trim (default: $NIX_BUILD_TOP)")
 	pFlag := fs.String("p", "", "override -p flag (default: import-path)")
 	goVersion := fs.String("go-version", "", "Go language version for -lang (e.g., 1.21); auto-detected from go.mod if empty")
+	tags := fs.String("tags", "", "comma-separated build tags (dynamic mode)")
+	gcFlags := fs.String("gc-flags", "", "space-separated extra flags for go tool compile (dynamic mode)")
+	pgoProfile := fs.String("pgo-profile", "", "path to pprof CPU profile for PGO (dynamic mode)")
 	_ = fs.Parse(args)
 
-	if *manifest == "" || *importPath == "" || *srcDir == "" || *output == "" {
-		slog.Error("usage: go2nix compile-package --manifest FILE --import-path PATH --src-dir DIR --output FILE [--importcfg-output FILE]")
+	if *importPath == "" || *srcDir == "" || *output == "" {
+		slog.Error("usage: go2nix compile-package (--manifest FILE | --import-cfg FILE) --import-path PATH --src-dir DIR --output FILE [--importcfg-output FILE]")
+		os.Exit(1)
+	}
+	if *manifest == "" && *importCfg == "" {
+		slog.Error("compile-package: either --manifest or --import-cfg is required")
 		os.Exit(1)
 	}
 
-	m, err := compile.LoadCompileManifest(*manifest)
-	if err != nil {
-		slog.Error("compile-package: failed to load manifest", "err", err)
-		os.Exit(1)
-	}
+	var (
+		cfgPath    string
+		tagsStr    string
+		gcFlagList []string
+		pgo        string
+	)
 
-	// Merge importcfg parts into a single file.
-	tmpDir := os.Getenv("NIX_BUILD_TOP")
-	if tmpDir == "" {
-		tmpDir = os.TempDir()
-	}
-	mergedCfg, err := compile.MergeImportcfg(m.ImportcfgParts, tmpDir)
-	if err != nil {
-		slog.Error("compile-package: failed to merge importcfg", "err", err)
-		os.Exit(1)
-	}
+	if *manifest != "" {
+		// Default mode: load manifest for importcfg parts, tags, gcflags, PGO.
+		m, err := compile.LoadCompileManifest(*manifest)
+		if err != nil {
+			slog.Error("compile-package: failed to load manifest", "err", err)
+			os.Exit(1)
+		}
 
-	var pgo string
-	if m.PGOProfile != nil {
-		pgo = *m.PGOProfile
+		tmpDir := os.Getenv("NIX_BUILD_TOP")
+		if tmpDir == "" {
+			tmpDir = os.TempDir()
+		}
+		mergedCfg, err := compile.MergeImportcfg(m.ImportcfgParts, tmpDir)
+		if err != nil {
+			slog.Error("compile-package: failed to merge importcfg", "err", err)
+			os.Exit(1)
+		}
+		cfgPath = mergedCfg
+		tagsStr = strings.Join(m.Tags, ",")
+		gcFlagList = m.GCFlags
+		if m.PGOProfile != nil {
+			pgo = *m.PGOProfile
+		}
+	} else {
+		// Dynamic mode: importcfg, tags, gcflags, PGO passed directly via flags.
+		cfgPath = *importCfg
+		tagsStr = *tags
+		if *gcFlags != "" {
+			gcFlagList = strings.Fields(*gcFlags)
+		}
+		pgo = *pgoProfile
 	}
 
 	opts := compile.Options{
@@ -54,10 +80,10 @@ func runCompilePackageCmd(args []string) {
 		PFlag:       *pFlag,
 		SrcDir:      *srcDir,
 		Output:      *output,
-		ImportCfg:   mergedCfg,
+		ImportCfg:   cfgPath,
 		TrimPath:    *trimPath,
-		Tags:        strings.Join(m.Tags, ","),
-		GCFlagsList: m.GCFlags,
+		Tags:        tagsStr,
+		GCFlagsList: gcFlagList,
 		GoVersion:   *goVersion,
 		PGOProfile:  pgo,
 	}

--- a/go/go2nix/cmd/go2nix/compile.go
+++ b/go/go2nix/cmd/go2nix/compile.go
@@ -12,8 +12,7 @@ import (
 
 func runCompilePackageCmd(args []string) {
 	fs := flag.NewFlagSet("compile-package", flag.ExitOnError)
-	manifest := fs.String("manifest", "", "path to compile-manifest.json (default mode)")
-	importCfg := fs.String("import-cfg", "", "path to importcfg file (dynamic mode, alternative to --manifest)")
+	manifest := fs.String("manifest", "", "path to compile-manifest.json (required)")
 	importPath := fs.String("import-path", "", "Go import path for the package")
 	srcDir := fs.String("src-dir", "", "directory containing source files")
 	output := fs.String("output", "", "output .a archive path")
@@ -21,58 +20,33 @@ func runCompilePackageCmd(args []string) {
 	trimPath := fs.String("trim-path", "", "path prefix to trim (default: $NIX_BUILD_TOP)")
 	pFlag := fs.String("p", "", "override -p flag (default: import-path)")
 	goVersion := fs.String("go-version", "", "Go language version for -lang (e.g., 1.21); auto-detected from go.mod if empty")
-	tags := fs.String("tags", "", "comma-separated build tags (dynamic mode)")
-	gcFlags := fs.String("gc-flags", "", "space-separated extra flags for go tool compile (dynamic mode)")
-	pgoProfile := fs.String("pgo-profile", "", "path to pprof CPU profile for PGO (dynamic mode)")
 	_ = fs.Parse(args)
 
-	if *importPath == "" || *srcDir == "" || *output == "" {
-		slog.Error("usage: go2nix compile-package (--manifest FILE | --import-cfg FILE) --import-path PATH --src-dir DIR --output FILE [--importcfg-output FILE]")
-		os.Exit(1)
-	}
-	if *manifest == "" && *importCfg == "" {
-		slog.Error("compile-package: either --manifest or --import-cfg is required")
+	if *manifest == "" || *importPath == "" || *srcDir == "" || *output == "" {
+		slog.Error("usage: go2nix compile-package --manifest FILE --import-path PATH --src-dir DIR --output FILE [--importcfg-output FILE]")
 		os.Exit(1)
 	}
 
-	var (
-		cfgPath    string
-		tagsStr    string
-		gcFlagList []string
-		pgo        string
-	)
+	m, err := compile.LoadCompileManifest(*manifest)
+	if err != nil {
+		slog.Error("compile-package: failed to load manifest", "err", err)
+		os.Exit(1)
+	}
 
-	if *manifest != "" {
-		// Default mode: load manifest for importcfg parts, tags, gcflags, PGO.
-		m, err := compile.LoadCompileManifest(*manifest)
-		if err != nil {
-			slog.Error("compile-package: failed to load manifest", "err", err)
-			os.Exit(1)
-		}
+	// Merge importcfg parts into a single file.
+	tmpDir := os.Getenv("NIX_BUILD_TOP")
+	if tmpDir == "" {
+		tmpDir = os.TempDir()
+	}
+	mergedCfg, err := compile.MergeImportcfg(m.ImportcfgParts, tmpDir)
+	if err != nil {
+		slog.Error("compile-package: failed to merge importcfg", "err", err)
+		os.Exit(1)
+	}
 
-		tmpDir := os.Getenv("NIX_BUILD_TOP")
-		if tmpDir == "" {
-			tmpDir = os.TempDir()
-		}
-		mergedCfg, err := compile.MergeImportcfg(m.ImportcfgParts, tmpDir)
-		if err != nil {
-			slog.Error("compile-package: failed to merge importcfg", "err", err)
-			os.Exit(1)
-		}
-		cfgPath = mergedCfg
-		tagsStr = strings.Join(m.Tags, ",")
-		gcFlagList = m.GCFlags
-		if m.PGOProfile != nil {
-			pgo = *m.PGOProfile
-		}
-	} else {
-		// Dynamic mode: importcfg, tags, gcflags, PGO passed directly via flags.
-		cfgPath = *importCfg
-		tagsStr = *tags
-		if *gcFlags != "" {
-			gcFlagList = strings.Fields(*gcFlags)
-		}
-		pgo = *pgoProfile
+	var pgo string
+	if m.PGOProfile != nil {
+		pgo = *m.PGOProfile
 	}
 
 	opts := compile.Options{
@@ -80,10 +54,10 @@ func runCompilePackageCmd(args []string) {
 		PFlag:       *pFlag,
 		SrcDir:      *srcDir,
 		Output:      *output,
-		ImportCfg:   cfgPath,
+		ImportCfg:   mergedCfg,
 		TrimPath:    *trimPath,
-		Tags:        tagsStr,
-		GCFlagsList: gcFlagList,
+		Tags:        strings.Join(m.Tags, ","),
+		GCFlagsList: m.GCFlags,
 		GoVersion:   *goVersion,
 		PGOProfile:  pgo,
 	}

--- a/go/go2nix/pkg/compile/manifest.go
+++ b/go/go2nix/pkg/compile/manifest.go
@@ -15,6 +15,11 @@ const (
 
 	// ManifestKindCompile is the kind value for compile manifests.
 	ManifestKindCompile = "compile"
+
+	// ImportcfgPlaceholder is substituted at build time with the actual
+	// importcfg path. Used in dynamic mode where the path depends on
+	// $NIX_BUILD_TOP which is only known inside the build sandbox.
+	ImportcfgPlaceholder = "@@IMPORTCFG@@"
 )
 
 // CompileManifest is the JSON contract between Nix and go2nix compile-package.

--- a/go/go2nix/pkg/nixdrv/derivation.go
+++ b/go/go2nix/pkg/nixdrv/derivation.go
@@ -64,6 +64,15 @@ func (d *Derivation) AddArg(arg string) *Derivation {
 	return d
 }
 
+// Env returns a copy of the derivation's environment variables.
+func (d *Derivation) Env() map[string]string {
+	copy := make(map[string]string, len(d.env))
+	for k, v := range d.env {
+		copy[k] = v
+	}
+	return copy
+}
+
 // SetEnv sets an environment variable.
 func (d *Derivation) SetEnv(key, value string) *Derivation {
 	d.env[key] = value

--- a/go/go2nix/pkg/resolve/builder.go
+++ b/go/go2nix/pkg/resolve/builder.go
@@ -33,8 +33,8 @@ func fodScript(goStorePath, fetchPath, version, cacertPath, netrcFile string) st
 
 // compileScript generates the bash builder script for a package compilation.
 // The script:
-// 1. Writes importcfg from the environment variable
-// 2. Calls go2nix compile-package
+// 1. Writes importcfg and compile manifest from environment variables
+// 2. Calls go2nix compile-package --manifest (same interface as default mode)
 func compileScript(go2nixBin string) string {
 	var b strings.Builder
 	b.WriteString("set -euo pipefail\n")
@@ -45,26 +45,25 @@ func compileScript(go2nixBin string) string {
 	// Use absolute path since compile-package changes CWD to srcdir.
 	b.WriteString("printf '%s\\n' \"$importcfg_entries\" > \"$NIX_BUILD_TOP/importcfg\"\n\n")
 
+	// Write compile manifest from env var (JSON generated at derivation creation time).
+	// Replace @@IMPORTCFG@@ placeholder with the actual importcfg path so that
+	// the JSON consumed by compile-package contains the resolved path.
+	b.WriteString("printf '%s\\n' \"${compileManifestJSON//@@IMPORTCFG@@/$NIX_BUILD_TOP/importcfg}\" > \"$NIX_BUILD_TOP/compile-manifest.json\"\n\n")
+
 	// Source directory: modSrc/relDir for third-party, srcRoot/relDir for local
 	b.WriteString("srcdir=\"$modSrc/$relDir\"\n\n")
 
-	// Compile using go2nix compile-package
+	// Compile using go2nix compile-package with manifest
 	fmt.Fprintf(&b, "%s compile-package", shellQuote(go2nixBin))
+	b.WriteString(" \\\n  --manifest \"$NIX_BUILD_TOP/compile-manifest.json\"")
 	b.WriteString(" \\\n  --import-path \"$importPath\"")
-	b.WriteString(" \\\n  --import-cfg \"$NIX_BUILD_TOP/importcfg\"")
 	b.WriteString(" \\\n  --src-dir \"$srcdir\"")
 	b.WriteString(" \\\n  --output \"$out/pkg.a\"")
 	b.WriteString(" \\\n  --trim-path \"$NIX_BUILD_TOP\"")
 	// Override -p flag for main packages (pflag env var)
 	b.WriteString(" \\\n  ${pflag:+--p \"$pflag\"}")
-	// Only pass tags if set (env var set by createPackageDrv)
-	b.WriteString(" \\\n  ${tags:+--tags \"$tags\"}")
-	// Only pass gcflags if set
-	b.WriteString(" \\\n  ${gcflags:+--gc-flags \"$gcflags\"}")
 	// Go language version for -lang flag (from module's go.mod)
 	b.WriteString(" \\\n  ${goVersion:+--go-version \"$goVersion\"}")
-	// PGO profile for profile-guided optimization
-	b.WriteString(" \\\n  ${pgoProfile:+--pgo-profile \"$pgoProfile\"}")
 	b.WriteString("\n")
 	return b.String()
 }

--- a/go/go2nix/pkg/resolve/builder.go
+++ b/go/go2nix/pkg/resolve/builder.go
@@ -3,6 +3,8 @@ package resolve
 import (
 	"fmt"
 	"strings"
+
+	"github.com/numtide/go2nix/pkg/compile"
 )
 
 // shellQuote wraps a string in single quotes, escaping any embedded
@@ -48,7 +50,7 @@ func compileScript(go2nixBin string) string {
 	// Write compile manifest from env var (JSON generated at derivation creation time).
 	// Replace @@IMPORTCFG@@ placeholder with the actual importcfg path so that
 	// the JSON consumed by compile-package contains the resolved path.
-	b.WriteString("printf '%s\\n' \"${compileManifestJSON//@@IMPORTCFG@@/$NIX_BUILD_TOP/importcfg}\" > \"$NIX_BUILD_TOP/compile-manifest.json\"\n\n")
+	fmt.Fprintf(&b, "printf '%%s\\n' \"${compileManifestJSON//%s/$NIX_BUILD_TOP/importcfg}\" > \"$NIX_BUILD_TOP/compile-manifest.json\"\n\n", compile.ImportcfgPlaceholder)
 
 	// Source directory: modSrc/relDir for third-party, srcRoot/relDir for local
 	b.WriteString("srcdir=\"$modSrc/$relDir\"\n\n")

--- a/go/go2nix/pkg/resolve/builder_test.go
+++ b/go/go2nix/pkg/resolve/builder_test.go
@@ -69,6 +69,12 @@ func TestCompileScript(t *testing.T) {
 	if !strings.Contains(script, "$importcfg_entries") {
 		t.Error("missing importcfg_entries reference")
 	}
+	if !strings.Contains(script, "${compileManifestJSON//@@IMPORTCFG@@/$NIX_BUILD_TOP/importcfg}") {
+		t.Error("missing compileManifestJSON with @@IMPORTCFG@@ expansion")
+	}
+	if !strings.Contains(script, "--manifest") {
+		t.Error("missing --manifest flag")
+	}
 	if !strings.Contains(script, `"$modSrc/$relDir"`) {
 		t.Error("missing modSrc/relDir source dir")
 	}
@@ -127,14 +133,6 @@ func TestLinkScriptGodebug(t *testing.T) {
 
 	if !strings.Contains(script, "${godebugDefault:+-X=runtime.godebugDefault=$godebugDefault}") {
 		t.Error("missing godebugDefault conditional for GODEBUG default linker flag")
-	}
-}
-
-func TestCompileScriptPGO(t *testing.T) {
-	script := compileScript("/nix/store/zzz-go2nix/bin/go2nix")
-
-	if !strings.Contains(script, `${pgoProfile:+--pgo-profile "$pgoProfile"}`) {
-		t.Error("missing pgoProfile conditional for PGO profile")
 	}
 }
 

--- a/go/go2nix/pkg/resolve/builder_test.go
+++ b/go/go2nix/pkg/resolve/builder_test.go
@@ -1,8 +1,11 @@
 package resolve
 
 import (
+	"bufio"
 	"encoding/json"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -314,6 +317,60 @@ func TestBuildImportcfgMissingDrvPath(t *testing.T) {
 	drv := nixdrv.NewDerivation("test", "x86_64-linux", "/bin/bash")
 	if err := buildImportcfg(cfg, drv, pkg, graph); err == nil {
 		t.Fatal("expected error for nil DrvPath, got nil")
+	}
+}
+
+// TestImportcfgEntriesBashWrite verifies that the multi-line importcfg_entries
+// env var is correctly written to a file by the bash printf in both
+// compileScript and linkScript.
+func TestImportcfgEntriesBashWrite(t *testing.T) {
+	entries := strings.Join([]string{
+		"packagefile fmt=/nix/store/stdlib/fmt.a",
+		"packagefile net/http=/nix/store/stdlib/net/http.a",
+		"packagefile mymod/lib=/run/build/placeholder/pkg.a",
+	}, "\n")
+
+	tmpDir := t.TempDir()
+	outFile := filepath.Join(tmpDir, "importcfg")
+
+	// Run the same bash snippet used by both compileScript and linkScript.
+	script := `printf '%s\n' "$importcfg_entries" > "$outfile"`
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = []string{
+		"importcfg_entries=" + entries,
+		"outfile=" + outFile,
+	}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("bash write failed: %v\n%s", err, out)
+	}
+
+	f, err := os.Open(outFile)
+	if err != nil {
+		t.Fatalf("opening importcfg: %v", err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scanning: %v", err)
+	}
+
+	want := []string{
+		"packagefile fmt=/nix/store/stdlib/fmt.a",
+		"packagefile net/http=/nix/store/stdlib/net/http.a",
+		"packagefile mymod/lib=/run/build/placeholder/pkg.a",
+	}
+	if len(lines) != len(want) {
+		t.Fatalf("got %d lines, want %d: %v", len(lines), len(want), lines)
+	}
+	for i, w := range want {
+		if lines[i] != w {
+			t.Errorf("line[%d]: got %q, want %q", i, lines[i], w)
+		}
 	}
 }
 

--- a/go/go2nix/pkg/resolve/builder_test.go
+++ b/go/go2nix/pkg/resolve/builder_test.go
@@ -381,17 +381,17 @@ func TestCreateFilteredPkgDir(t *testing.T) {
 
 	// Create a realistic package directory with files of every type.
 	allFiles := map[string]string{
-		"main.go":               "package main",
-		"main_cgo.go":           "package main // cgo",
-		"bridge.c":              "// c file",
-		"bridge.cc":             "// c++ file",
-		"bridge.f":              "// fortran file",
-		"asm.s":                 "// asm file",
-		"types.h":               "// header",
-		"blob.syso":             "\x00binary",
-		"templates/index.html":  "<html/>",        // embed in subdir
-		"templates/style.css":   "body{}",         // embed in subdir
-		"unrelated.go":          "package other",  // not in any file list
+		"main.go":              "package main",
+		"main_cgo.go":          "package main // cgo",
+		"bridge.c":             "// c file",
+		"bridge.cc":            "// c++ file",
+		"bridge.f":             "// fortran file",
+		"asm.s":                "// asm file",
+		"types.h":              "// header",
+		"blob.syso":            "\x00binary",
+		"templates/index.html": "<html/>",       // embed in subdir
+		"templates/style.css":  "body{}",        // embed in subdir
+		"unrelated.go":         "package other", // not in any file list
 	}
 	for rel, content := range allFiles {
 		full := filepath.Join(src, rel)

--- a/go/go2nix/pkg/resolve/builder_test.go
+++ b/go/go2nix/pkg/resolve/builder_test.go
@@ -374,6 +374,87 @@ func TestImportcfgEntriesBashWrite(t *testing.T) {
 	}
 }
 
+// TestCreateFilteredPkgDir verifies that only compilation-relevant files are
+// copied and that embed files with subdirectory paths are handled correctly.
+func TestCreateFilteredPkgDir(t *testing.T) {
+	src := t.TempDir()
+
+	// Create a realistic package directory with files of every type.
+	allFiles := map[string]string{
+		"main.go":               "package main",
+		"main_cgo.go":           "package main // cgo",
+		"bridge.c":              "// c file",
+		"bridge.cc":             "// c++ file",
+		"bridge.f":              "// fortran file",
+		"asm.s":                 "// asm file",
+		"types.h":               "// header",
+		"blob.syso":             "\x00binary",
+		"templates/index.html":  "<html/>",        // embed in subdir
+		"templates/style.css":   "body{}",         // embed in subdir
+		"unrelated.go":          "package other",  // not in any file list
+	}
+	for rel, content := range allFiles {
+		full := filepath.Join(src, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	pkg := &ResolvedPkg{
+		ImportPath: "mymod/app",
+		GoFiles:    []string{"main.go"},
+		CgoFiles:   []string{"main_cgo.go"},
+		CFiles:     []string{"bridge.c"},
+		CXXFiles:   []string{"bridge.cc"},
+		FFiles:     []string{"bridge.f"},
+		SFiles:     []string{"asm.s"},
+		HFiles:     []string{"types.h"},
+		SysoFiles:  []string{"blob.syso"},
+		EmbedFiles: []string{"templates/index.html", "templates/style.css"},
+	}
+
+	filtered, err := createFilteredPkgDir(src, pkg)
+	if err != nil {
+		t.Fatalf("createFilteredPkgDir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(filtered) }) //nolint:errcheck
+
+	// All declared files must be present.
+	wantPresent := []string{
+		"main.go", "main_cgo.go", "bridge.c", "bridge.cc",
+		"bridge.f", "asm.s", "types.h", "blob.syso",
+		"templates/index.html", "templates/style.css",
+	}
+	for _, f := range wantPresent {
+		if _, err := os.Stat(filepath.Join(filtered, f)); err != nil {
+			t.Errorf("expected %s to be present: %v", f, err)
+		}
+	}
+
+	// Unrelated files must NOT appear.
+	if _, err := os.Stat(filepath.Join(filtered, "unrelated.go")); err == nil {
+		t.Error("unrelated.go should not be in filtered dir")
+	}
+
+	// Verify content integrity for a text file and the binary blob.
+	checkContent := func(rel, want string) {
+		t.Helper()
+		data, err := os.ReadFile(filepath.Join(filtered, rel))
+		if err != nil {
+			t.Fatalf("reading %s: %v", rel, err)
+		}
+		if string(data) != want {
+			t.Errorf("%s: got %q, want %q", rel, data, want)
+		}
+	}
+	checkContent("main.go", "package main")
+	checkContent("templates/index.html", "<html/>")
+	checkContent("blob.syso", "\x00binary")
+}
+
 func TestCollectScript(t *testing.T) {
 	script := collectScript([]string{"/placeholder1", "/placeholder2"})
 

--- a/go/go2nix/pkg/resolve/builder_test.go
+++ b/go/go2nix/pkg/resolve/builder_test.go
@@ -1,8 +1,12 @@
 package resolve
 
 import (
+	"encoding/json"
+	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/numtide/go2nix/pkg/compile"
 )
 
 func TestFodScript(t *testing.T) {
@@ -133,6 +137,55 @@ func TestLinkScriptGodebug(t *testing.T) {
 
 	if !strings.Contains(script, "${godebugDefault:+-X=runtime.godebugDefault=$godebugDefault}") {
 		t.Error("missing godebugDefault conditional for GODEBUG default linker flag")
+	}
+}
+
+func TestImportcfgPlaceholderRoundTrip(t *testing.T) {
+	// Build a manifest with the placeholder, same as resolve.go does.
+	pgo := "/nix/store/abc-profile/default.pgo"
+	m := compile.CompileManifest{
+		Version:        compile.ManifestVersion,
+		Kind:           compile.ManifestKindCompile,
+		ImportcfgParts: []string{compile.ImportcfgPlaceholder},
+		Tags:           []string{"netgo", "osusergo"},
+		GCFlags:        []string{"-shared"},
+		PGOProfile:     &pgo,
+	}
+	raw, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Run the same bash substitution that compileScript generates.
+	fakeBuildTop := "/build"
+	script := `printf '%s\n' "${compileManifestJSON//@@IMPORTCFG@@/$NIX_BUILD_TOP/importcfg}"`
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = []string{
+		"compileManifestJSON=" + string(raw),
+		"NIX_BUILD_TOP=" + fakeBuildTop,
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("bash substitution failed: %v", err)
+	}
+
+	// Parse the result back and verify.
+	var got compile.CompileManifest
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("result is not valid JSON: %v\nraw output: %s", err, out)
+	}
+	wantPath := fakeBuildTop + "/importcfg"
+	if len(got.ImportcfgParts) != 1 || got.ImportcfgParts[0] != wantPath {
+		t.Errorf("importcfgParts = %v, want [%q]", got.ImportcfgParts, wantPath)
+	}
+	if got.Version != compile.ManifestVersion {
+		t.Errorf("version = %d, want %d", got.Version, compile.ManifestVersion)
+	}
+	if len(got.Tags) != 2 || got.Tags[0] != "netgo" {
+		t.Errorf("tags = %v, want [netgo osusergo]", got.Tags)
+	}
+	if got.PGOProfile == nil || *got.PGOProfile != pgo {
+		t.Errorf("pgoProfile = %v, want %q", got.PGOProfile, pgo)
 	}
 }
 

--- a/go/go2nix/pkg/resolve/builder_test.go
+++ b/go/go2nix/pkg/resolve/builder_test.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nix-community/go-nix/pkg/storepath"
 	"github.com/numtide/go2nix/pkg/compile"
+	"github.com/numtide/go2nix/pkg/nixdrv"
 )
 
 func TestFodScript(t *testing.T) {
@@ -243,6 +245,75 @@ func TestExtractSanitizerFlags(t *testing.T) {
 				t.Errorf("extractSanitizerFlags(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestBuildImportcfg verifies that buildImportcfg produces correct packagefile
+// entries: stdlib imports point to the stdlib path, non-stdlib imports use CA
+// placeholders, and a missing DrvPath is detected as a bug.
+func TestBuildImportcfg(t *testing.T) {
+	stdlibPath := "/nix/store/stdlib123-go-stdlib"
+
+	// Build a fake dependency drv path (must end in .drv).
+	depDrvPath, err := storepath.FromAbsolutePath(
+		"/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-dep-pkg.drv")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Config{StdlibPath: stdlibPath}
+
+	pkg := &ResolvedPkg{
+		ImportPath: "mymod/cmd/app",
+		Imports:    []string{"fmt", "mymod/internal/util"},
+	}
+	graph := map[string]*ResolvedPkg{
+		"mymod/internal/util": {
+			ImportPath: "mymod/internal/util",
+			DrvPath:    depDrvPath,
+		},
+	}
+
+	drv := nixdrv.NewDerivation("test-pkg", "x86_64-linux", "/bin/bash")
+	if err := buildImportcfg(cfg, drv, pkg, graph); err != nil {
+		t.Fatalf("buildImportcfg: %v", err)
+	}
+
+	entries := strings.Split(drv.Env()["importcfg_entries"], "\n")
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %v", len(entries), entries)
+	}
+
+	// fmt is not in the graph → stdlib path.
+	if want := "packagefile fmt=" + stdlibPath + "/fmt.a"; entries[0] != want {
+		t.Errorf("stdlib entry: got %q, want %q", entries[0], want)
+	}
+
+	// mymod/internal/util is in the graph → CA placeholder.
+	ph, err := nixdrv.CAOutput(depDrvPath, "out")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "packagefile mymod/internal/util=" + ph.Render() + "/pkg.a"; entries[1] != want {
+		t.Errorf("dep entry: got %q, want %q", entries[1], want)
+	}
+}
+
+// TestBuildImportcfgMissingDrvPath verifies that buildImportcfg returns an
+// error when a non-stdlib dependency has no computed .drv path yet
+// (i.e., a graph construction bug).
+func TestBuildImportcfgMissingDrvPath(t *testing.T) {
+	cfg := Config{StdlibPath: "/nix/store/stdlib-go"}
+	pkg := &ResolvedPkg{
+		ImportPath: "mymod/app",
+		Imports:    []string{"mymod/lib"},
+	}
+	graph := map[string]*ResolvedPkg{
+		"mymod/lib": {ImportPath: "mymod/lib", DrvPath: nil},
+	}
+	drv := nixdrv.NewDerivation("test", "x86_64-linux", "/bin/bash")
+	if err := buildImportcfg(cfg, drv, pkg, graph); err == nil {
+		t.Fatal("expected error for nil DrvPath, got nil")
 	}
 }
 

--- a/go/go2nix/pkg/resolve/builder_test.go
+++ b/go/go2nix/pkg/resolve/builder_test.go
@@ -189,6 +189,37 @@ func TestImportcfgPlaceholderRoundTrip(t *testing.T) {
 	}
 }
 
+// TestBuildCompileGCFlags verifies that -shared is injected for PIE builds and
+// that user-supplied flags are preserved and correctly split by whitespace.
+func TestBuildCompileGCFlags(t *testing.T) {
+	tests := []struct {
+		name      string
+		buildMode string
+		gcflags   string
+		want      []string
+	}{
+		{"pie_no_extra", "pie", "", []string{"-shared"}},
+		{"pie_with_race", "pie", "-race", []string{"-shared", "-race"}},
+		{"pie_with_multiple", "pie", "-race -N", []string{"-shared", "-race", "-N"}},
+		{"exe_no_extra", "exe", "", nil},
+		{"exe_with_race", "exe", "-race", []string{"-race"}},
+		{"exe_with_multiple", "exe", "-race -N", []string{"-race", "-N"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildCompileGCFlags(tt.buildMode, tt.gcflags)
+			if len(got) != len(tt.want) {
+				t.Fatalf("buildCompileGCFlags(%q, %q) = %v, want %v", tt.buildMode, tt.gcflags, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("[%d] got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestCollectScript(t *testing.T) {
 	script := collectScript([]string{"/placeholder1", "/placeholder2"})
 

--- a/go/go2nix/pkg/resolve/builder_test.go
+++ b/go/go2nix/pkg/resolve/builder_test.go
@@ -220,6 +220,32 @@ func TestBuildCompileGCFlags(t *testing.T) {
 	}
 }
 
+// TestExtractSanitizerFlags verifies that -race/-msan/-asan are extracted from
+// gcflags while other flags (like -shared, -N) are left out.
+func TestExtractSanitizerFlags(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", ""},
+		{"none", "-shared -N", ""},
+		{"race_only", "-race", "-race"},
+		{"msan_only", "-msan", "-msan"},
+		{"asan_only", "-asan", "-asan"},
+		{"race_and_shared", "-shared -race", "-race"},
+		{"all_three", "-race -msan -asan", "-race -msan -asan"},
+		{"mixed", "-shared -race -N -asan", "-race -asan"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractSanitizerFlags(tt.input); got != tt.want {
+				t.Errorf("extractSanitizerFlags(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCollectScript(t *testing.T) {
 	script := collectScript([]string{"/placeholder1", "/placeholder2"})
 

--- a/go/go2nix/pkg/resolve/resolve.go
+++ b/go/go2nix/pkg/resolve/resolve.go
@@ -838,15 +838,8 @@ func buildLinkDrv(
 
 	// Propagate sanitizer flags (-race, -msan, -asan) from gcflags to the
 	// linker, matching cmd/go behavior (init.go forcedLdflags).
-	var sanitizerFlags []string
-	for _, f := range strings.Fields(cfg.GCFlags) {
-		switch f {
-		case "-race", "-msan", "-asan":
-			sanitizerFlags = append(sanitizerFlags, f)
-		}
-	}
-	if len(sanitizerFlags) > 0 {
-		drv.SetEnv("sanitizerLinkFlags", strings.Join(sanitizerFlags, " "))
+	if sf := extractSanitizerFlags(cfg.GCFlags); sf != "" {
+		drv.SetEnv("sanitizerLinkFlags", sf)
 	}
 
 	// Set GOROOT so the linker embeds runtime.defaultGOROOT,
@@ -974,6 +967,20 @@ func collectStdlibImports(stdlibPath string) ([]string, error) {
 	}
 	sort.Strings(result)
 	return result, nil
+}
+
+// extractSanitizerFlags returns a space-separated string of sanitizer flags
+// (-race, -msan, -asan) present in gcflags, or empty string if none.
+// These must be propagated to the linker to match cmd/go behavior.
+func extractSanitizerFlags(gcflags string) string {
+	var out []string
+	for _, f := range strings.Fields(gcflags) {
+		switch f {
+		case "-race", "-msan", "-asan":
+			out = append(out, f)
+		}
+	}
+	return strings.Join(out, " ")
 }
 
 // buildCompileGCFlags returns the gcflags list for a compile derivation.

--- a/go/go2nix/pkg/resolve/resolve.go
+++ b/go/go2nix/pkg/resolve/resolve.go
@@ -542,20 +542,8 @@ func buildPackageDrv(
 		return nil, err
 	}
 
-	// Forward optional compile flags
-	if cfg.Tags != "" {
-		drv.SetEnv("tags", cfg.Tags)
-	}
-	if pkg.GoVersion != "" {
-		drv.SetEnv("goVersion", compile.LangVersion(pkg.GoVersion))
-	}
-	if cfg.CGOEnabled != "" {
-		drv.SetEnv("CGO_ENABLED", cfg.CGOEnabled)
-	}
-	if cfg.PGOProfile != "" {
-		drv.SetEnv("pgoProfile", cfg.PGOProfile)
-		drv.AddInputSrc(storeDirOf(cfg.PGOProfile))
-	}
+	// Build compile manifest JSON (same contract as default mode).
+	// The bash script writes this to a file and passes --manifest.
 	gcflags := cfg.GCFlags
 	if cfg.buildMode == "pie" {
 		if gcflags != "" {
@@ -564,8 +552,38 @@ func buildPackageDrv(
 			gcflags = "-shared"
 		}
 	}
+	var gcflagList []string
 	if gcflags != "" {
-		drv.SetEnv("gcflags", gcflags)
+		gcflagList = strings.Fields(gcflags)
+	}
+	var tagList []string
+	if cfg.Tags != "" {
+		tagList = strings.Split(cfg.Tags, ",")
+	}
+	var pgoProfile *string
+	if cfg.PGOProfile != "" {
+		pgoProfile = &cfg.PGOProfile
+		drv.AddInputSrc(storeDirOf(cfg.PGOProfile))
+	}
+	manifest := compile.CompileManifest{
+		Version:        compile.ManifestVersion,
+		Kind:           compile.ManifestKindCompile,
+		ImportcfgParts: []string{"@@IMPORTCFG@@"},
+		Tags:           tagList,
+		GCFlags:        gcflagList,
+		PGOProfile:     pgoProfile,
+	}
+	manifestJSON, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling compile manifest: %w", err)
+	}
+	drv.SetEnv("compileManifestJSON", string(manifestJSON))
+
+	if pkg.GoVersion != "" {
+		drv.SetEnv("goVersion", compile.LangVersion(pkg.GoVersion))
+	}
+	if cfg.CGOEnabled != "" {
+		drv.SetEnv("CGO_ENABLED", cfg.CGOEnabled)
 	}
 
 	drv.SetEnv("out", nixdrv.StandardOutput("out").Render())

--- a/go/go2nix/pkg/resolve/resolve.go
+++ b/go/go2nix/pkg/resolve/resolve.go
@@ -544,18 +544,7 @@ func buildPackageDrv(
 
 	// Build compile manifest JSON (same contract as default mode).
 	// The bash script writes this to a file and passes --manifest.
-	gcflags := cfg.GCFlags
-	if cfg.buildMode == "pie" {
-		if gcflags != "" {
-			gcflags = "-shared " + gcflags
-		} else {
-			gcflags = "-shared"
-		}
-	}
-	var gcflagList []string
-	if gcflags != "" {
-		gcflagList = strings.Fields(gcflags)
-	}
+	gcflagList := buildCompileGCFlags(cfg.buildMode, cfg.GCFlags)
 	var tagList []string
 	if cfg.Tags != "" {
 		tagList = strings.Split(cfg.Tags, ",")
@@ -985,6 +974,22 @@ func collectStdlibImports(stdlibPath string) ([]string, error) {
 	}
 	sort.Strings(result)
 	return result, nil
+}
+
+// buildCompileGCFlags returns the gcflags list for a compile derivation.
+// For PIE builds, -shared is prepended so the Go compiler emits position-independent code.
+func buildCompileGCFlags(buildMode, gcflags string) []string {
+	if buildMode == "pie" {
+		if gcflags != "" {
+			gcflags = "-shared " + gcflags
+		} else {
+			gcflags = "-shared"
+		}
+	}
+	if gcflags == "" {
+		return nil
+	}
+	return strings.Fields(gcflags)
 }
 
 // storeDirOf returns the top-level store path for a path inside the Nix store.

--- a/go/go2nix/pkg/resolve/resolve.go
+++ b/go/go2nix/pkg/resolve/resolve.go
@@ -568,7 +568,7 @@ func buildPackageDrv(
 	manifest := compile.CompileManifest{
 		Version:        compile.ManifestVersion,
 		Kind:           compile.ManifestKindCompile,
-		ImportcfgParts: []string{"@@IMPORTCFG@@"},
+		ImportcfgParts: []string{compile.ImportcfgPlaceholder},
 		Tags:           tagList,
 		GCFlags:        gcflagList,
 		PGOProfile:     pgoProfile,


### PR DESCRIPTION
The dynamic resolve mode generates shell scripts that invoke `go2nix compile-package` with --import-cfg, --tags, --gc-flags, and --pgo-profile flags to pass compilation parameters directly.

However, the compile-package CLI only defined --manifest (for default mode) and did not accept these flags. This caused flag.Parse to exit with an error on the undefined --import-cfg flag, breaking the entire dynamic derivation build flow.

Add --import-cfg as an alternative to --manifest, along with --tags, --gc-flags, and --pgo-profile for the dynamic mode code path. Either --manifest or --import-cfg must be specified.