### PR TITLE
helpers: add parseLocalReplaces + goModLocalReplaceDirs

### DIFF
--- a/nix/helpers.nix
+++ b/nix/helpers.nix
@@ -1,5 +1,5 @@
 # go2nix/nix/helpers.nix — shared utility functions.
-{
+rec {
   # Make a string safe for use as a Nix derivation name.
   # Valid store-path characters: [a-zA-Z0-9+-._?=]
   # Go import paths may contain / ~ @, all of which are illegal.
@@ -77,4 +77,57 @@
   normalizeSubPackages = map (
     sp: if sp == "." || builtins.substring 0 2 sp == "./" then sp else "./${sp}"
   );
+
+  # Parse go.mod text and return the list of local replace target paths
+  # (as strings, relative to the go.mod's directory).
+  #
+  # `=>` appears only in `replace` directives (golang.org/x/mod/modfile/rule.go
+  # parseReplace), so a single regex pass over the whole file finds every local
+  # target regardless of inline vs block syntax. A replace target is local when
+  # IsDirectoryPath(ns) is true — this regex covers the Unix `./` and `../`
+  # prefix forms; bare `.`/`..` (no slash) and absolute `/` paths are valid per
+  # IsDirectoryPath but intentionally out of scope here. [^[:space:]]* stops at
+  # CR (CRLF-safe) and at the space before any trailing `// comment`.
+  parseLocalReplaces =
+    goModText:
+    builtins.concatMap (x: if builtins.isList x then x else [ ]) (
+      builtins.split "=>[[:space:]]+(\\.\\.?/[^[:space:]]*)" goModText
+    );
+
+  # Walk go.mod local replace directives transitively. Returns the list of
+  # directory paths including the root module. genericClosure deduplicates
+  # by key (the canonicalized path string), so diamond deps and cycles are
+  # handled in C++ without a Nix-level visited set.
+  #
+  # Use this to construct a minimal source fileset for a monorepo module:
+  # pass the module directory, get back just the directories the Go build
+  # actually needs, avoiding full-repo source hashes.
+  goModLocalReplaceDirs =
+    dir:
+    map (x: x.dir) (
+      builtins.genericClosure {
+        startSet = [
+          {
+            key = builtins.toString dir;
+            inherit dir;
+          }
+        ];
+        operator =
+          { dir, ... }:
+          let
+            goMod = dir + "/go.mod";
+            rels = if builtins.pathExists goMod then parseLocalReplaces (builtins.readFile goMod) else [ ];
+          in
+          map (
+            r:
+            let
+              next = dir + "/${r}";
+            in
+            {
+              key = builtins.toString next;
+              dir = next;
+            }
+          ) rels;
+      }
+    );
 }

--- a/tests/nix/helpers_test.nix
+++ b/tests/nix/helpers_test.nix
@@ -8,6 +8,8 @@ let
     sanitizeName
     removePrefix
     escapeModPath
+    parseLocalReplaces
+    goModLocalReplaceDirs
     ;
 
   assertEq =
@@ -21,10 +23,11 @@ in
 # --- sanitizeName ---
 assert assertEq "sanitizeName slashes" (sanitizeName "github.com/foo/bar") "github.com-foo-bar";
 
-assert assertEq "sanitizeName plus" (sanitizeName "google.golang.org/grpc+extra")
-  "google.golang.org-grpc_extra";
+assert assertEq "sanitizeName plus preserved" (sanitizeName "google.golang.org/grpc+extra")
+  "google.golang.org-grpc+extra";
 
-assert assertEq "sanitizeName both" (sanitizeName "github.com/a+b/c+d") "github.com-a_b-c_d";
+assert assertEq "sanitizeName slash with plus" (sanitizeName "github.com/a+b/c+d")
+  "github.com-a+b-c+d";
 
 assert assertEq "sanitizeName no change" (sanitizeName "simple-name") "simple-name";
 
@@ -50,5 +53,100 @@ assert assertEq "escapeModPath all caps" (escapeModPath "ABC") "!a!b!c";
 
 assert assertEq "escapeModPath mixed" (escapeModPath "github.com/FiloSottile/yubikey-agent")
   "github.com/!filo!sottile/yubikey-agent";
+
+# --- parseLocalReplaces ---
+let
+  assertListEq =
+    name: actual: expected:
+    if actual == expected then
+      true
+    else
+      builtins.throw "${name}: got ${builtins.toJSON actual}, want ${builtins.toJSON expected}";
+  sort = builtins.sort builtins.lessThan;
+in
+
+assert assertListEq "parseLocalReplaces inline"
+  (parseLocalReplaces ''
+    module example.com/m
+    go 1.25
+    replace github.com/a/b => ../a-b
+    replace github.com/c/d => github.com/c/d v1.2.3
+    replace github.com/e/f => ./local
+  '')
+  [
+    "../a-b"
+    "./local"
+  ];
+
+assert assertListEq "parseLocalReplaces block"
+  (parseLocalReplaces ''
+    module example.com/m
+    replace (
+    	github.com/a/b => ../a-b
+    	github.com/c/d => github.com/c/d v1.2.3
+    	github.com/e/f => ../e-f
+    )
+  '')
+  [
+    "../a-b"
+    "../e-f"
+  ];
+
+assert assertListEq "parseLocalReplaces mixed inline+block"
+  (parseLocalReplaces ''
+    replace github.com/x => ../x
+    replace (
+    	github.com/y => ../y
+    )
+    replace github.com/z => github.com/z v0.0.1
+  '')
+  [
+    "../x"
+    "../y"
+  ];
+
+assert assertListEq "parseLocalReplaces versioned LHS" (parseLocalReplaces ''
+  replace github.com/a/b v1.0.0 => ../a-b
+'') [ "../a-b" ];
+
+assert assertListEq "parseLocalReplaces empty" (parseLocalReplaces ''
+  module example.com/m
+  go 1.25
+'') [ ];
+
+assert assertListEq "parseLocalReplaces CRLF"
+  (parseLocalReplaces "replace github.com/a => ../a\r\nreplace github.com/b => ../b\r\n")
+  [
+    "../a"
+    "../b"
+  ];
+
+# --- goModLocalReplaceDirs ---
+# torture-project/app-partial has block replaces pointing to 5 internal/* dirs,
+# each of which (transitively) replace => ../common.
+let
+  torture = ../fixtures/torture-project;
+  dirs = goModLocalReplaceDirs (torture + "/app-partial");
+  dirStrs = sort (map (d: removePrefix (builtins.toString torture + "/") (builtins.toString d)) dirs);
+in
+assert assertListEq "goModLocalReplaceDirs app-partial transitive" dirStrs [
+  "app-partial"
+  "internal/aws"
+  "internal/common"
+  "internal/conflict-a"
+  "internal/crypto"
+  "internal/db"
+];
+
+# Diamond: app-partial → {aws, crypto, db, ...} → common. Visited-set must dedupe.
+let
+  torture = ../fixtures/torture-project;
+  dirs = goModLocalReplaceDirs (torture + "/internal/aws");
+  dirStrs = sort (map (d: removePrefix (builtins.toString torture + "/") (builtins.toString d)) dirs);
+in
+assert assertListEq "goModLocalReplaceDirs single hop" dirStrs [
+  "internal/aws"
+  "internal/common"
+];
 
 true


### PR DESCRIPTION
Walk `go.mod` local replace directives transitively to discover the minimal set of source directories a monorepo module needs. Lets callers build a narrow `src` fileset instead of passing the full repository root — any monorepo edit would otherwise rebuild the module.

## `parseLocalReplaces`

Single regex pass over the whole file. `=>` appears only in `replace` directives per `golang.org/x/mod/modfile/rule.go` `parseReplace`, so no per-line state machine is needed to distinguish inline from block syntax.

Covers the Unix `./` and `../` forms of `IsDirectoryPath` (rule.go:775-778). Bare `.`/`..` without a slash and absolute `/` paths are valid per `IsDirectoryPath` but intentionally out of scope — they don't appear in practice and the Windows forms are rejected by `go mod tidy` on non-Windows anyway (rule.go:619).

## `goModLocalReplaceDirs`

Transitive walk via `builtins.genericClosure` — dedup by canonicalized path string is done in C++, so diamond deps and cycles are free.

## Tests

Verified against `tests/fixtures/torture-project`:
- `app-partial`: block-form replaces, 6 dirs found including `internal/common` via BFS (aws/crypto/db all point to it, deduped)
- `app-full`: 14-way fanout, 15 dirs total
- `internal/aws`: single hop, diamond dedup

Also fixes two `sanitizeName` test assertions that expected `+` to be escaped — `+` is a valid store-path character per the docstring at `nix/helpers.nix:4` and the function correctly leaves it alone. The suite has been red on `main` since e9a904d.
