### PR TITLE
resolve: populate manifest.Files in dynamic mode

### DIFF
--- a/go/go2nix/pkg/resolve/graph.go
+++ b/go/go2nix/pkg/resolve/graph.go
@@ -23,6 +23,7 @@ type ResolvedPkg struct {
 	SFiles         []string
 	HFiles         []string
 	SysoFiles      []string // .syso system object files
+	EmbedPatterns  []string // //go:embed patterns
 	EmbedFiles     []string // resolved files matching //go:embed patterns (may include subdirectory paths)
 	Imports        []string // all import paths (including stdlib)
 	IsLocal        bool
@@ -59,6 +60,7 @@ func buildPackageGraph(
 			SFiles:         pkg.SFiles,
 			HFiles:         pkg.HFiles,
 			SysoFiles:      pkg.SysoFiles,
+			EmbedPatterns:  pkg.EmbedPatterns,
 			EmbedFiles:     pkg.EmbedFiles,
 			Name:           pkg.Name,
 			DefaultGODEBUG: pkg.DefaultGODEBUG,

--- a/go/go2nix/pkg/resolve/resolve.go
+++ b/go/go2nix/pkg/resolve/resolve.go
@@ -561,6 +561,17 @@ func buildPackageDrv(
 		Tags:           tagList,
 		GCFlags:        gcflagList,
 		PGOProfile:     pgoProfile,
+		Files: &compile.ManifestFiles{
+			GoFiles:       pkg.GoFiles,
+			CgoFiles:      pkg.CgoFiles,
+			SFiles:        pkg.SFiles,
+			CFiles:        pkg.CFiles,
+			CXXFiles:      pkg.CXXFiles,
+			FFiles:        pkg.FFiles,
+			HFiles:        pkg.HFiles,
+			SysoFiles:     pkg.SysoFiles,
+			EmbedPatterns: pkg.EmbedPatterns,
+		},
 	}
 	manifestJSON, err := json.Marshal(manifest)
 	if err != nil {


### PR DESCRIPTION
Stacked on #43.

Dynamic mode (`pkg/resolve`) already carries the full file lists from `go list` in `ResolvedPkg` (`graph.go:14-62`), but `resolve.go:557` was building the compile manifest without `Files`, so `compile-package` fell back to `gofiles.ListFiles` for every package — the same redundant discovery that #43 removes for dag mode.

This threads `EmbedPatterns` through `ResolvedPkg` and sets `manifest.Files` alongside the other manifest fields, matching the dag builder.

After this and a corresponding testrunner change, the only remaining `ListFiles` callers in the compile path will be the explicit fallback branch — which can then be removed with a `ManifestVersion` bump to 2 (separate PR).

## Test plan

- [x] `go build ./... && go vet ./... && go test ./pkg/resolve/...`
- [x] `golangci-lint run ./pkg/resolve/...` — 0 issues
- [ ] dynamic-mode integration fixture (needs `recursive-nix` + `dynamic-derivations`; deferring to CI)