### PR TITLE
fetch-go-module: add netrcContent for host-path credentials

### DIFF
--- a/nix/dag/fetch-go-module.nix
+++ b/nix/dag/fetch-go-module.nix
@@ -11,13 +11,25 @@
 #     Outputs the full GOMODCACHE directory (backward-compatible with existing
 #     lockfile hashes).
 #
-# For private modules, set netrcFile in mk-go-env.nix to provide credentials.
+# For private modules, set netrcFile or netrcContent in mk-go-env.nix.
+#
+# netrcFile: a Nix path or store path string. Interpolated into the build
+#   script as `cp ${netrcFile}` — the path must be visible inside the FOD
+#   sandbox (store paths are; raw host paths like "/root/.netrc" are not).
+#
+# netrcContent: the literal file contents. Passed via env var and written
+#   in the build phase. Use this when reading credentials from a host path
+#   at eval time: `netrcContent = builtins.readFile /path/to/.netrc`.
+#   Contents become part of the .drv hash but FODs are output-addressed so
+#   this doesn't affect caching.
 {
+  lib,
   go,
   stdenvNoCC,
   cacert,
   helpers,
   netrcFile,
+  netrcContent ? null,
 }:
 let
   inherit (helpers) sanitizeName escapeModPath;
@@ -32,51 +44,61 @@ let
   escapedPath = escapeModPath fetchPath;
   dirSuffix = "${escapedPath}@${version}";
 in
-stdenvNoCC.mkDerivation {
-  name = "gomod-${sanitizeName fetchPath}-${version}";
+stdenvNoCC.mkDerivation (
+  {
+    name = "gomod-${sanitizeName fetchPath}-${version}";
 
-  # Fixed-output derivation: content-addressed by NAR hash.
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = hash;
+    # Fixed-output derivation: content-addressed by NAR hash.
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = hash;
 
-  nativeBuildInputs = [
-    go
-    cacert
-  ];
+    nativeBuildInputs = [
+      go
+      cacert
+    ];
 
-  # No source — we download in the build phase.
-  dontUnpack = true;
+    # No source — we download in the build phase.
+    dontUnpack = true;
 
-  buildPhase = ''
-    export HOME=$TMPDIR
-    export GOSUMDB=off
-    export GONOSUMCHECK='*'
-    ${
-      if netrcFile != null then
+    buildPhase = ''
+      export HOME=$TMPDIR
+      export GOSUMDB=off
+      export GONOSUMCHECK='*'
+      ${
+        if netrcContent != null then
+          ''
+            printf '%s' "$NETRC_CONTENT" > $HOME/.netrc
+            chmod 600 $HOME/.netrc
+          ''
+        else if netrcFile != null then
+          ''
+            cp ${netrcFile} $HOME/.netrc
+            chmod 600 $HOME/.netrc
+          ''
+        else
+          ""
+      }
+    ''
+    + (
+      if sourceOnly then
         ''
-          cp ${netrcFile} $HOME/.netrc
-          chmod 600 $HOME/.netrc
+          export GOMODCACHE=$TMPDIR/modcache
+          go mod download "${fetchPath}@${version}"
+          cp -r "$TMPDIR/modcache/${dirSuffix}" "$out"
         ''
       else
-        ""
-    }
-  ''
-  + (
-    if sourceOnly then
-      ''
-        export GOMODCACHE=$TMPDIR/modcache
-        go mod download "${fetchPath}@${version}"
-        cp -r "$TMPDIR/modcache/${dirSuffix}" "$out"
-      ''
-    else
-      ''
-        export GOMODCACHE=$out
-        go mod download "${fetchPath}@${version}"
-      ''
-  );
+        ''
+          export GOMODCACHE=$out
+          go mod download "${fetchPath}@${version}"
+        ''
+    );
 
-  # Skip other phases.
-  dontInstall = true;
-  dontFixup = true;
-}
+    # Skip other phases.
+    dontInstall = true;
+    dontFixup = true;
+  }
+  // lib.optionalAttrs (netrcContent != null) {
+    NETRC_CONTENT = netrcContent;
+  }
+)

--- a/nix/mk-go-env.nix
+++ b/nix/mk-go-env.nix
@@ -11,6 +11,7 @@
   callPackage,
   tags ? [ ],
   netrcFile ? null,
+  netrcContent ? null,
   nixPackage ? null,
   # Env vars forwarded to stdlib compilation and go tool invocations.
   # Scope-level because stdlib is scope-level — every buildGoApplication
@@ -23,6 +24,7 @@ callPackage ./scope.nix {
     go2nix
     tags
     netrcFile
+    netrcContent
     nixPackage
     goEnv
     ;

--- a/nix/scope.nix
+++ b/nix/scope.nix
@@ -13,6 +13,7 @@
   newScope,
   tags ? [ ],
   netrcFile ? null,
+  netrcContent ? null,
   nixPackage ? null,
   goEnv ? { },
 }:
@@ -44,6 +45,7 @@ lib.makeScope newScope (
       tags
       tagFlag
       netrcFile
+      netrcContent
       nixPackage
       hasDynamicDerivations
       goEnv


### PR DESCRIPTION
The existing `netrcFile` interpolates the path into `buildPhase` (`cp ${netrcFile}`). That works for Nix paths (`./netrc`) and store path strings, but **not** for raw host paths like `"/root/.netrc"` — the FOD sandbox doesn't mount host filesystems.

A common pattern that hits this:

```nix
homeNetrc = builtins.getEnv "HOME" + "/.netrc";
netrcFile = if builtins.pathExists homeNetrc then homeNetrc else null;
```

`builtins.pathExists` returns true at eval time (host filesystem visible), the string `/root/.netrc` flows into the derivation, `cp` fails in the sandbox.

## Change

Add `netrcContent` — pass the literal contents via env var, written with `printf` in `buildPhase`:

```nix
mkGoEnv {
  netrcContent = builtins.readFile /path/to/.netrc;  # eval-time read, no sandbox issue
}
```

`netrcFile` is unchanged; `netrcContent` takes precedence if both are set.

**Trade-off:** contents land in the `.drv` (nix store metadata, world-readable). FODs are output-addressed so this doesn't affect caching, but anyone with store read access can see the credentials. For setups where that matters, `netrcFile` with a properly-coerced store path (or `extra-sandbox-paths`) remains the right choice.