### PR TITLE
Fix mainSrc filter for modRoot with "./" prefix

### DIFF
--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -463,15 +463,16 @@ let
   # Source for the final link derivation: only the main package directories.
   mainSrc =
     let
+      cleanModRoot = lib.removePrefix "./" modRoot;
       subPkgDirs = map (
         sp:
         let
           clean = lib.removePrefix "./" sp;
         in
-        if modRoot == "." then clean else "${modRoot}/${clean}"
+        if modRoot == "." then clean else "${cleanModRoot}/${clean}"
       ) normalizedSubPackages;
       # Include modRoot for go.mod access.
-      allowedDirs = [ modRoot ] ++ subPkgDirs;
+      allowedDirs = [ cleanModRoot ] ++ subPkgDirs;
       # When modRoot is "." or any subPackage resolves to ".", the entire
       # source tree is needed — no filtering required.
       includeAll = builtins.elem "." allowedDirs;


### PR DESCRIPTION
The mainSrc filter compared store-relative paths (e.g. `myapp/go.mod`)
against allowedDirs that preserved the `./` prefix from modRoot
(e.g. `./myapp`). The mismatch caused the filter to reject all
files, producing an empty mainSrc derivation.

Strip `./` from modRoot before building allowedDirs so the prefixes
match the store-relative paths in the filter callback.