### PR TITLE
dag: feed go-list file lists through the compile manifest

### DIFF
--- a/go/go2nix/cmd/go2nix/compile.go
+++ b/go/go2nix/cmd/go2nix/compile.go
@@ -64,6 +64,15 @@ func runCompilePackageCmd(args []string) {
 		PGOProfile:  pgo,
 	}
 
+	if m.Files != nil {
+		pf, err := m.Files.ToPkgFiles(*srcDir)
+		if err != nil {
+			slog.Error("compile-package: failed to resolve manifest files", "err", err)
+			os.Exit(1)
+		}
+		opts.Files = pf
+	}
+
 	if err := compile.CompileGoPackage(opts); err != nil {
 		slog.Error("compile-package failed", "err", err, "pkg", *importPath)
 		os.Exit(1)

--- a/go/go2nix/pkg/compile/compile.go
+++ b/go/go2nix/pkg/compile/compile.go
@@ -26,8 +26,7 @@ type Options struct {
 	GCFlagsList []string          // extra flags for go tool compile
 	GoVersion   string            // Go language version for -lang flag (e.g., "1.21"); auto-detected from go.mod if empty
 	PGOProfile  string            // path to pprof CPU profile for PGO; empty disables PGO
-	GoFiles     []string          // explicit Go files to compile (bypasses ListFiles discovery; paths relative to SrcDir)
-	EmbedCfg    *gofiles.EmbedCfg // explicit embed config (used with GoFiles to pass pre-resolved embed metadata)
+	Files       *gofiles.PkgFiles // explicit file lists (bypasses ListFiles discovery; paths relative to SrcDir)
 
 	// Resolved once by CompilePackage; avoids repeated go env subprocesses.
 	goroot        string
@@ -88,11 +87,8 @@ func CompileGoPackage(opts Options) error {
 	slog.Debug("compile-package", "import-path", opts.ImportPath, "src", opts.SrcDir)
 
 	var files gofiles.PkgFiles
-	if len(opts.GoFiles) > 0 {
-		// Explicit file list (used by test runner for _test.go files that
-		// go/build.ImportDir would place in TestGoFiles, not GoFiles).
-		files.GoFiles = opts.GoFiles
-		files.EmbedCfg = opts.EmbedCfg
+	if opts.Files != nil {
+		files = *opts.Files
 	} else {
 		var err error
 		// Pass the toolchain version (not opts.GoVersion, which is the

--- a/go/go2nix/pkg/compile/manifest.go
+++ b/go/go2nix/pkg/compile/manifest.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+
+	"github.com/numtide/go2nix/pkg/gofiles"
 )
 
 const (
@@ -25,12 +28,60 @@ const (
 // CompileManifest is the JSON contract between Nix and go2nix compile-package.
 // Written by Nix at eval time via builtins.toFile, read by Go at build time.
 type CompileManifest struct {
-	Version        int      `json:"version"`
-	Kind           string   `json:"kind"`
-	ImportcfgParts []string `json:"importcfgParts"`
-	Tags           []string `json:"tags"`
-	GCFlags        []string `json:"gcflags"`
-	PGOProfile     *string  `json:"pgoProfile"`
+	Version        int            `json:"version"`
+	Kind           string         `json:"kind"`
+	ImportcfgParts []string       `json:"importcfgParts"`
+	Tags           []string       `json:"tags"`
+	GCFlags        []string       `json:"gcflags"`
+	PGOProfile     *string        `json:"pgoProfile"`
+	Files          *ManifestFiles `json:"files,omitempty"`
+}
+
+// ManifestFiles is the per-package file list discovered at eval time by
+// `go list` (via the resolveGoPackages plugin). When present,
+// compile-package uses it directly instead of re-running file discovery
+// with go/build.ImportDir at build time.
+type ManifestFiles struct {
+	GoFiles       []string `json:"goFiles,omitempty"`
+	CgoFiles      []string `json:"cgoFiles,omitempty"`
+	SFiles        []string `json:"sFiles,omitempty"`
+	CFiles        []string `json:"cFiles,omitempty"`
+	CXXFiles      []string `json:"cxxFiles,omitempty"`
+	FFiles        []string `json:"fFiles,omitempty"`
+	HFiles        []string `json:"hFiles,omitempty"`
+	SysoFiles     []string `json:"sysoFiles,omitempty"`
+	EmbedPatterns []string `json:"embedPatterns,omitempty"`
+}
+
+// ToPkgFiles converts a ManifestFiles into a gofiles.PkgFiles. Embed
+// patterns are resolved against srcDir at build time so the resulting
+// EmbedCfg paths point into the realised store path rather than eval-time
+// paths.
+func (mf *ManifestFiles) ToPkgFiles(srcDir string) (*gofiles.PkgFiles, error) {
+	pf := &gofiles.PkgFiles{
+		GoFiles:   mf.GoFiles,
+		CgoFiles:  mf.CgoFiles,
+		SFiles:    mf.SFiles,
+		CFiles:    mf.CFiles,
+		CXXFiles:  mf.CXXFiles,
+		FFiles:    mf.FFiles,
+		HFiles:    mf.HFiles,
+		SysoFiles: mf.SysoFiles,
+	}
+	if len(mf.EmbedPatterns) > 0 {
+		cfg, err := gofiles.ResolveEmbedCfg(srcDir, mf.EmbedPatterns)
+		if err != nil {
+			return nil, fmt.Errorf("resolving embed patterns: %w", err)
+		}
+		pf.EmbedCfg = cfg
+		embedFiles := make([]string, 0, len(cfg.Files))
+		for f := range cfg.Files {
+			embedFiles = append(embedFiles, f)
+		}
+		sort.Strings(embedFiles)
+		pf.EmbedFiles = embedFiles
+	}
+	return pf, nil
 }
 
 // LoadCompileManifest reads and validates a compile manifest from path.

--- a/go/go2nix/pkg/compile/manifest_test.go
+++ b/go/go2nix/pkg/compile/manifest_test.go
@@ -3,6 +3,7 @@ package compile
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -90,6 +91,106 @@ func TestLoadCompileManifest_fields(t *testing.T) {
 	}
 	if m.PGOProfile == nil || *m.PGOProfile != "/pgo" {
 		t.Errorf("pgoProfile = %v", m.PGOProfile)
+	}
+}
+
+func TestLoadCompileManifest_filesOmitted(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "manifest.json")
+	json := `{"version":1,"kind":"compile","importcfgParts":[],"tags":[],"gcflags":[],"pgoProfile":null}`
+	if err := os.WriteFile(path, []byte(json), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := LoadCompileManifest(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Files != nil {
+		t.Errorf("files should be nil when absent, got %+v", m.Files)
+	}
+}
+
+func TestLoadCompileManifest_files(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "manifest.json")
+	json := `{"version":1,"kind":"compile","importcfgParts":[],"tags":[],"gcflags":[],"pgoProfile":null,` +
+		`"files":{"goFiles":["a.go","b.go"],"cgoFiles":["c.go"],"sFiles":["asm_amd64.s"],` +
+		`"hFiles":["x.h"],"embedPatterns":["data/*.txt"]}}`
+	if err := os.WriteFile(path, []byte(json), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := LoadCompileManifest(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Files == nil {
+		t.Fatal("files = nil, want non-nil")
+	}
+	if !slices.Equal(m.Files.GoFiles, []string{"a.go", "b.go"}) {
+		t.Errorf("goFiles = %v", m.Files.GoFiles)
+	}
+	if !slices.Equal(m.Files.CgoFiles, []string{"c.go"}) {
+		t.Errorf("cgoFiles = %v", m.Files.CgoFiles)
+	}
+	if !slices.Equal(m.Files.SFiles, []string{"asm_amd64.s"}) {
+		t.Errorf("sFiles = %v", m.Files.SFiles)
+	}
+	if !slices.Equal(m.Files.HFiles, []string{"x.h"}) {
+		t.Errorf("hFiles = %v", m.Files.HFiles)
+	}
+	if !slices.Equal(m.Files.EmbedPatterns, []string{"data/*.txt"}) {
+		t.Errorf("embedPatterns = %v", m.Files.EmbedPatterns)
+	}
+}
+
+func TestManifestFilesToPkgFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"data/a.txt", "data/b.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mf := &ManifestFiles{
+		GoFiles:       []string{"main.go"},
+		CgoFiles:      []string{"c.go"},
+		SFiles:        []string{"asm.s"},
+		EmbedPatterns: []string{"data/*.txt"},
+	}
+	pf, err := mf.ToPkgFiles(dir)
+	if err != nil {
+		t.Fatalf("ToPkgFiles: %v", err)
+	}
+
+	if !slices.Equal(pf.GoFiles, []string{"main.go"}) {
+		t.Errorf("GoFiles = %v", pf.GoFiles)
+	}
+	if !slices.Equal(pf.CgoFiles, []string{"c.go"}) {
+		t.Errorf("CgoFiles = %v", pf.CgoFiles)
+	}
+	if !slices.Equal(pf.SFiles, []string{"asm.s"}) {
+		t.Errorf("SFiles = %v", pf.SFiles)
+	}
+	if pf.EmbedCfg == nil {
+		t.Fatal("EmbedCfg = nil, want resolved config")
+	}
+	if !slices.Equal(pf.EmbedFiles, []string{"data/a.txt", "data/b.txt"}) {
+		t.Errorf("EmbedFiles = %v", pf.EmbedFiles)
+	}
+	got := pf.EmbedCfg.Patterns["data/*.txt"]
+	if !slices.Equal(got, []string{"data/a.txt", "data/b.txt"}) {
+		t.Errorf("EmbedCfg.Patterns[data/*.txt] = %v", got)
+	}
+
+	// No embed patterns → no resolution, EmbedCfg stays nil.
+	mf2 := &ManifestFiles{GoFiles: []string{"x.go"}}
+	pf2, err := mf2.ToPkgFiles(dir)
+	if err != nil {
+		t.Fatalf("ToPkgFiles (no embed): %v", err)
+	}
+	if pf2.EmbedCfg != nil || len(pf2.EmbedFiles) != 0 {
+		t.Errorf("expected no embed data, got cfg=%v files=%v", pf2.EmbedCfg, pf2.EmbedFiles)
 	}
 }
 

--- a/go/go2nix/pkg/testrunner/testrunner.go
+++ b/go/go2nix/pkg/testrunner/testrunner.go
@@ -245,8 +245,7 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 			TrimPath:    opts.TrimPath,
 			Tags:        opts.Tags,
 			GCFlagsList: opts.GCFlagsList,
-			GoFiles:     goFiles,
-			EmbedCfg:    mergedEmbedCfg,
+			Files:       &gofiles.PkgFiles{GoFiles: goFiles, EmbedCfg: mergedEmbedCfg},
 		}); err != nil {
 			return fmt.Errorf("compiling internal test: %w", err)
 		}
@@ -344,8 +343,7 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 			TrimPath:    opts.TrimPath,
 			Tags:        opts.Tags,
 			GCFlagsList: opts.GCFlagsList,
-			GoFiles:     pkg.XTestGoFiles,
-			EmbedCfg:    pkg.XTestEmbedCfg,
+			Files:       &gofiles.PkgFiles{GoFiles: pkg.XTestGoFiles, EmbedCfg: pkg.XTestEmbedCfg},
 		}); err != nil {
 			return fmt.Errorf("compiling external test: %w", err)
 		}
@@ -390,7 +388,7 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 		TrimPath:    opts.TrimPath,
 		Tags:        opts.Tags,
 		GCFlagsList: opts.GCFlagsList,
-		GoFiles:     []string{"_testmain.go"},
+		Files:       &gofiles.PkgFiles{GoFiles: []string{"_testmain.go"}},
 	}); err != nil {
 		return fmt.Errorf("compiling test main: %w", err)
 	}

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -200,19 +200,25 @@ let
   # references store paths of other derivations. The shell hook writes
   # it to a file before invoking go2nix.
   mkCompileManifestJSON =
-    deps:
-    builtins.toJSON {
-      version = 1;
-      kind = "compile";
-      importcfgParts = [ "${stdlib}/importcfg" ] ++ map depCompileCfg deps;
-      inherit tags;
-      gcflags =
-        let
-          base = gcflags;
-        in
-        if buildMode == "pie" then [ "-shared" ] ++ base else base;
-      pgoProfile = if pgoProfile != null then "${pgoProfile}" else null;
-    };
+    {
+      deps,
+      files,
+    }:
+    builtins.toJSON (
+      {
+        version = 1;
+        kind = "compile";
+        importcfgParts = [ "${stdlib}/importcfg" ] ++ map depCompileCfg deps;
+        inherit tags;
+        gcflags =
+          let
+            base = gcflags;
+          in
+          if buildMode == "pie" then [ "-shared" ] ++ base else base;
+        pgoProfile = if pgoProfile != null then "${pgoProfile}" else null;
+      }
+      // (if files != null then { inherit files; } else { })
+    );
 
   # Env attrset for per-package compile derivations. goEnv is the scope-level
   # base; the hook-required keys overlay it; packageOverrides.<pkg>.env wins.
@@ -222,12 +228,13 @@ let
       srcDir,
       deps,
       extraEnv,
+      files ? null,
     }:
     goEnv
     // {
       goPackagePath = importPath;
       goPackageSrcDir = srcDir;
-      compileManifestJSON = mkCompileManifestJSON deps;
+      compileManifestJSON = mkCompileManifestJSON { inherit deps files; };
     }
     // extraEnv;
 
@@ -294,8 +301,14 @@ let
         ;
       subPackages = normalizedSubPackages;
       resolveHashes = !hasLockfile;
+      # File lists in the manifest are computed at eval time by `go list`;
+      # pass the same target platform here that the build derivations will
+      # use so constraint evaluation matches.
+      goos = stdenv.hostPlatform.go.GOOS;
+      goarch = stdenv.hostPlatform.go.GOARCH;
     }
     // (if goProxy != null then { inherit goProxy; } else { })
+    // (if CGO_ENABLED != null then { cgoEnabled = toString CGO_ENABLED; } else { })
   );
 
   # Module hashes from plugin (lockfile-free path).
@@ -384,6 +397,7 @@ let
           deps
           extraEnv
           ;
+        files = pkg.files or null;
       };
     }
   ) goPackagesResult.packages;
@@ -493,6 +507,7 @@ let
           deps
           extraEnv
           ;
+        files = pkg.files or null;
       };
     }
   ) goPackagesResult.localPackages;
@@ -602,6 +617,7 @@ let
             deps
             extraEnv
             ;
+          files = pkg.files or null;
         };
       }
     ) goPackagesResult.testPackages

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -133,13 +133,12 @@ let
     export NIX_BUILD_TOP="$TMPDIR"
     export HOME="$TMPDIR/home"; mkdir -p "$HOME"
     export GOPROXY=off GOSUMDB=off GONOSUMCHECK='*'
-    echo "$compileManifestJSON" > "$TMPDIR/m.json"
     mkdir -p "$out/$(dirname "$goPackagePath")"
     if [ -n "''${iface:-}" ]; then
       mkdir -p "$iface/$(dirname "$goPackagePath")"
       exec "$go2nixBin" \
         compile-package \
-        --manifest "$TMPDIR/m.json" \
+        --manifest "$compileManifestJSONPath" \
         --import-path "$goPackagePath" \
         --src-dir "$goPackageSrcDir" \
         --output "$out/$goPackagePath.a" \
@@ -149,7 +148,7 @@ let
     else
       exec "$go2nixBin" \
         compile-package \
-        --manifest "$TMPDIR/m.json" \
+        --manifest "$compileManifestJSONPath" \
         --import-path "$goPackagePath" \
         --src-dir "$goPackageSrcDir" \
         --output "$out/$goPackagePath.a" \
@@ -184,6 +183,11 @@ let
         inherit (stdenv.hostPlatform) system;
         builder = "${bash}/bin/bash";
         args = [ rawGoCompileScript ];
+        # compileManifestJSON now carries per-file lists; pass it via a
+        # temp file so packages with thousands of source files don't risk
+        # MAX_ARG_STRLEN. (The stdenv/cgo path already avoids this via
+        # __structuredAttrs.)
+        passAsFile = [ "compileManifestJSON" ];
         goPath = "${coreutils}/bin:${go}/bin";
         go2nixBin = "${go2nix}/bin/go2nix";
       }
@@ -304,8 +308,8 @@ let
       # File lists in the manifest are computed at eval time by `go list`;
       # pass the same target platform here that the build derivations will
       # use so constraint evaluation matches.
-      goos = stdenv.hostPlatform.go.GOOS;
-      goarch = stdenv.hostPlatform.go.GOARCH;
+      goos = stdenv.hostPlatform.go.GOOS or null;
+      goarch = stdenv.hostPlatform.go.GOARCH or null;
     }
     // (if goProxy != null then { inherit goProxy; } else { })
     // (if CGO_ENABLED != null then { cgoEnabled = toString CGO_ENABLED; } else { })

--- a/packages/go2nix-nix-plugin/rust/src/resolve.rs
+++ b/packages/go2nix-nix-plugin/rust/src/resolve.rs
@@ -41,8 +41,24 @@ struct GoPackage {
     module: Option<GoModule>,
     #[serde(rename = "Imports")]
     imports: Vec<String>,
+    #[serde(rename = "GoFiles")]
+    go_files: Vec<String>,
     #[serde(rename = "CgoFiles")]
     cgo_files: Vec<String>,
+    #[serde(rename = "SFiles")]
+    s_files: Vec<String>,
+    #[serde(rename = "CFiles")]
+    c_files: Vec<String>,
+    #[serde(rename = "CXXFiles")]
+    cxx_files: Vec<String>,
+    #[serde(rename = "FFiles")]
+    f_files: Vec<String>,
+    #[serde(rename = "HFiles")]
+    h_files: Vec<String>,
+    #[serde(rename = "SysoFiles")]
+    syso_files: Vec<String>,
+    #[serde(rename = "EmbedPatterns")]
+    embed_patterns: Vec<String>,
     #[serde(rename = "CgoPkgConfig")]
     cgo_pkg_config: Vec<String>,
     #[serde(rename = "CgoCFLAGS")]
@@ -74,6 +90,7 @@ pub(crate) struct PkgData {
     cgo_cflags: Vec<String>,
     cgo_ldflags: Vec<String>,
     is_cgo: bool,
+    files: PkgFiles,
 }
 
 struct LocalPkgData {
@@ -85,6 +102,60 @@ struct LocalPkgData {
     cgo_cflags: Vec<String>,
     cgo_ldflags: Vec<String>,
     is_cgo: bool,
+    files: PkgFiles,
+}
+
+/// Per-package source file lists as reported by `go list`, threaded through
+/// to the compile manifest so build-time can skip its own discovery pass.
+#[derive(Clone, Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PkgFiles {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    go_files: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    cgo_files: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    s_files: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    c_files: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    cxx_files: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    f_files: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    h_files: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    syso_files: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    embed_patterns: Vec<String>,
+}
+
+impl PkgFiles {
+    fn is_empty(&self) -> bool {
+        self.go_files.is_empty()
+            && self.cgo_files.is_empty()
+            && self.s_files.is_empty()
+            && self.c_files.is_empty()
+            && self.cxx_files.is_empty()
+            && self.f_files.is_empty()
+            && self.h_files.is_empty()
+            && self.syso_files.is_empty()
+            && self.embed_patterns.is_empty()
+    }
+}
+
+fn pkg_files_from(p: &GoPackage) -> PkgFiles {
+    PkgFiles {
+        go_files: p.go_files.clone(),
+        cgo_files: p.cgo_files.clone(),
+        s_files: p.s_files.clone(),
+        c_files: p.c_files.clone(),
+        cxx_files: p.cxx_files.clone(),
+        f_files: p.f_files.clone(),
+        h_files: p.h_files.clone(),
+        syso_files: p.syso_files.clone(),
+        embed_patterns: p.embed_patterns.clone(),
+    }
 }
 
 fn sanitize_name(s: &str) -> String {
@@ -191,7 +262,7 @@ fn run_go_list(
 ) -> Result<Vec<u8>> {
     let mut cmd = Command::new(go_bin);
     cmd.arg("list");
-    cmd.arg("-json=ImportPath,Dir,Module,Imports,CgoFiles,CgoPkgConfig,CgoCFLAGS,CgoLDFLAGS,Error");
+    cmd.arg("-json=ImportPath,Dir,Module,Imports,GoFiles,CgoFiles,SFiles,CFiles,CXXFiles,FFiles,HFiles,SysoFiles,EmbedPatterns,CgoPkgConfig,CgoCFLAGS,CgoLDFLAGS,Error");
     cmd.arg("-deps");
     cmd.arg("-e");
     cmd.arg("-buildvcs=false");
@@ -230,7 +301,7 @@ fn run_go_list_test(
 ) -> Result<Vec<u8>> {
     let mut cmd = Command::new(go_bin);
     cmd.arg("list");
-    cmd.arg("-json=ImportPath,Module,Imports,CgoFiles,CgoPkgConfig,CgoCFLAGS,CgoLDFLAGS,Error");
+    cmd.arg("-json=ImportPath,Module,Imports,GoFiles,CgoFiles,SFiles,CFiles,CXXFiles,FFiles,HFiles,SysoFiles,EmbedPatterns,CgoPkgConfig,CgoCFLAGS,CgoLDFLAGS,Error");
     cmd.arg("-deps");
     cmd.arg("-test");
     cmd.arg("-e");
@@ -282,16 +353,18 @@ pub(crate) fn parse_test_packages(
             }
         }
 
-        // Skip stdlib (no module).
-        let Some(module) = jpkg.module else {
-            continue;
-        };
-
         // Skip synthetic test packages: test mains (foo.test) and
         // recompiled variants (foo [foo.test]).
         if jpkg.import_path.contains('[') || jpkg.import_path.ends_with(".test") {
             continue;
         }
+
+        let files = pkg_files_from(&jpkg);
+
+        // Skip stdlib (no module).
+        let Some(module) = jpkg.module else {
+            continue;
+        };
 
         let (replace_path, replace_version) = extract_replace(&module);
 
@@ -334,6 +407,7 @@ pub(crate) fn parse_test_packages(
             cgo_cflags: jpkg.cgo_cflags,
             cgo_ldflags: jpkg.cgo_ldflags,
             is_cgo: !jpkg.cgo_files.is_empty(),
+            files,
         });
     }
 
@@ -384,6 +458,7 @@ pub(crate) fn parse_go_packages(stdout: &[u8]) -> Result<PackageGraph> {
         cgo_cflags: Vec<String>,
         cgo_ldflags: Vec<String>,
         is_cgo: bool,
+        files: PkgFiles,
     }
     let mut raw_local_pkgs: Vec<RawLocalPkg> = Vec::new();
 
@@ -396,6 +471,8 @@ pub(crate) fn parse_go_packages(stdout: &[u8]) -> Result<PackageGraph> {
                 continue;
             }
         }
+
+        let files = pkg_files_from(&jpkg);
 
         // stdlib packages have no module
         let Some(module) = jpkg.module else {
@@ -423,6 +500,7 @@ pub(crate) fn parse_go_packages(stdout: &[u8]) -> Result<PackageGraph> {
                 cgo_cflags: jpkg.cgo_cflags,
                 cgo_ldflags: jpkg.cgo_ldflags,
                 is_cgo: !jpkg.cgo_files.is_empty(),
+                files,
             });
 
             continue;
@@ -452,6 +530,7 @@ pub(crate) fn parse_go_packages(stdout: &[u8]) -> Result<PackageGraph> {
             cgo_cflags: jpkg.cgo_cflags,
             cgo_ldflags: jpkg.cgo_ldflags,
             is_cgo: !jpkg.cgo_files.is_empty(),
+            files,
         });
     }
 
@@ -489,6 +568,7 @@ pub(crate) fn parse_go_packages(stdout: &[u8]) -> Result<PackageGraph> {
                 cgo_cflags: raw.cgo_cflags,
                 cgo_ldflags: raw.cgo_ldflags,
                 is_cgo: raw.is_cgo,
+                files: raw.files,
             }
         })
         .collect();
@@ -543,7 +623,6 @@ fn default_sub_packages() -> Vec<String> {
 fn default_dot() -> String {
     ".".to_owned()
 }
-
 
 /// Query `go env GOMODCACHE` to find the module cache directory.
 pub(crate) fn find_gomodcache(go_bin: &str) -> Result<std::path::PathBuf> {
@@ -609,8 +688,7 @@ pub(crate) fn resolve_packages(input: &JsonInput) -> Result<PackageGraph> {
             .map(|p| p.import_path.clone())
             .collect();
 
-        let test_stdout =
-            run_go_list_test(go_bin, &input.src, &local_ips, &opts)?;
+        let test_stdout = run_go_list_test(go_bin, &input.src, &local_ips, &opts)?;
 
         let test_pkgs = parse_test_packages(
             &test_stdout,
@@ -642,6 +720,8 @@ struct JsonLocalPkg {
     cgo_cflags: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     cgo_ldflags: Vec<String>,
+    #[serde(skip_serializing_if = "PkgFiles::is_empty")]
+    files: PkgFiles,
 }
 
 #[derive(Serialize)]
@@ -673,6 +753,8 @@ struct JsonPkg {
     cgo_cflags: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     cgo_ldflags: Vec<String>,
+    #[serde(skip_serializing_if = "PkgFiles::is_empty")]
+    files: PkgFiles,
 }
 
 #[derive(Serialize)]
@@ -713,6 +795,7 @@ fn pkg_data_to_json_pkg(p: &PkgData, allowed_imports: &dyn Fn(&str) -> bool) -> 
         cgo_pkg_config: p.cgo_pkg_config.clone(),
         cgo_cflags: p.cgo_cflags.clone(),
         cgo_ldflags: p.cgo_ldflags.clone(),
+        files: p.files.clone(),
     }
 }
 
@@ -763,6 +846,7 @@ pub(crate) fn package_graph_to_json(
                 cgo_pkg_config: lp.cgo_pkg_config.clone(),
                 cgo_cflags: lp.cgo_cflags.clone(),
                 cgo_ldflags: lp.cgo_ldflags.clone(),
+                files: lp.files.clone(),
             },
         );
     }
@@ -970,6 +1054,68 @@ mod tests {
         assert_eq!(graph.packages[0].cgo_pkg_config, vec!["libfoo"]);
         assert_eq!(graph.packages[0].cgo_cflags, vec!["-I/usr/include"]);
         assert_eq!(graph.packages[0].cgo_ldflags, vec!["-lfoo"]);
+        assert_eq!(graph.packages[0].files.cgo_files, vec!["bridge.go"]);
+    }
+
+    #[test]
+    fn parse_file_lists_round_trip_to_json() {
+        let input = r#"{"ImportPath":"github.com/f/p","Module":{"Path":"github.com/f/p","Version":"v1.0.0"},"Imports":[],"GoFiles":["a.go","b.go"],"CgoFiles":["c.go"],"SFiles":["asm.s"],"CFiles":["x.c"],"CXXFiles":["x.cc"],"FFiles":["x.f90"],"HFiles":["x.h"],"SysoFiles":["x.syso"],"EmbedPatterns":["data/*"]}"#;
+        let graph = parse_go_packages(input.as_bytes()).unwrap();
+        let f = &graph.packages[0].files;
+        assert_eq!(f.go_files, vec!["a.go", "b.go"]);
+        assert_eq!(f.cgo_files, vec!["c.go"]);
+        assert_eq!(f.s_files, vec!["asm.s"]);
+        assert_eq!(f.c_files, vec!["x.c"]);
+        assert_eq!(f.cxx_files, vec!["x.cc"]);
+        assert_eq!(f.f_files, vec!["x.f90"]);
+        assert_eq!(f.h_files, vec!["x.h"]);
+        assert_eq!(f.syso_files, vec!["x.syso"]);
+        assert_eq!(f.embed_patterns, vec!["data/*"]);
+
+        let jp = pkg_data_to_json_pkg(&graph.packages[0], &|_| true);
+        let json = serde_json::to_value(&jp).unwrap();
+        let files = &json["files"];
+        assert_eq!(files["goFiles"], serde_json::json!(["a.go", "b.go"]));
+        assert_eq!(files["cgoFiles"], serde_json::json!(["c.go"]));
+        assert_eq!(files["sFiles"], serde_json::json!(["asm.s"]));
+        assert_eq!(files["cFiles"], serde_json::json!(["x.c"]));
+        assert_eq!(files["cxxFiles"], serde_json::json!(["x.cc"]));
+        assert_eq!(files["fFiles"], serde_json::json!(["x.f90"]));
+        assert_eq!(files["hFiles"], serde_json::json!(["x.h"]));
+        assert_eq!(files["sysoFiles"], serde_json::json!(["x.syso"]));
+        assert_eq!(files["embedPatterns"], serde_json::json!(["data/*"]));
+    }
+
+    #[test]
+    fn json_pkg_omits_empty_files() {
+        let p = PkgData {
+            import_path: "github.com/foo/bar".into(),
+            mod_path: "github.com/foo/bar".into(),
+            mod_version: "v1.0.0".into(),
+            replace_version: String::new(),
+            imports: vec![],
+            cgo_pkg_config: vec![],
+            cgo_cflags: vec![],
+            cgo_ldflags: vec![],
+            is_cgo: false,
+            files: PkgFiles::default(),
+        };
+        let jp = pkg_data_to_json_pkg(&p, &|_| true);
+        let json = serde_json::to_value(&jp).unwrap();
+        assert!(
+            json.get("files").is_none(),
+            "empty files should be omitted, got {json}"
+        );
+    }
+
+    #[test]
+    fn parse_local_file_lists() {
+        let input = r#"{"ImportPath":"example.com/m","Dir":"/src","Module":{"Path":"example.com/m","Main":true},"Imports":[],"GoFiles":["main.go"],"SFiles":["asm_amd64.s"]}"#;
+        let graph = parse_go_packages(input.as_bytes()).unwrap();
+        assert_eq!(graph.local_packages.len(), 1);
+        let f = &graph.local_packages[0].files;
+        assert_eq!(f.go_files, vec!["main.go"]);
+        assert_eq!(f.s_files, vec!["asm_amd64.s"]);
     }
 
     // --- parse_test_packages ---
@@ -979,9 +1125,14 @@ mod tests {
         let mut third_party = BTreeSet::new();
         third_party.insert("github.com/already/known".to_owned());
 
-        let input = third_party_json("github.com/already/known", "github.com/already/known", "v1.0.0");
+        let input = third_party_json(
+            "github.com/already/known",
+            "github.com/already/known",
+            "v1.0.0",
+        );
         let mut replacements = BTreeMap::new();
-        let result = parse_test_packages(input.as_bytes(), &third_party, &mut replacements).unwrap();
+        let result =
+            parse_test_packages(input.as_bytes(), &third_party, &mut replacements).unwrap();
         assert!(result.is_empty());
     }
 
@@ -991,7 +1142,8 @@ mod tests {
 
         let input = third_party_json("github.com/testify", "github.com/testify", "v1.9.0");
         let mut replacements = BTreeMap::new();
-        let result = parse_test_packages(input.as_bytes(), &third_party, &mut replacements).unwrap();
+        let result =
+            parse_test_packages(input.as_bytes(), &third_party, &mut replacements).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].import_path, "github.com/testify");
     }
@@ -1011,7 +1163,8 @@ mod tests {
         .join("\n");
 
         let mut replacements = BTreeMap::new();
-        let result = parse_test_packages(input.as_bytes(), &third_party, &mut replacements).unwrap();
+        let result =
+            parse_test_packages(input.as_bytes(), &third_party, &mut replacements).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].import_path, "github.com/testify");
     }
@@ -1021,7 +1174,8 @@ mod tests {
         let third_party = BTreeSet::new();
         let input = local_pkg_json("example.com/m/internal/x", "example.com/m", "/src/x", &[]);
         let mut replacements = BTreeMap::new();
-        let result = parse_test_packages(input.as_bytes(), &third_party, &mut replacements).unwrap();
+        let result =
+            parse_test_packages(input.as_bytes(), &third_party, &mut replacements).unwrap();
         assert!(result.is_empty());
     }
 
@@ -1034,7 +1188,8 @@ mod tests {
         ]
         .join("\n");
         let mut replacements = BTreeMap::new();
-        let result = parse_test_packages(input.as_bytes(), &third_party, &mut replacements).unwrap();
+        let result =
+            parse_test_packages(input.as_bytes(), &third_party, &mut replacements).unwrap();
         assert_eq!(result.len(), 1);
     }
 
@@ -1049,7 +1204,8 @@ mod tests {
             "v1.1.0",
         );
         let mut replacements = BTreeMap::new();
-        let result = parse_test_packages(input.as_bytes(), &third_party, &mut replacements).unwrap();
+        let result =
+            parse_test_packages(input.as_bytes(), &third_party, &mut replacements).unwrap();
         assert_eq!(result.len(), 1);
         let (path, _) = &replacements["github.com/test/dep@v1.1.0"];
         assert_eq!(path, "github.com/fork/dep");
@@ -1092,9 +1248,18 @@ mod tests {
 
     #[test]
     fn sanitize_name_whitelist() {
-        assert_eq!(sanitize_name("github.com/foo/bar+baz"), "github.com-foo-bar+baz");
-        assert_eq!(sanitize_name("git.sr.ht/~geb/dotool"), "git.sr.ht-_geb-dotool");
-        assert_eq!(sanitize_name("example.com/@scope/pkg"), "example.com-_at_scope-pkg");
+        assert_eq!(
+            sanitize_name("github.com/foo/bar+baz"),
+            "github.com-foo-bar+baz"
+        );
+        assert_eq!(
+            sanitize_name("git.sr.ht/~geb/dotool"),
+            "git.sr.ht-_geb-dotool"
+        );
+        assert_eq!(
+            sanitize_name("example.com/@scope/pkg"),
+            "example.com-_at_scope-pkg"
+        );
     }
 
     // --- pkg_data_to_json_pkg ---
@@ -1111,6 +1276,7 @@ mod tests {
             cgo_cflags: vec![],
             cgo_ldflags: vec![],
             is_cgo: false,
+            files: PkgFiles::default(),
         };
         let jp = pkg_data_to_json_pkg(&p, &|_| true);
         assert_eq!(jp.subdir, "sub/pkg");
@@ -1130,6 +1296,7 @@ mod tests {
             cgo_cflags: vec![],
             cgo_ldflags: vec![],
             is_cgo: false,
+            files: PkgFiles::default(),
         };
         let jp = pkg_data_to_json_pkg(&p, &|_| true);
         assert_eq!(jp.mod_key, "github.com/foo/bar@v2.0.0");
@@ -1186,6 +1353,7 @@ mod tests {
             cgo_cflags: vec![],
             cgo_ldflags: vec![],
             is_cgo: false,
+            files: PkgFiles::default(),
         };
         let jp = pkg_data_to_json_pkg(&p, &|imp| imp == "github.com/keep");
         assert_eq!(jp.imports, vec!["github.com/keep"]);
@@ -1218,13 +1386,23 @@ mod tests {
         // No explicit goProxy: inherit from env.
         let mut cmd = std::process::Command::new("true");
         configure_go_env(&mut cmd, "/tmp", &test_opts(None));
-        assert_eq!(cmd_env(&cmd, "GOPROXY").as_deref(), Some("https://proxy.example/"));
+        assert_eq!(
+            cmd_env(&cmd, "GOPROXY").as_deref(),
+            Some("https://proxy.example/")
+        );
         assert_eq!(cmd_env(&cmd, "NETRC").as_deref(), Some("/tmp/netrc-test"));
 
         // Explicit goProxy: overrides inherited value.
         let mut cmd = std::process::Command::new("true");
-        configure_go_env(&mut cmd, "/tmp", &test_opts(Some("https://explicit.example/")));
-        assert_eq!(cmd_env(&cmd, "GOPROXY").as_deref(), Some("https://explicit.example/"));
+        configure_go_env(
+            &mut cmd,
+            "/tmp",
+            &test_opts(Some("https://explicit.example/")),
+        );
+        assert_eq!(
+            cmd_env(&cmd, "GOPROXY").as_deref(),
+            Some("https://explicit.example/")
+        );
 
         std::env::remove_var("GOPROXY");
         std::env::remove_var("NETRC");


### PR DESCRIPTION
## Summary

In dag mode, file discovery happens twice for every package: the plugin runs `go list -json -deps` at eval time (which already computes the correct GoFiles/CgoFiles/SFiles/etc. for the target platform), then each compile derivation re-runs `go/build.ImportDir` via `gofiles.ListFiles`. The second pass is the one that #41 had to patch — it only exists because the first pass throws the file lists away.

This PR makes `go list` the single source of truth: the resolver captures the file lists, the Nix builder writes them into `compileManifestJSON`, and `compile-package` uses them directly instead of re-discovering.

## Changes

- **`pkg/compile`**: `Options.GoFiles`/`EmbedCfg` replaced by `Options.Files *gofiles.PkgFiles`. When set, the full struct is used verbatim (all file kinds, not just GoFiles); otherwise the existing `ListFiles` fallback is unchanged. testrunner migrated.
- **`pkg/compile/manifest.go` + `cmd/go2nix/compile.go`**: optional `files` block (`goFiles, cgoFiles, sFiles, cFiles, cxxFiles, fFiles, hFiles, sysoFiles, embedPatterns`). `(*ManifestFiles).ToPkgFiles(srcDir)` does the conversion and resolves embed patterns at build time against the realised source.
- **`packages/go2nix-nix-plugin/rust/src/resolve.rs`**: extend the `-json=` filter and thread the lists through `GoPackage` → `PkgData`/`LocalPkgData` → `JsonPkg`/`JsonLocalPkg` as a camelCase `files` object (omitted when empty). `is_cgo` is unchanged. Synthetic `.test` packages are filtered before file capture.
- **`nix/dag/default.nix`**: `mkCompileManifestJSON`/`mkCompileEnv` accept and forward `files`; all three call sites pass `pkg.files or null`. `resolveGoPackages` is now given `goos`/`goarch`/`cgoEnabled` so eval-time `go list` evaluates build constraints against the same target as the compile derivations — required now that file lists are frozen at eval rather than re-derived in the sandbox.

## Compatibility

Additive; manifest version stays `1`. New go2nix + old manifest → `Files == nil` → `ListFiles` fallback. Old go2nix + new manifest → unknown JSON field ignored → `ListFiles`. Derivation hashes change because the manifest grows.

## Embed handling

Only `EmbedPatterns` are passed (not resolved files): `go list` does not expose the pattern→file map `-embedcfg` needs, and eval-time absolute paths would be wrong inside the sandbox. Resolution stays at build time via the existing `gofiles.ResolveEmbedCfg`.

## Test plan

- [x] `go test ./...` (14 packages, fresh cache) — incl. 3 new manifest tests
- [x] `cargo test` (38 tests) — incl. 3 new round-trip tests; no new clippy warnings
- [x] Rust↔Go JSON schema asserted by test (9/9 field names match)
- [x] `nix eval .#packages.x86_64-linux.test-fixture-testify-basic.drvPath` evaluates cleanly with both new and old plugin output
- [x] Round-trip probe: absent / `null` / full / `{}` `files` all behave correctly through `ToPkgFiles`
- [x] `nix build .#go2nix-nix-plugin` — Rust+C++ link OK
- [ ] `nix build .#test-fixture-testify-basic` end-to-end (needs `recursive-nix` system feature; not available on my host, deferring to CI)

## Follow-ups (not in this PR)

- **Dynamic mode** (`pkg/resolve/resolve.go:557-564`) builds the manifest without `Files` and so still relies on the `ListFiles` fallback. The data is already in `ResolvedPkg` (`graph.go:14-62`); wiring it through is ~10 lines plus threading `EmbedPatterns` from `golist.Pkg`.
- The **testrunner** recompile-for-test loop still relies on the `ListFiles` fallback for dependent packages (it doesn't have a manifest). Unchanged here.
- Once both of the above are migrated, the `ListFiles` fallback in `compile.go` and the `tags` field in the manifest can be dropped, with `ManifestVersion` bumped to 2 so an old plugin + new go2nix fails loudly instead of silently re-discovering.
