### PR TITLE
Stop forcing GOPROXY — inherit from environment by default

### DIFF
--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -132,8 +132,7 @@ let
   lockfileModules = builtins.mapAttrs parseModEntry lockfileModTable;
 
   # --- Package graph from plugin (eval-time go list) ---
-  # goProxy defaults to "off": reads from the host's GOMODCACHE (populated
-  # by `go mod download`). No network access or writes during eval.
+  # goProxy is unset by default — inherits the environment's GOPROXY.
   # When resolveHashes is true, the plugin also computes NAR hashes for all
   # modules from go.sum + GOMODCACHE, returned as moduleHashes.
   goPackagesResult = builtins.resolveGoPackages (

--- a/packages/go2nix-nix-plugin/plugin/resolveGoPackages.cc
+++ b/packages/go2nix-nix-plugin/plugin/resolveGoPackages.cc
@@ -103,7 +103,7 @@ static RegisterPrimOp rp(PrimOp {
   - `subPackages` (optional): List of package patterns (default: ["./..."])
   - `modRoot` (optional): Subdirectory containing go.mod (default: ".")
   - `goos` / `goarch` (optional): Cross-compilation targets
-  - `goProxy` (optional): GOPROXY value (default: "off")
+  - `goProxy` (optional): GOPROXY override; when unset, inherits the environment
   - `cgoEnabled` (optional): CGO_ENABLED value
   - `doCheck` (optional): When true, runs a second `go list -deps -test`
     pass to discover test-only third-party dependencies (default: false)

--- a/packages/go2nix-nix-plugin/rust/src/resolve.rs
+++ b/packages/go2nix-nix-plugin/rust/src/resolve.rs
@@ -120,7 +120,7 @@ struct GoListOpts<'a> {
     mod_root: &'a str,
     goos: &'a str,
     goarch: &'a str,
-    go_proxy: &'a str,
+    go_proxy: Option<&'a str>,
     cgo_enabled: &'a str,
 }
 
@@ -142,13 +142,17 @@ fn configure_go_env(cmd: &mut Command, src_dir: &str, opts: &GoListOpts) {
     for (k, v) in inherit_env(&["GOMODCACHE", "GOPATH", "HOME"]) {
         cmd.env(&k, &v);
     }
-    cmd.env("GOPROXY", opts.go_proxy);
+    if let Some(proxy) = opts.go_proxy {
+        cmd.env("GOPROXY", proxy);
+    }
     cmd.env("GONOSUMCHECK", "*");
     cmd.env("GOFLAGS", "-mod=readonly");
     cmd.env("GOENV", "off");
     cmd.env("GOWORK", "off");
 
-    if opts.go_proxy != "off" {
+    // When GOPROXY is not "off", the go toolchain needs network access.
+    let proxy_off = opts.go_proxy.map_or(false, |p| p == "off");
+    if !proxy_off {
         for (k, v) in inherit_env(&[
             "PATH",
             "TMPDIR",
@@ -515,8 +519,8 @@ pub(crate) struct JsonInput {
     goos: String,
     #[serde(default)]
     goarch: String,
-    #[serde(default = "default_off")]
-    go_proxy: String,
+    #[serde(default)]
+    go_proxy: Option<String>,
     #[serde(default)]
     cgo_enabled: String,
     /// When true, resolve NAR hashes for all modules from go.sum + GOMODCACHE.
@@ -531,9 +535,7 @@ fn default_sub_packages() -> Vec<String> {
 fn default_dot() -> String {
     ".".to_owned()
 }
-fn default_off() -> String {
-    "off".to_owned()
-}
+
 
 /// Query `go env GOMODCACHE` to find the module cache directory.
 pub(crate) fn find_gomodcache(go_bin: &str) -> Result<std::path::PathBuf> {
@@ -579,7 +581,7 @@ pub(crate) fn resolve_packages(input: &JsonInput) -> Result<PackageGraph> {
         mod_root: &input.mod_root,
         goos: &input.goos,
         goarch: &input.goarch,
-        go_proxy: &input.go_proxy,
+        go_proxy: input.go_proxy.as_deref(),
         cgo_enabled: &input.cgo_enabled,
     };
 


### PR DESCRIPTION
Forcing GOPROXY=off meant every user had to manually run "go mod download" before nix-build. Leave it unset so Go uses whatever the user/system has configured. The goProxy option still lets callers override explicitly.