### PR TITLE
testrunner: set Files in recompile-for-test loop

### DIFF
--- a/go/go2nix/pkg/testrunner/testrunner.go
+++ b/go/go2nix/pkg/testrunner/testrunner.go
@@ -298,6 +298,7 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 				TrimPath:    opts.TrimPath,
 				Tags:        opts.Tags,
 				GCFlagsList: opts.GCFlagsList,
+				Files:       &depPkg.PkgFiles,
 			}); err != nil {
 				return fmt.Errorf("recompiling %s for test: %w", depIP, err)
 			}


### PR DESCRIPTION
Stacked on #44 (which is stacked on #43).

The `recompileForTest` loop at `testrunner.go:293` was the last `CompileGoPackage` caller that relied on the `gofiles.ListFiles` fallback. `LocalPkg` already embeds `gofiles.PkgFiles`, so this just passes `&depPkg.PkgFiles` through.

After this and #44, every compile-path caller supplies `Files` explicitly. The fallback branch in `compile.go:94` is now only reachable from a manifest-less `compile-package` invocation (debug-only) or an old-format manifest — clearing the way to remove it and bump `ManifestVersion` to 2 in a follow-up.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./pkg/testrunner/... ./pkg/compile/...`
- [x] `golangci-lint run ./pkg/testrunner/...` — 0 issues
- [x] grep confirms no `CompileGoPackage` caller in `pkg/` or `cmd/` omits `Files`