### PR TITLE
fetch-go-module + resolve: inherit GOPROXY/NETRC from environment

### DIFF
--- a/go/go2nix/go.mod
+++ b/go/go2nix/go.mod
@@ -4,9 +4,9 @@ go 1.26
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/nix-community/go-nix v0.0.0-20260320180134-5c5435a2b4a8
+	github.com/nix-community/go-nix v0.0.0-20260401165014-ac2535ed3bd6
 	golang.org/x/mod v0.32.0
 	golang.org/x/sync v0.19.0
 )
 
-replace github.com/nix-community/go-nix => github.com/numtide/go-nix v0.0.0-20260320180134-5c5435a2b4a8
+replace github.com/nix-community/go-nix => github.com/numtide/go-nix v0.0.0-20260401165014-ac2535ed3bd6

--- a/go/go2nix/go.sum
+++ b/go/go2nix/go.sum
@@ -4,8 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249 h1:NHrXEjTNQY7P0Zfx1aMrNhpgxHmow66XQtm0aQLY0AE=
 github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249/go.mod h1:mpRZBD8SJ55OIICQ3iWH0Yz3cjzA61JdqMLoWXeB2+8=
-github.com/numtide/go-nix v0.0.0-20260320180134-5c5435a2b4a8 h1:XEtd+CKMG6kZtRCT3/VKzmIho6EEYJtPrL0L/0nTsWY=
-github.com/numtide/go-nix v0.0.0-20260320180134-5c5435a2b4a8/go.mod h1:XEMmavm5b3xZDNLNAZ5RxqdXALjcCCfCAY7ECQNnLDU=
+github.com/numtide/go-nix v0.0.0-20260401165014-ac2535ed3bd6 h1:+TiCWGzaT1lLuX4KzqECcQEfA1i2nHYEPWMrpYinwVY=
+github.com/numtide/go-nix v0.0.0-20260401165014-ac2535ed3bd6/go.mod h1:r43qCYjEhW4skVbeDUwS5yLMRibRMR71k85l0BpM028=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/nix/dag/fetch-go-module.nix
+++ b/nix/dag/fetch-go-module.nix
@@ -12,7 +12,10 @@
 #     lockfile hashes).
 #
 # For private modules, set netrcFile in mk-go-env.nix to provide credentials.
+# GOPROXY and NETRC are inherited from the build environment via impureEnvVars
+# (matching nixpkgs buildGoModule for GOPROXY; cmd/go reads $NETRC directly).
 {
+  lib,
   go,
   stdenvNoCC,
   cacert,
@@ -39,6 +42,14 @@ stdenvNoCC.mkDerivation {
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
   outputHash = hash;
+
+  # Inherit proxy configuration from the build environment. outputHash pins
+  # the result regardless of which proxy serves it; this just lets the fetch
+  # route through a private/caching proxy. Matches nixpkgs buildGoModule.
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+    "GOPROXY"
+    "NETRC"
+  ];
 
   nativeBuildInputs = [
     go

--- a/packages/go2nix-nix-plugin/rust/src/resolve.rs
+++ b/packages/go2nix-nix-plugin/rust/src/resolve.rs
@@ -142,9 +142,11 @@ fn configure_go_env(cmd: &mut Command, src_dir: &str, opts: &GoListOpts) {
     cmd.current_dir(&work_dir);
 
     // Minimal environment — GOROOT is self-detected from the binary location,
-    // -buildvcs=false avoids VCS tool lookups.
+    // -buildvcs=false avoids VCS tool lookups. GOPROXY/NETRC are inherited so
+    // private/caching proxies configured in the host environment are respected;
+    // an explicit goProxy arg still wins below.
     cmd.env_clear();
-    for (k, v) in inherit_env(&["GOMODCACHE", "GOPATH", "HOME"]) {
+    for (k, v) in inherit_env(&["GOMODCACHE", "GOPATH", "HOME", "GOPROXY", "NETRC"]) {
         cmd.env(&k, &v);
     }
     if let Some(proxy) = opts.go_proxy {
@@ -1187,5 +1189,44 @@ mod tests {
         };
         let jp = pkg_data_to_json_pkg(&p, &|imp| imp == "github.com/keep");
         assert_eq!(jp.imports, vec!["github.com/keep"]);
+    }
+
+    fn test_opts(go_proxy: Option<&str>) -> GoListOpts<'_> {
+        GoListOpts {
+            tags: &[],
+            mod_root: ".",
+            goos: "",
+            goarch: "",
+            go_proxy,
+            cgo_enabled: "",
+        }
+    }
+
+    fn cmd_env(cmd: &std::process::Command, key: &str) -> Option<String> {
+        cmd.get_envs()
+            .find(|(k, _)| *k == key)
+            .and_then(|(_, v)| v.map(|v| v.to_string_lossy().into_owned()))
+    }
+
+    // One test (not two) because std::env mutation is process-global and the
+    // default cargo test harness runs tests in parallel.
+    #[test]
+    fn configure_go_env_goproxy_netrc_inherit_and_override() {
+        std::env::set_var("GOPROXY", "https://proxy.example/");
+        std::env::set_var("NETRC", "/tmp/netrc-test");
+
+        // No explicit goProxy: inherit from env.
+        let mut cmd = std::process::Command::new("true");
+        configure_go_env(&mut cmd, "/tmp", &test_opts(None));
+        assert_eq!(cmd_env(&cmd, "GOPROXY").as_deref(), Some("https://proxy.example/"));
+        assert_eq!(cmd_env(&cmd, "NETRC").as_deref(), Some("/tmp/netrc-test"));
+
+        // Explicit goProxy: overrides inherited value.
+        let mut cmd = std::process::Command::new("true");
+        configure_go_env(&mut cmd, "/tmp", &test_opts(Some("https://explicit.example/")));
+        assert_eq!(cmd_env(&cmd, "GOPROXY").as_deref(), Some("https://explicit.example/"));
+
+        std::env::remove_var("GOPROXY");
+        std::env::remove_var("NETRC");
     }
 }

--- a/packages/go2nix/default.nix
+++ b/packages/go2nix/default.nix
@@ -14,7 +14,7 @@ buildGoModule {
 
   subPackages = [ "cmd/go2nix" ];
 
-  vendorHash = "sha256-wErO6a+nDSAZvW8UsYJyfbGiwF3IgN4TuEm7Chw3Q4A=";
+  vendorHash = "sha256-rUoUq91b6knN5soMbjgssc1Zi4UuLTprBujhuXrhUVU=";
 
   meta = {
     description = "Go Build — Nix-native Go package compiler";

--- a/tests/nix/fetch_go_module_test.nix
+++ b/tests/nix/fetch_go_module_test.nix
@@ -1,0 +1,28 @@
+# tests/nix/fetch_go_module_test.nix — unit tests for nix/dag/fetch-go-module.nix
+#
+# Run: nix eval -f tests/nix/fetch_go_module_test.nix --impure
+# Returns true on success, throws on failure.
+let
+  pkgs = import <nixpkgs> { };
+  fetcher = pkgs.callPackage ../../nix/dag/fetch-go-module.nix {
+    inherit (pkgs) go;
+    helpers = import ../../nix/helpers.nix;
+    netrcFile = null;
+  };
+  drv = fetcher {
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    fetchPath = "example.com/test/module";
+    version = "v1.0.0";
+  };
+
+  assertElem =
+    name: x: xs:
+    if builtins.elem x xs then
+      true
+    else
+      builtins.throw "${name}: expected ${x} in [${builtins.concatStringsSep ", " xs}]";
+in
+assert assertElem "impureEnvVars has GOPROXY" "GOPROXY" drv.impureEnvVars;
+assert assertElem "impureEnvVars has NETRC" "NETRC" drv.impureEnvVars;
+assert assertElem "impureEnvVars has http_proxy" "http_proxy" drv.impureEnvVars;
+true


### PR DESCRIPTION
Closes #36.

## fetch-go-module.nix

Add `impureEnvVars` (proxy vars + `GOPROXY` + `NETRC`) so the FOD inherits proxy config from the build environment — same pattern as nixpkgs `buildGoModule` (`pkgs/build-support/go/module.nix`). `outputHash` pins the result; this just lets the fetch route through a configured proxy.

`cmd/go` reads `$NETRC` directly (see `cmd/go/internal/auth/netrc.go`: `netrcPath()` checks `$NETRC` before `$HOME/.netrc`), so inheriting the env var is sufficient — no copy step needed. The existing `netrcFile` arg (a Nix path) is unchanged and still works.

## resolve.rs

`configure_go_env` now inherits `GOPROXY` and `NETRC` alongside `GOMODCACHE`/`GOPATH`/`HOME`. Eval-time `go list -deps` previously always defaulted to `proxy.golang.org` because `env_clear()` stripped the host's `GOPROXY`. An explicit `goProxy` arg to `buildGoApplication` still overrides.

## Behavior

- No `GOPROXY` in env → unchanged (`proxy.golang.org,direct`).
- `GOPROXY` in env → both eval and build respect it.
- `NETRC` in env → `go mod download` reads it directly. If sandboxing is enabled, the file must be visible inside the sandbox (e.g. via `extra-sandbox-paths`); a missing file is non-fatal — Go treats `IsNotExist` as no credentials.
- `netrcFile` arg → unchanged, still works.

## Tests

- `tests/nix/fetch_go_module_test.nix` — asserts the FOD's `impureEnvVars` contains `GOPROXY`, `NETRC`, and proxy vars.
- `resolve.rs::configure_go_env_goproxy_netrc_inherit_and_override` — verifies inherit + explicit-override precedence.

Second commit bumps go-nix to `ac2535e` (picks up numtide/go-nix#7's glog/x/net CVE fixes) with the corresponding `vendorHash` update.