### PR TITLE
stdlib: plumb goEnv from mkGoEnv through to go install std

### DIFF
--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -84,6 +84,23 @@ let
       pgoProfile = if pgoProfile != null then "${pgoProfile}" else null;
     };
 
+  # Env attrset for per-package compile derivations. goEnv is the scope-level
+  # base; the hook-required keys overlay it; packageOverrides.<pkg>.env wins.
+  mkCompileEnv =
+    {
+      importPath,
+      srcDir,
+      deps,
+      extraEnv,
+    }:
+    goEnv
+    // {
+      goPackagePath = importPath;
+      goPackageSrcDir = srcDir;
+      compileManifestJSON = mkCompileManifestJSON deps;
+    }
+    // extraEnv;
+
   # Match Go's internal/platform.DefaultPIE: PIE for darwin, windows, android, ios.
   buildMode =
     let
@@ -228,14 +245,14 @@ let
       nativeBuildInputs = [ hooks.goModuleHook ] ++ cgoBuildInputs ++ extraNativeBuildInputs;
       buildInputs = deps;
 
-      env =
-        goEnv
-        // {
-          goPackagePath = importPath;
-          goPackageSrcDir = srcDir;
-          compileManifestJSON = mkCompileManifestJSON deps;
-        }
-        // extraEnv;
+      env = mkCompileEnv {
+        inherit
+          importPath
+          srcDir
+          deps
+          extraEnv
+          ;
+      };
     }
   ) goPackagesResult.packages;
 
@@ -313,14 +330,14 @@ let
       nativeBuildInputs = [ hooks.goModuleHook ] ++ cgoBuildInputs ++ extraNativeBuildInputs;
       buildInputs = deps;
 
-      env =
-        goEnv
-        // {
-          goPackagePath = importPath;
-          goPackageSrcDir = srcDir;
-          compileManifestJSON = mkCompileManifestJSON deps;
-        }
-        // extraEnv;
+      env = mkCompileEnv {
+        inherit
+          importPath
+          srcDir
+          deps
+          extraEnv
+          ;
+      };
     }
   ) goPackagesResult.localPackages;
 
@@ -411,14 +428,14 @@ let
         nativeBuildInputs = [ hooks.goModuleHook ] ++ cgoBuildInputs ++ extraNativeBuildInputs;
         buildInputs = deps;
 
-        env =
-          goEnv
-          // {
-            goPackagePath = importPath;
-            goPackageSrcDir = srcDir;
-            compileManifestJSON = mkCompileManifestJSON deps;
-          }
-          // extraEnv;
+        env = mkCompileEnv {
+          inherit
+            importPath
+            srcDir
+            deps
+            extraEnv
+            ;
+        };
       }
     ) goPackagesResult.testPackages
   );

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -30,6 +30,7 @@
   fetchers,
   helpers,
   stdlib,
+  goEnv,
   ...
 }:
 
@@ -227,12 +228,14 @@ let
       nativeBuildInputs = [ hooks.goModuleHook ] ++ cgoBuildInputs ++ extraNativeBuildInputs;
       buildInputs = deps;
 
-      env = {
-        goPackagePath = importPath;
-        goPackageSrcDir = srcDir;
-        compileManifestJSON = mkCompileManifestJSON deps;
-      }
-      // extraEnv;
+      env =
+        goEnv
+        // {
+          goPackagePath = importPath;
+          goPackageSrcDir = srcDir;
+          compileManifestJSON = mkCompileManifestJSON deps;
+        }
+        // extraEnv;
     }
   ) goPackagesResult.packages;
 
@@ -310,12 +313,14 @@ let
       nativeBuildInputs = [ hooks.goModuleHook ] ++ cgoBuildInputs ++ extraNativeBuildInputs;
       buildInputs = deps;
 
-      env = {
-        goPackagePath = importPath;
-        goPackageSrcDir = srcDir;
-        compileManifestJSON = mkCompileManifestJSON deps;
-      }
-      // extraEnv;
+      env =
+        goEnv
+        // {
+          goPackagePath = importPath;
+          goPackageSrcDir = srcDir;
+          compileManifestJSON = mkCompileManifestJSON deps;
+        }
+        // extraEnv;
     }
   ) goPackagesResult.localPackages;
 
@@ -406,12 +411,14 @@ let
         nativeBuildInputs = [ hooks.goModuleHook ] ++ cgoBuildInputs ++ extraNativeBuildInputs;
         buildInputs = deps;
 
-        env = {
-          goPackagePath = importPath;
-          goPackageSrcDir = srcDir;
-          compileManifestJSON = mkCompileManifestJSON deps;
-        }
-        // extraEnv;
+        env =
+          goEnv
+          // {
+            goPackagePath = importPath;
+            goPackageSrcDir = srcDir;
+            compileManifestJSON = mkCompileManifestJSON deps;
+          }
+          // extraEnv;
       }
     ) goPackagesResult.testPackages
   );
@@ -593,10 +600,12 @@ stdenv.mkDerivation (
       inherit testPackages testDepsImportcfg;
     };
 
-    env = {
-      inherit linkManifestJSON;
-    }
-    // (if CGO_ENABLED != null then { inherit CGO_ENABLED; } else { })
-    // (if doCheck then { inherit testManifestJSON; } else { });
+    env =
+      goEnv
+      // {
+        inherit linkManifestJSON;
+      }
+      // (if CGO_ENABLED != null then { inherit CGO_ENABLED; } else { })
+      // (if doCheck then { inherit testManifestJSON; } else { });
   }
 )

--- a/nix/dynamic/default.nix
+++ b/nix/dynamic/default.nix
@@ -26,6 +26,7 @@
   netrcFile,
   stdlib,
   helpers,
+  goEnv,
 }:
 
 {
@@ -123,7 +124,13 @@ let
     dontInstall = true;
     dontFixup = true;
 
+    # goEnv exports reach `go2nix resolve` (which runs go list), but not the
+    # synthesized per-package derivations — same limitation as packageOverrides.env
+    # above. stdlib is already goEnv-aware via the scope.
     buildPhase = ''
+      ${lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (k: v: "export ${k}=${lib.escapeShellArg (toString v)}") goEnv
+      )}
       export NIX_CONFIG="extra-experimental-features = nix-command ca-derivations dynamic-derivations"
       export HOME=$TMPDIR
 

--- a/nix/mk-go-env.nix
+++ b/nix/mk-go-env.nix
@@ -12,6 +12,10 @@
   tags ? [ ],
   netrcFile ? null,
   nixPackage ? null,
+  # Env vars forwarded to stdlib compilation and go tool invocations.
+  # Scope-level because stdlib is scope-level — every buildGoApplication
+  # call in this scope shares the same stdlib derivation.
+  goEnv ? { },
 }:
 callPackage ./scope.nix {
   inherit
@@ -20,5 +24,6 @@ callPackage ./scope.nix {
     tags
     netrcFile
     nixPackage
+    goEnv
     ;
 }

--- a/nix/scope.nix
+++ b/nix/scope.nix
@@ -14,6 +14,7 @@
   tags ? [ ],
   netrcFile ? null,
   nixPackage ? null,
+  goEnv ? { },
 }:
 let
   tagFlag = if tags == [ ] then "" else builtins.concatStringsSep "," tags;
@@ -45,11 +46,12 @@ lib.makeScope newScope (
       netrcFile
       nixPackage
       hasDynamicDerivations
+      goEnv
       ;
 
     helpers = import ./helpers.nix;
 
-    stdlib = callPackage ./stdlib.nix { };
+    stdlib = callPackage ./stdlib.nix { inherit goEnv; };
 
     hooks = callPackage ./dag/hooks { };
 

--- a/nix/stdlib.nix
+++ b/nix/stdlib.nix
@@ -4,19 +4,43 @@
 #   $out/<pkg>.a     for each stdlib package
 #   $out/importcfg   mapping import paths to .a file paths
 #
-# This is a single derivation shared by all builds using the same Go version.
+# A single derivation per (go version, goEnv) pair.
 # Reference: TVL depot nix/buildGo/default.nix buildStdlib.
 {
   go,
   runCommandCC,
+  lib,
+  # Env vars forwarded to `go install std`. This is the only cmd/go
+  # invocation in go2nix — per-package compile and link use go tool
+  # directly, bypassing cmd/go's env-driven source selection (GOFIPS140
+  # snapshot replacement, GOEXPERIMENT overlays, etc.). Settings that
+  # change which stdlib sources get compiled belong here.
+  goEnv ? { },
 }:
-runCommandCC "go-stdlib-${go.version}" { nativeBuildInputs = [ go ]; } ''
+let
+  # Hash goEnv into the name so distinct env configurations get distinct
+  # cache entries. Values are stringified first so { X = 4; } and
+  # { X = "4"; } — identical under the toString export below — share a key.
+  envSuffix = lib.optionalString (goEnv != { }) (
+    "-"
+    + builtins.substring 0 8 (
+      builtins.hashString "sha256" (builtins.toJSON (lib.mapAttrs (_: toString) goEnv))
+    )
+  );
+  envExports = lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (k: v: "export ${k}=${lib.escapeShellArg (toString v)}") goEnv
+  );
+in
+runCommandCC "go-stdlib-${go.version}${envSuffix}" { nativeBuildInputs = [ go ]; } ''
+  ${envExports}
   HOME="$NIX_BUILD_TOP/home"
   mkdir -p "$HOME"
 
-  # Copy Go source tree so we can write to it.
+  # Copy Go source tree so we can write to it. lib/ carries toolchain
+  # data cmd/go reads under certain env vars (e.g. lib/fips140/*.zip
+  # for GOFIPS140 snapshot selection).
   goroot="$(go env GOROOT)"
-  cp -R "$goroot/src" "$goroot/pkg" .
+  cp -R "$goroot/src" "$goroot/pkg" "$goroot/lib" .
   chmod -R +w .
 
   # Compile all stdlib packages.


### PR DESCRIPTION
Adds scope-level `goEnv ? {}` that flows `mkGoEnv` → `scope` → `stdlib` + `dag` + `dynamic`. This is the passthrough for env vars that `cmd/go` reads for source selection but `go tool compile`/`link` do not — `stdlib.nix`'s `go install std` is the only `cmd/go` invocation in go2nix.

## Why scope-level

`stdlib` is scope-level. Settings like `GOFIPS140=v1.0.0` (swaps `crypto/internal/fips140/*` for a validated snapshot from `GOROOT/lib/fips140/` via `fsys.Bind`) or `GOEXPERIMENT` change which stdlib sources get compiled. A caller needing two configurations calls `mkGoEnv` twice — two scopes, two stdlibs.

## Changes

**`stdlib.nix`**
- `goEnv` exported before `go install std`
- `lib/` added to the GOROOT copy (`lib/fips140/*.zip`, `lib/time/zoneinfo.zip`)
- `goEnv` hashed into the drv name. Values normalized via `toString` so `{ X = 4; }` and `{ X = "4"; }` — identical under shell export — share a cache key.

**`dag/default.nix`**
- `goEnv` merged as base into all four env blocks (third-party, local, test compile + link). `go tool compile` reads `GOEXPERIMENT` from env via `internal/buildcfg` (20+ callsites on `buildcfg.Experiment.{FieldTrack, SIMD, NewInliner, LoopVar, CgoCheck2, ...}`), so this is live for experiments even though `GOFIPS140` is stdlib-only. `packageOverrides.<pkg>.env` still wins per-package.

**`dynamic/default.nix`**
- `goEnv` exported in the wrapper `buildPhase` so `go2nix resolve` inherits it. Synthesized per-package derivations do not get it — same limitation as `packageOverrides.env`.

**`mk-go-env.nix`, `scope.nix`**
- Plumbing.

## Cache impact

The stdlib builder script text changes unconditionally (`lib/` in the cp, expanded comment), so the drv hash differs even for `goEnv = {}`. First build after merge misses the cache. Name is unchanged (`go-stdlib-<version>`); hash is not.

## Verification

```
$ GOFIPS140=v1.0.0 go list -deps crypto/sha256 | grep fips | head -3
crypto/internal/fips140deps/godebug
crypto/internal/fips140/v1.0.0-c2097c7c
crypto/internal/fips140/v1.0.0-c2097c7c/alias
```

`go install std` with `GOFIPS140` and `lib/` copied: snapshot unpacks to `GOMODCACHE` (no network), compiles the `/v1.0.0-c2097c7c/` packages.
