### PR TITLE
plugin: make 'go' field optional, fall back to GO2NIX_DEFAULT_GO

### DIFF
--- a/packages/go2nix-nix-plugin/rust/src/lib.rs
+++ b/packages/go2nix-nix-plugin/rust/src/lib.rs
@@ -56,7 +56,12 @@ pub unsafe extern "C" fn resolve_go_packages_json(
                 src_dir.join(mod_root).join("go.sum")
             };
 
-            let gomodcache = resolve::find_gomodcache(&opts.go)
+            let go_bin = opts
+                .go
+                .as_deref()
+                .or(resolve::DEFAULT_GO)
+                .ok_or_else(|| "resolveGoPackages: 'go' not provided and GO2NIX_DEFAULT_GO was unset at plugin build time".to_owned())?;
+            let gomodcache = resolve::find_gomodcache(go_bin)
                 .map_err(|e| format!("finding GOMODCACHE: {e:#}"))?;
 
             module_hashes::resolve_module_hashes(&go_sum_path, &gomodcache)

--- a/packages/go2nix-nix-plugin/rust/src/resolve.rs
+++ b/packages/go2nix-nix-plugin/rust/src/resolve.rs
@@ -3,10 +3,15 @@
 //! Runs `go list -json -deps -e`, parses the output into a `PackageGraph`,
 //! and serializes it to JSON for the C++ nix shim.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::process::Command;
+
+/// Baked-in default Go binary path, set at compile time via GO2NIX_DEFAULT_GO.
+/// `option_env!` (not `env!`) so the plugin still compiles when the var is unset;
+/// an explicit `go` field in the input always takes precedence.
+pub(crate) const DEFAULT_GO: Option<&str> = option_env!("GO2NIX_DEFAULT_GO");
 
 // ---------------------------------------------------------------------------
 // Go list JSON types
@@ -505,7 +510,8 @@ pub(crate) fn parse_go_packages(stdout: &[u8]) -> Result<PackageGraph> {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct JsonInput {
-    pub(crate) go: String,
+    #[serde(default)]
+    pub(crate) go: Option<String>,
     pub(crate) src: String,
     #[serde(default)]
     do_check: bool,
@@ -576,6 +582,12 @@ pub(crate) fn find_gomodcache(go_bin: &str) -> Result<std::path::PathBuf> {
 /// When `do_check` is set and local packages exist, a second pass
 /// (`go list -deps -test`) discovers test-only third-party dependencies.
 pub(crate) fn resolve_packages(input: &JsonInput) -> Result<PackageGraph> {
+    let go_bin = input
+        .go
+        .as_deref()
+        .or(DEFAULT_GO)
+        .ok_or_else(|| anyhow!("resolveGoPackages: 'go' not provided and GO2NIX_DEFAULT_GO was unset at plugin build time"))?;
+
     let opts = GoListOpts {
         tags: &input.tags,
         mod_root: &input.mod_root,
@@ -585,7 +597,7 @@ pub(crate) fn resolve_packages(input: &JsonInput) -> Result<PackageGraph> {
         cgo_enabled: &input.cgo_enabled,
     };
 
-    let stdout = run_go_list(&input.go, &input.src, &input.sub_packages, &opts)?;
+    let stdout = run_go_list(go_bin, &input.src, &input.sub_packages, &opts)?;
     let mut graph = parse_go_packages(&stdout)?;
 
     if input.do_check && !graph.local_packages.is_empty() {
@@ -596,7 +608,7 @@ pub(crate) fn resolve_packages(input: &JsonInput) -> Result<PackageGraph> {
             .collect();
 
         let test_stdout =
-            run_go_list_test(&input.go, &input.src, &local_ips, &opts)?;
+            run_go_list_test(go_bin, &input.src, &local_ips, &opts)?;
 
         let test_pkgs = parse_test_packages(
             &test_stdout,

--- a/packages/go2nix-nix-plugin/rust/src/resolve.rs
+++ b/packages/go2nix-nix-plugin/rust/src/resolve.rs
@@ -1133,6 +1133,45 @@ mod tests {
         assert_eq!(jp.mod_key, "github.com/foo/bar@v2.0.0");
     }
 
+    // --- go field resolution ---
+
+    #[test]
+    fn json_input_go_absent_deserializes_to_none() {
+        let input: JsonInput =
+            serde_json::from_str(r##"{"src":"/src","subPackages":["./..."]}"##).unwrap();
+        assert!(input.go.is_none());
+    }
+
+    #[test]
+    fn json_input_go_explicit_deserializes_to_some() {
+        let input: JsonInput = serde_json::from_str(
+            r##"{"go":"/nix/store/xxx-go/bin/go","src":"/src","subPackages":["./..."]}"##,
+        )
+        .unwrap();
+        assert_eq!(input.go.as_deref(), Some("/nix/store/xxx-go/bin/go"));
+    }
+
+    /// When go is absent and DEFAULT_GO is unset at compile time (the normal CI
+    /// case), resolve_packages must return the descriptive error immediately,
+    /// before attempting to spawn any subprocess.
+    #[test]
+    fn resolve_packages_errors_without_go_field() {
+        // DEFAULT_GO is None in test builds (GO2NIX_DEFAULT_GO not set in CI).
+        if DEFAULT_GO.is_some() {
+            return; // compiled with default baked in — skip
+        }
+        let input: JsonInput =
+            serde_json::from_str(r##"{"src":"/nonexistent","subPackages":["./..."]}"##).unwrap();
+        let err = match resolve_packages(&input) {
+            Err(e) => e,
+            Ok(_) => panic!("expected error when go is absent"),
+        };
+        assert!(
+            err.to_string().contains("GO2NIX_DEFAULT_GO"),
+            "unexpected error: {err}"
+        );
+    }
+
     #[test]
     fn json_pkg_filters_imports() {
         let p = PkgData {


### PR DESCRIPTION
## Summary

Add a compile-time constant baked in via `option_env!("GO2NIX_DEFAULT_GO")`. This lets packagers embed the Go binary path at build time so callers don't have to pass `go = "${go}/bin/go"` explicitly.

## Changes

### `resolve.rs`
- Added `pub(crate) const DEFAULT_GO: Option<&str> = option_env!("GO2NIX_DEFAULT_GO")` — `option_env!` (not `env!`) so the plugin still compiles without the var set
- `JsonInput.go`: `String` → `#[serde(default)] Option<String>`
- `resolve_packages`: resolves `go_bin` via `input.go → DEFAULT_GO → error` before the first `run_go_list` call; both `run_go_list` and `run_go_list_test` now receive `go_bin`

### `lib.rs`
- The lockfile-free path (`find_gomodcache`) had its own `&opts.go` reference — applies the same `DEFAULT_GO` fallback so both code paths stay consistent

## Behaviour

- Existing callers passing `go = "${go}/bin/go"` are completely unaffected — explicit `go` always wins
- When `GO2NIX_DEFAULT_GO` is set at build time, callers can omit the `go` field entirely
- When neither is set, a clear error is returned at runtime