### PR TITLE
Pin nixpkgs to nix 2.34.2

### DIFF
--- a/docs/src/builder-api.md
+++ b/docs/src/builder-api.md
@@ -138,7 +138,7 @@ goEnv = go2nix.lib.mkGoEnv {
   # Optional:
   tags = [ "nethttpomithttp2" ];
   netrcFile = ./my-netrc;
-  nixPackage = pkgs.nixVersions.latest;  # required for experimental mode
+  nixPackage = pkgs.nixVersions.nix_2_34;  # required for experimental mode
 };
 ```
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773597492,
-        "narHash": "sha256-hQ284SkIeNaeyud+LS0WVLX+WL2rxcVZLFEaK0e03zg=",
+        "lastModified": 1774273680,
+        "narHash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a07d4ce6bee67d7c838a8a5796e75dff9caa21ef",
+        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a07d4ce6bee67d7c838a8a5796e75dff9caa21ef",
+        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/a07d4ce6bee67d7c838a8a5796e75dff9caa21ef";
+    nixpkgs.url = "github:nixos/nixpkgs/fdc7b8f7b30fdbedec91b71ed82f36e1637483ed";
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
## Summary
- Update nixpkgs input commit to include nix 2.34.2 (was 2.34.1)
- Replace last `nixVersions.latest` reference in docs with `nixVersions.nix_2_34`