### PR TITLE
fix(gofiles): use target toolchain ReleaseTags for build constraint evaluation

### DIFF
--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -71,17 +71,20 @@ List Go source files for a package directory, respecting build tags and
 constraints.
 
 ```
-go2nix list-files [-tags=...] <package-dir>
+go2nix list-files [-tags=...] [-go-version=...] <package-dir>
 ```
 
 Outputs JSON with categorized file lists (Go files, C files, assembly, etc.).
+
+`-go-version` sets the target Go toolchain version (e.g. `1.25`) used to
+evaluate `//go:build go1.N` constraints; defaults to `go env GOVERSION`.
 
 ## list-packages
 
 List all local packages in a Go module with their import dependencies.
 
 ```
-go2nix list-packages [-tags=...] <module-root>
+go2nix list-packages [-tags=...] [-go-version=...] <module-root>
 ```
 
 Outputs JSON with each package's import path and dependencies.

--- a/go/go2nix/cmd/go2nix/goversion.go
+++ b/go/go2nix/cmd/go2nix/goversion.go
@@ -14,9 +14,5 @@ func resolveGoVersion(flagValue string) string {
 	if flagValue != "" {
 		return compile.LangVersion(strings.TrimPrefix(flagValue, "go"))
 	}
-	v := compile.GoEnvVar("GOVERSION")
-	if v == "" {
-		return ""
-	}
-	return compile.LangVersion(strings.TrimPrefix(v, "go"))
+	return compile.ToolchainVersion()
 }

--- a/go/go2nix/cmd/go2nix/goversion.go
+++ b/go/go2nix/cmd/go2nix/goversion.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/numtide/go2nix/pkg/compile"
+)
+
+// resolveGoVersion returns the target Go toolchain major.minor version for
+// build-tag evaluation. If flagValue is non-empty it wins (stripped of any
+// leading "go" and patch component); otherwise it falls back to
+// `go env GOVERSION` from the toolchain on PATH.
+func resolveGoVersion(flagValue string) string {
+	if flagValue != "" {
+		return compile.LangVersion(strings.TrimPrefix(flagValue, "go"))
+	}
+	v := compile.GoEnvVar("GOVERSION")
+	if v == "" {
+		return ""
+	}
+	return compile.LangVersion(strings.TrimPrefix(v, "go"))
+}

--- a/go/go2nix/cmd/go2nix/listfiles.go
+++ b/go/go2nix/cmd/go2nix/listfiles.go
@@ -12,13 +12,14 @@ import (
 func runListFilesCmd(args []string) {
 	fs := flag.NewFlagSet("list-files", flag.ExitOnError)
 	tagsFlag := fs.String("tags", "", "comma-separated build tags")
+	goVersionFlag := fs.String("go-version", "", "target Go toolchain version (e.g. \"1.25\"); defaults to `go env GOVERSION`")
 	_ = fs.Parse(args)
 	if fs.NArg() != 1 {
-		slog.Error("usage: go2nix list-files [-tags=...] <package-dir>")
+		slog.Error("usage: go2nix list-files [-tags=...] [-go-version=...] <package-dir>")
 		os.Exit(1)
 	}
 
-	result, err := gofiles.ListFiles(fs.Arg(0), *tagsFlag)
+	result, err := gofiles.ListFiles(fs.Arg(0), *tagsFlag, resolveGoVersion(*goVersionFlag))
 	if err != nil {
 		slog.Error("list-files failed", "err", err)
 		os.Exit(1)

--- a/go/go2nix/cmd/go2nix/listpkgs.go
+++ b/go/go2nix/cmd/go2nix/listpkgs.go
@@ -12,13 +12,14 @@ import (
 func runListPackagesCmd(args []string) {
 	fs := flag.NewFlagSet("list-packages", flag.ExitOnError)
 	tagsFlag := fs.String("tags", "", "comma-separated build tags")
+	goVersionFlag := fs.String("go-version", "", "target Go toolchain version (e.g. \"1.25\"); defaults to `go env GOVERSION`")
 	_ = fs.Parse(args)
 	if fs.NArg() != 1 {
-		slog.Error("usage: go2nix list-packages [-tags=...] <module-root>")
+		slog.Error("usage: go2nix list-packages [-tags=...] [-go-version=...] <module-root>")
 		os.Exit(1)
 	}
 
-	pkgs, err := localpkgs.ListLocalPackages(fs.Arg(0), *tagsFlag)
+	pkgs, err := localpkgs.ListLocalPackages(fs.Arg(0), *tagsFlag, resolveGoVersion(*goVersionFlag))
 	if err != nil {
 		slog.Error("list-packages failed", "err", err)
 		os.Exit(1)

--- a/go/go2nix/pkg/compile/compile.go
+++ b/go/go2nix/pkg/compile/compile.go
@@ -95,7 +95,10 @@ func CompileGoPackage(opts Options) error {
 		files.EmbedCfg = opts.EmbedCfg
 	} else {
 		var err error
-		files, err = gofiles.ListFiles(opts.SrcDir, opts.Tags)
+		// Pass the toolchain version (not opts.GoVersion, which is the
+		// -lang language version from go.mod) so //go:build go1.N
+		// constraints are evaluated against the actual compiler.
+		files, err = gofiles.ListFiles(opts.SrcDir, opts.Tags, toolchainVersion())
 		if err != nil {
 			return fmt.Errorf("listing files: %w", err)
 		}

--- a/go/go2nix/pkg/compile/compile.go
+++ b/go/go2nix/pkg/compile/compile.go
@@ -98,7 +98,7 @@ func CompileGoPackage(opts Options) error {
 		// Pass the toolchain version (not opts.GoVersion, which is the
 		// -lang language version from go.mod) so //go:build go1.N
 		// constraints are evaluated against the actual compiler.
-		files, err = gofiles.ListFiles(opts.SrcDir, opts.Tags, toolchainVersion())
+		files, err = gofiles.ListFiles(opts.SrcDir, opts.Tags, ToolchainVersion())
 		if err != nil {
 			return fmt.Errorf("listing files: %w", err)
 		}

--- a/go/go2nix/pkg/compile/util.go
+++ b/go/go2nix/pkg/compile/util.go
@@ -158,12 +158,12 @@ func findGoVersion(dir string) string {
 	return ""
 }
 
-// toolchainVersion returns the major.minor version of the Go toolchain
+// ToolchainVersion returns the major.minor version of the Go toolchain
 // that will be invoked for compilation, queried from `go env GOVERSION`
 // (cached for the lifetime of the process). Used to override
 // build.Context.ReleaseTags so file selection matches the target toolchain
 // rather than the Go version that built this binary.
-func toolchainVersion() string {
+func ToolchainVersion() string {
 	v := GoEnvVar("GOVERSION")
 	if v == "" {
 		return ""

--- a/go/go2nix/pkg/compile/util.go
+++ b/go/go2nix/pkg/compile/util.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 
 	"golang.org/x/mod/modfile"
 )
@@ -163,13 +164,13 @@ func findGoVersion(dir string) string {
 // (cached for the lifetime of the process). Used to override
 // build.Context.ReleaseTags so file selection matches the target toolchain
 // rather than the Go version that built this binary.
-func ToolchainVersion() string {
+var ToolchainVersion = sync.OnceValue(func() string {
 	v := GoEnvVar("GOVERSION")
 	if v == "" {
 		return ""
 	}
 	return LangVersion(strings.TrimPrefix(v, "go"))
-}
+})
 
 // LangVersion strips the patch version from a Go version string,
 // matching internal/gover.Lang: "1.21.3" → "1.21", "1.21" → "1.21".

--- a/go/go2nix/pkg/compile/util.go
+++ b/go/go2nix/pkg/compile/util.go
@@ -158,6 +158,19 @@ func findGoVersion(dir string) string {
 	return ""
 }
 
+// toolchainVersion returns the major.minor version of the Go toolchain
+// that will be invoked for compilation, queried from `go env GOVERSION`
+// (cached for the lifetime of the process). Used to override
+// build.Context.ReleaseTags so file selection matches the target toolchain
+// rather than the Go version that built this binary.
+func toolchainVersion() string {
+	v := GoEnvVar("GOVERSION")
+	if v == "" {
+		return ""
+	}
+	return LangVersion(strings.TrimPrefix(v, "go"))
+}
+
 // LangVersion strips the patch version from a Go version string,
 // matching internal/gover.Lang: "1.21.3" → "1.21", "1.21" → "1.21".
 func LangVersion(v string) string {

--- a/go/go2nix/pkg/gofiles/gofiles.go
+++ b/go/go2nix/pkg/gofiles/gofiles.go
@@ -5,6 +5,7 @@ package gofiles
 import (
 	"fmt"
 	"go/build"
+	"go/version"
 	"io/fs"
 	"os"
 	pathpkg "path"
@@ -65,18 +66,23 @@ func BuildContext(tags string, goVersion string) build.Context {
 
 // ReleaseTagsForVersion returns the build.Context.ReleaseTags slice for a
 // given Go version: ["go1.1", "go1.2", ..., "go1.N"]. Accepts "1.25",
-// "1.25.3", "go1.25", or "go1.25.3". Returns nil for an empty or
-// unparseable input so callers can fall back to build.Default.ReleaseTags.
+// "1.25.3", "go1.25", "go1.25.3", or prerelease forms like "go1.26rc1" /
+// "go1.26beta2". Returns nil for an empty or unparseable input so callers
+// can fall back to build.Default.ReleaseTags.
 func ReleaseTagsForVersion(goVersion string) []string {
-	v := strings.TrimPrefix(goVersion, "go")
-	if v == "" {
+	if goVersion == "" {
 		return nil
 	}
-	major, rest, ok := strings.Cut(v, ".")
+	// go/version.Lang canonicalizes "go1.26rc1", "go1.25.3", etc. to
+	// "go1.N". It requires the "go" prefix.
+	if !strings.HasPrefix(goVersion, "go") {
+		goVersion = "go" + goVersion
+	}
+	lang := strings.TrimPrefix(version.Lang(goVersion), "go")
+	major, minorStr, ok := strings.Cut(lang, ".")
 	if !ok || major != "1" {
 		return nil
 	}
-	minorStr, _, _ := strings.Cut(rest, ".")
 	minor, err := strconv.Atoi(minorStr)
 	if err != nil || minor < 1 {
 		return nil

--- a/go/go2nix/pkg/gofiles/gofiles.go
+++ b/go/go2nix/pkg/gofiles/gofiles.go
@@ -10,6 +10,7 @@ import (
 	pathpkg "path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"golang.org/x/mod/module"
@@ -37,8 +38,15 @@ type EmbedCfg struct {
 	Files    map[string]string   `json:"Files"`
 }
 
-// BuildContext returns a build.Context configured from tags and environment.
-func BuildContext(tags string) build.Context {
+// BuildContext returns a build.Context configured from tags, environment,
+// and the target Go toolchain version.
+//
+// goVersion overrides ctx.ReleaseTags so that //go:build go1.N constraints
+// are evaluated against the target toolchain — not against the Go version
+// that built this binary (build.Default.ReleaseTags). Pass "" to leave
+// ReleaseTags at its default; pass "1.25", "1.25.3", or "go1.25" to target
+// Go 1.25.
+func BuildContext(tags string, goVersion string) build.Context {
 	ctx := build.Default
 	if tags != "" {
 		ctx.BuildTags = strings.Split(tags, ",")
@@ -49,7 +57,35 @@ func BuildContext(tags string) build.Context {
 	if v := os.Getenv("GOARCH"); v != "" {
 		ctx.GOARCH = v
 	}
+	if rt := ReleaseTagsForVersion(goVersion); rt != nil {
+		ctx.ReleaseTags = rt
+	}
 	return ctx
+}
+
+// ReleaseTagsForVersion returns the build.Context.ReleaseTags slice for a
+// given Go version: ["go1.1", "go1.2", ..., "go1.N"]. Accepts "1.25",
+// "1.25.3", "go1.25", or "go1.25.3". Returns nil for an empty or
+// unparseable input so callers can fall back to build.Default.ReleaseTags.
+func ReleaseTagsForVersion(goVersion string) []string {
+	v := strings.TrimPrefix(goVersion, "go")
+	if v == "" {
+		return nil
+	}
+	major, rest, ok := strings.Cut(v, ".")
+	if !ok || major != "1" {
+		return nil
+	}
+	minorStr, _, _ := strings.Cut(rest, ".")
+	minor, err := strconv.Atoi(minorStr)
+	if err != nil || minor < 1 {
+		return nil
+	}
+	tags := make([]string, 0, minor)
+	for i := 1; i <= minor; i++ {
+		tags = append(tags, "go1."+strconv.Itoa(i))
+	}
+	return tags
 }
 
 // BuildPkgFiles constructs a PkgFiles from a go/build.Package, resolving
@@ -89,9 +125,10 @@ func BuildPkgFiles(pkg *build.Package, dir string) (PkgFiles, error) {
 	return result, nil
 }
 
-// ListFiles discovers source files in dir using the given build tags.
-func ListFiles(dir string, tags string) (PkgFiles, error) {
-	ctx := BuildContext(tags)
+// ListFiles discovers source files in dir using the given build tags and
+// target Go version. See BuildContext for the meaning of goVersion.
+func ListFiles(dir string, tags string, goVersion string) (PkgFiles, error) {
+	ctx := BuildContext(tags, goVersion)
 	pkg, err := ctx.ImportDir(dir, build.IgnoreVendor)
 	if err != nil {
 		return PkgFiles{}, fmt.Errorf("analysing %s: %w", dir, err)

--- a/go/go2nix/pkg/gofiles/gofiles_test.go
+++ b/go/go2nix/pkg/gofiles/gofiles_test.go
@@ -14,7 +14,7 @@ func TestListFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	files, err := ListFiles(dir, "")
+	files, err := ListFiles(dir, "", "")
 	if err != nil {
 		t.Fatalf("ListFiles: %v", err)
 	}
@@ -27,7 +27,7 @@ func TestListFiles(t *testing.T) {
 }
 
 func TestBuildContextTags(t *testing.T) {
-	ctx := BuildContext("integration,debug")
+	ctx := BuildContext("integration,debug", "")
 	if len(ctx.BuildTags) != 2 {
 		t.Errorf("BuildTags = %v, want [integration debug]", ctx.BuildTags)
 	}
@@ -195,7 +195,7 @@ func TestListFiles_LibraryPackage(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "lib.go"), "package lib\n\nvar X = 1\n")
 
-	files, err := ListFiles(dir, "")
+	files, err := ListFiles(dir, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func TestListFiles_LibraryPackage(t *testing.T) {
 
 func TestListFiles_EmptyDir(t *testing.T) {
 	dir := t.TempDir()
-	_, err := ListFiles(dir, "")
+	_, err := ListFiles(dir, "", "")
 	if err == nil {
 		t.Fatal("expected error for directory with no Go files, got nil")
 	}

--- a/go/go2nix/pkg/gofiles/release_tags_test.go
+++ b/go/go2nix/pkg/gofiles/release_tags_test.go
@@ -83,9 +83,12 @@ func TestReleaseTagsForVersion(t *testing.T) {
 		}
 	}
 
-	// Empty input means "do not override" — return nil so callers fall
-	// back to build.Default.ReleaseTags.
-	if got := ReleaseTagsForVersion(""); got != nil {
-		t.Errorf("ReleaseTagsForVersion(\"\") = %v, want nil", got)
+	// Empty or unparseable input means "do not override" — must return nil
+	// (not an empty slice) so BuildContext falls back to
+	// build.Default.ReleaseTags rather than setting ReleaseTags = []string{}.
+	for _, in := range []string{"", "1", "1.0", "2.0", "garbage", "go"} {
+		if got := ReleaseTagsForVersion(in); got != nil {
+			t.Errorf("ReleaseTagsForVersion(%q) = %v, want nil", in, got)
+		}
 	}
 }

--- a/go/go2nix/pkg/gofiles/release_tags_test.go
+++ b/go/go2nix/pkg/gofiles/release_tags_test.go
@@ -1,0 +1,86 @@
+package gofiles
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// TestListFilesRespectsTargetGoVersion is the regression test for the bug
+// where gofiles.BuildContext used build.Default.ReleaseTags (the Go version
+// that built the go2nix binary) instead of the target toolchain's version,
+// causing //go:build go1.N constraints to be evaluated against the wrong
+// release tags.
+//
+// Repro from the bug report: a package with two version-gated files. When
+// asked to list files for go1.25, only the !go1.26 file must be selected,
+// regardless of which Go version built this test binary.
+func TestListFilesRespectsTargetGoVersion(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(name, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write("base.go", "package p\n\nfunc Base() int { return 1 }\n")
+	write("config_go125.go", "//go:build !go1.26\n\npackage p\n\nfunc Versioned() int { return 125 }\n")
+	write("config_go126.go", "//go:build go1.26\n\npackage p\n\nfunc Versioned() int { return 126 }\n")
+
+	// Target Go 1.25: must select base.go + config_go125.go, never config_go126.go.
+	files, err := ListFiles(dir, "", "1.25")
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+
+	want := []string{"base.go", "config_go125.go"}
+	got := append([]string(nil), files.GoFiles...)
+	slices.Sort(got)
+	if !slices.Equal(got, want) {
+		t.Errorf("GoFiles for go1.25 target = %v, want %v", got, want)
+	}
+
+	// Target Go 1.26: should now flip to selecting config_go126.go.
+	files, err = ListFiles(dir, "", "1.26")
+	if err != nil {
+		t.Fatalf("ListFiles go1.26: %v", err)
+	}
+	want = []string{"base.go", "config_go126.go"}
+	got = append([]string(nil), files.GoFiles...)
+	slices.Sort(got)
+	if !slices.Equal(got, want) {
+		t.Errorf("GoFiles for go1.26 target = %v, want %v", got, want)
+	}
+}
+
+func TestReleaseTagsForVersion(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantLen int // number of "go1.N" tags
+		last    string
+	}{
+		{"1.25", 25, "go1.25"},
+		{"1.25.3", 25, "go1.25"},
+		{"go1.25", 25, "go1.25"},
+		{"go1.25.3", 25, "go1.25"},
+		{"1.1", 1, "go1.1"},
+	}
+	for _, tc := range cases {
+		got := ReleaseTagsForVersion(tc.in)
+		if len(got) != tc.wantLen {
+			t.Errorf("ReleaseTagsForVersion(%q) len = %d, want %d (%v)", tc.in, len(got), tc.wantLen, got)
+		}
+		if len(got) > 0 && got[len(got)-1] != tc.last {
+			t.Errorf("ReleaseTagsForVersion(%q) last = %q, want %q", tc.in, got[len(got)-1], tc.last)
+		}
+	}
+
+	// Empty input means "do not override" — return nil so callers fall
+	// back to build.Default.ReleaseTags.
+	if got := ReleaseTagsForVersion(""); got != nil {
+		t.Errorf("ReleaseTagsForVersion(\"\") = %v, want nil", got)
+	}
+}

--- a/go/go2nix/pkg/gofiles/release_tags_test.go
+++ b/go/go2nix/pkg/gofiles/release_tags_test.go
@@ -67,6 +67,11 @@ func TestReleaseTagsForVersion(t *testing.T) {
 		{"go1.25", 25, "go1.25"},
 		{"go1.25.3", 25, "go1.25"},
 		{"1.1", 1, "go1.1"},
+		// Prerelease toolchains: `go env GOVERSION` returns e.g.
+		// "go1.26rc1" with no dot before the suffix.
+		{"go1.26rc1", 26, "go1.26"},
+		{"go1.26beta2", 26, "go1.26"},
+		{"1.26rc1", 26, "go1.26"},
 	}
 	for _, tc := range cases {
 		got := ReleaseTagsForVersion(tc.in)

--- a/go/go2nix/pkg/localpkgs/localpkgs.go
+++ b/go/go2nix/pkg/localpkgs/localpkgs.go
@@ -36,7 +36,10 @@ type LocalPkg struct {
 
 // ListLocalPackages discovers all local packages under root (the directory
 // containing go.mod) and returns them in topological dependency order.
-func ListLocalPackages(root string, tags string) ([]*LocalPkg, error) {
+//
+// goVersion is the target Go toolchain version (e.g. "1.25"); see
+// gofiles.BuildContext for the meaning. Pass "" to use build.Default.
+func ListLocalPackages(root string, tags string, goVersion string) ([]*LocalPkg, error) {
 	goModData, err := os.ReadFile(filepath.Join(root, "go.mod"))
 	if err != nil {
 		return nil, fmt.Errorf("reading go.mod: %w", err)
@@ -59,7 +62,7 @@ func ListLocalPackages(root string, tags string) ([]*LocalPkg, error) {
 		}
 	}
 
-	ctx := gofiles.BuildContext(tags)
+	ctx := gofiles.BuildContext(tags, goVersion)
 	pkgs := map[string]*LocalPkg{}
 	localDeps := map[string][]string{}
 

--- a/go/go2nix/pkg/localpkgs/localpkgs_test.go
+++ b/go/go2nix/pkg/localpkgs/localpkgs_test.go
@@ -177,7 +177,7 @@ func TestListLocalPackages_Basic(t *testing.T) {
 	writeFile(t, filepath.Join(root, "main.go"), "package main\n\nimport \"example.com/test/lib\"\n\nvar _ = lib.X\n\nfunc main() {}\n")
 	writeFile(t, filepath.Join(root, "lib", "lib.go"), "package lib\n\nvar X = 1\n")
 
-	pkgs, err := ListLocalPackages(root, "")
+	pkgs, err := ListLocalPackages(root, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,7 +207,7 @@ func TestListLocalPackages_SkipsVendorAndTestdata(t *testing.T) {
 	writeFile(t, filepath.Join(root, "testdata", "t.go"), "package testdata\n")
 	writeFile(t, filepath.Join(root, "_hidden", "h.go"), "package hidden\n")
 
-	pkgs, err := ListLocalPackages(root, "")
+	pkgs, err := ListLocalPackages(root, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func TestListLocalPackages_SkipsVendorAndTestdata(t *testing.T) {
 
 func TestListLocalPackages_NoGoMod(t *testing.T) {
 	root := t.TempDir()
-	_, err := ListLocalPackages(root, "")
+	_, err := ListLocalPackages(root, "", "")
 	if err == nil {
 		t.Fatal("expected error for missing go.mod, got nil")
 	}
@@ -267,7 +267,7 @@ func TestAdd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pkgs, err := ListLocalPackages(dir, "")
+	pkgs, err := ListLocalPackages(dir, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/go2nix/pkg/testrunner/testrunner.go
+++ b/go/go2nix/pkg/testrunner/testrunner.go
@@ -40,7 +40,7 @@ func (o Options) checkFlagsArgs() []string {
 
 // Run discovers testable packages and runs their tests.
 func Run(opts Options) error {
-	pkgs, err := localpkgs.ListLocalPackages(opts.ModuleRoot, opts.Tags, compile.LangVersion(strings.TrimPrefix(compile.GoEnvVar("GOVERSION"), "go")))
+	pkgs, err := localpkgs.ListLocalPackages(opts.ModuleRoot, opts.Tags, compile.ToolchainVersion())
 	if err != nil {
 		return fmt.Errorf("listing local packages: %w", err)
 	}

--- a/go/go2nix/pkg/testrunner/testrunner.go
+++ b/go/go2nix/pkg/testrunner/testrunner.go
@@ -40,7 +40,7 @@ func (o Options) checkFlagsArgs() []string {
 
 // Run discovers testable packages and runs their tests.
 func Run(opts Options) error {
-	pkgs, err := localpkgs.ListLocalPackages(opts.ModuleRoot, opts.Tags)
+	pkgs, err := localpkgs.ListLocalPackages(opts.ModuleRoot, opts.Tags, compile.LangVersion(strings.TrimPrefix(compile.GoEnvVar("GOVERSION"), "go")))
 	if err != nil {
 		return fmt.Errorf("listing local packages: %w", err)
 	}


### PR DESCRIPTION
## Summary

`gofiles.BuildContext` started from `build.Default` and never overrode `ctx.ReleaseTags`, so `//go:build go1.N` constraints were evaluated against **the Go version that built the go2nix binary** rather than the target toolchain.

When go2nix was built with Go 1.26 and pointed at a Go 1.25 toolchain, file discovery selected `go1.26`-only files and the actual compile then failed with `file requires newer Go version go1.26`. Observed in the wild on `golang.org/x/net/http2` (and any package that gates files by `//go:build go1.N` / `!go1.N`).

The bug has existed since `pkg/gofiles` was first introduced; it only became reachable in practice once Go 1.26 shipped and downstream modules started gating on it.

## Fix

`BuildContext` and `ListFiles` now take an explicit target Go version, used to derive `ReleaseTags = ["go1.1", ..., "go1.N"]`. The toolchain version is queried once from `go env GOVERSION` of the `go` binary on `PATH` — the authoritative source for what will actually compile — and **not** from the `-lang` directive in `go.mod` (which is the *language* version, a different thing the bug report rightly flagged).

All five buggy call sites are fixed:

- `pkg/compile.CompileGoPackage` feeds `toolchainVersion()` into `ListFiles`
- `pkg/localpkgs.ListLocalPackages` takes `goVersion` and threads it through
- `pkg/testrunner` passes the toolchain version to `ListLocalPackages`
- `cmd/go2nix list-files` and `list-packages` get a `--go-version` flag (defaults to `go env GOVERSION`)

## Regression test

`pkg/gofiles/release_tags_test.go` reproduces the report's minimal repro: a package with `config_go125.go` (`//go:build !go1.26`) and `config_go126.go` (`//go:build go1.26`). It asserts both directions — targeting `1.25` selects only the `!go1.26` file, targeting `1.26` flips to the `go1.26` file — regardless of which Go built the test binary. There's also a unit test for `ReleaseTagsForVersion`.

## Out of scope (follow-up)

There is a deeper design smell: `compile-package` re-discovers files independently of graph discovery (which uses `go list` and is already correct). The structurally cleaner fix would be to plumb the resolved file set from the Rust plugin through the compile manifest so `compile-package` never re-runs discovery. That's a much larger change spanning Rust + Nix + Go and a manifest schema bump, and it doesn't help the `list-files` / `localpkgs` CLI paths either. Worth doing as a follow-up; this PR closes the correctness bug end-to-end with a small, targeted change.

## Test plan

- [x] `go test ./...` in `go/go2nix` — all packages green
- [x] `go vet ./...` clean
- [x] New regression test fails on `main`, passes with this change
- [ ] Build go2nix with Go 1.26, point at a Go 1.25 toolchain, build a project that depends on `golang.org/x/net/http2`.