### PR TITLE
manifest: v2 — require Files, drop ListFiles fallback

### DIFF
--- a/go/go2nix/cmd/go2nix/compile.go
+++ b/go/go2nix/cmd/go2nix/compile.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"strings"
 
 	"github.com/numtide/go2nix/pkg/compile"
 )
@@ -58,7 +57,6 @@ func runCompilePackageCmd(args []string) {
 		IfaceOutput: *ifaceOutput,
 		ImportCfg:   mergedCfg,
 		TrimPath:    *trimPath,
-		Tags:        strings.Join(m.Tags, ","),
 		GCFlagsList: m.GCFlags,
 		GoVersion:   *goVersion,
 		PGOProfile:  pgo,
@@ -71,6 +69,10 @@ func runCompilePackageCmd(args []string) {
 			os.Exit(1)
 		}
 		opts.Files = pf
+	}
+	if opts.Files == nil {
+		slog.Error("compile-package: manifest is missing files; rebuild the nix-plugin", "version", m.Version)
+		os.Exit(1)
 	}
 
 	if err := compile.CompileGoPackage(opts); err != nil {

--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -170,8 +170,6 @@ func linkBinary(manifestPath, output string) error {
 	}
 	gcflagsList = append(gcflagsList, m.GCFlags...)
 
-	tagsStr := strings.Join(m.Tags, ",")
-
 	var pgoProfile string
 	if m.PGOProfile != nil {
 		pgoProfile = *m.PGOProfile
@@ -199,8 +197,8 @@ func linkBinary(manifestPath, output string) error {
 	for _, sp := range m.SubPackages {
 		var importpath, srcdir, binname string
 
-		clean := strings.TrimPrefix(sp, "./")
-		if sp == "." || clean == "" {
+		clean := strings.TrimPrefix(sp.Path, "./")
+		if sp.Path == "." || clean == "" {
 			importpath = modulePath
 			srcdir = m.ModuleRoot
 			binname = m.Pname
@@ -220,15 +218,23 @@ func linkBinary(manifestPath, output string) error {
 			return err
 		}
 
+		if sp.Files == nil {
+			return fmt.Errorf("link manifest: subPackage %q is missing files; rebuild the nix-plugin", sp.Path)
+		}
+		pf, err := sp.Files.ToPkgFiles(srcdir)
+		if err != nil {
+			return fmt.Errorf("resolving files for %s: %w", importpath, err)
+		}
+
 		if err := compile.CompileGoPackage(compile.Options{
 			ImportPath:  "main",
 			SrcDir:      srcdir,
 			Output:      mainArchive,
 			ImportCfg:   compileCfg,
 			TrimPath:    tmpDir,
-			Tags:        tagsStr,
 			GCFlagsList: gcflagsList,
 			PGOProfile:  pgoProfile,
+			Files:       pf,
 		}); err != nil {
 			return fmt.Errorf("compiling main %s: %w", importpath, err)
 		}

--- a/go/go2nix/pkg/compile/compile.go
+++ b/go/go2nix/pkg/compile/compile.go
@@ -22,7 +22,6 @@ type Options struct {
 	IfaceOutput string            // optional export-data-only interface output (compile-time deps key on this; rules_go .x model)
 	ImportCfg   string            // path to importcfg file
 	TrimPath    string            // path prefix to trim (defaults to $NIX_BUILD_TOP)
-	Tags        string            // comma-separated build tags
 	GCFlagsList []string          // extra flags for go tool compile
 	GoVersion   string            // Go language version for -lang flag (e.g., "1.21"); auto-detected from go.mod if empty
 	PGOProfile  string            // path to pprof CPU profile for PGO; empty disables PGO
@@ -86,19 +85,10 @@ func CompileGoPackage(opts Options) error {
 
 	slog.Debug("compile-package", "import-path", opts.ImportPath, "src", opts.SrcDir)
 
-	var files gofiles.PkgFiles
-	if opts.Files != nil {
-		files = *opts.Files
-	} else {
-		var err error
-		// Pass the toolchain version (not opts.GoVersion, which is the
-		// -lang language version from go.mod) so //go:build go1.N
-		// constraints are evaluated against the actual compiler.
-		files, err = gofiles.ListFiles(opts.SrcDir, opts.Tags, ToolchainVersion())
-		if err != nil {
-			return fmt.Errorf("listing files: %w", err)
-		}
+	if opts.Files == nil {
+		return fmt.Errorf("compile.Options.Files is required (package %s)", opts.ImportPath)
 	}
+	files := *opts.Files
 
 	if len(files.GoFiles) == 0 && len(files.CgoFiles) == 0 {
 		return fmt.Errorf("no Go files found in %s (package %s)", opts.SrcDir, opts.ImportPath)

--- a/go/go2nix/pkg/compile/manifest.go
+++ b/go/go2nix/pkg/compile/manifest.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// ManifestVersion is the current schema version for all manifest types.
-	ManifestVersion = 1
+	ManifestVersion = 2
 
 	// ManifestKindCompile is the kind value for compile manifests.
 	ManifestKindCompile = "compile"
@@ -31,7 +31,6 @@ type CompileManifest struct {
 	Version        int            `json:"version"`
 	Kind           string         `json:"kind"`
 	ImportcfgParts []string       `json:"importcfgParts"`
-	Tags           []string       `json:"tags"`
 	GCFlags        []string       `json:"gcflags"`
 	PGOProfile     *string        `json:"pgoProfile"`
 	Files          *ManifestFiles `json:"files,omitempty"`
@@ -119,7 +118,7 @@ type LinkManifest struct {
 	// ImportcfgParts/LocalArchives (.a link objects).
 	CompileImportcfgParts []string          `json:"compileImportcfgParts,omitempty"`
 	LocalIfaces           map[string]string `json:"localIfaces,omitempty"`
-	SubPackages           []string          `json:"subPackages"`
+	SubPackages           []LinkSubPackage  `json:"subPackages"`
 	ModuleRoot            string            `json:"moduleRoot"`
 	Lockfile              *string           `json:"lockfile"`
 	Pname                 string            `json:"pname"`
@@ -129,6 +128,12 @@ type LinkManifest struct {
 	GCFlags               []string          `json:"gcflags"`
 	Tags                  []string          `json:"tags"`
 	PGOProfile            *string           `json:"pgoProfile"`
+}
+
+// LinkSubPackage is one main-package entry in a LinkManifest.
+type LinkSubPackage struct {
+	Path  string         `json:"path"`
+	Files *ManifestFiles `json:"files,omitempty"`
 }
 
 // LoadLinkManifest reads and validates a link manifest from path.

--- a/go/go2nix/pkg/compile/manifest_test.go
+++ b/go/go2nix/pkg/compile/manifest_test.go
@@ -15,20 +15,20 @@ func TestLoadCompileManifest(t *testing.T) {
 	}{
 		{
 			name: "valid manifest",
-			json: `{"version":1,"kind":"compile","importcfgParts":["/a/importcfg","/b/importcfg"],"tags":["nethttpomithttp2"],"gcflags":["-shared"],"pgoProfile":null}`,
+			json: `{"version":2,"kind":"compile","importcfgParts":["/a/importcfg","/b/importcfg"],"gcflags":["-shared"],"pgoProfile":null}`,
 		},
 		{
 			name: "valid with pgo",
-			json: `{"version":1,"kind":"compile","importcfgParts":[],"tags":[],"gcflags":[],"pgoProfile":"/nix/store/xxx-profile.pprof"}`,
+			json: `{"version":2,"kind":"compile","importcfgParts":[],"gcflags":[],"pgoProfile":"/nix/store/xxx-profile.pprof"}`,
 		},
 		{
 			name:    "wrong version",
-			json:    `{"version":2,"kind":"compile","importcfgParts":[],"tags":[],"gcflags":[],"pgoProfile":null}`,
-			wantErr: "unsupported version 2",
+			json:    `{"version":1,"kind":"compile","importcfgParts":[],"gcflags":[],"pgoProfile":null}`,
+			wantErr: "unsupported version 1",
 		},
 		{
 			name:    "wrong kind",
-			json:    `{"version":1,"kind":"link","importcfgParts":[],"tags":[],"gcflags":[],"pgoProfile":null}`,
+			json:    `{"version":2,"kind":"link","importcfgParts":[],"gcflags":[],"pgoProfile":null}`,
 			wantErr: `wrong kind "link"`,
 		},
 		{
@@ -58,8 +58,8 @@ func TestLoadCompileManifest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if m.Version != 1 {
-				t.Errorf("version = %d, want 1", m.Version)
+			if m.Version != ManifestVersion {
+				t.Errorf("version = %d, want %d", m.Version, ManifestVersion)
 			}
 			if m.Kind != "compile" {
 				t.Errorf("kind = %q, want compile", m.Kind)
@@ -70,7 +70,7 @@ func TestLoadCompileManifest(t *testing.T) {
 
 func TestLoadCompileManifest_fields(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "manifest.json")
-	json := `{"version":1,"kind":"compile","importcfgParts":["/a","/b"],"tags":["foo","bar"],"gcflags":["-shared","-N"],"pgoProfile":"/pgo"}`
+	json := `{"version":2,"kind":"compile","importcfgParts":["/a","/b"],"gcflags":["-shared","-N"],"pgoProfile":"/pgo"}`
 	if err := os.WriteFile(path, []byte(json), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -83,9 +83,6 @@ func TestLoadCompileManifest_fields(t *testing.T) {
 	if len(m.ImportcfgParts) != 2 || m.ImportcfgParts[0] != "/a" || m.ImportcfgParts[1] != "/b" {
 		t.Errorf("importcfgParts = %v", m.ImportcfgParts)
 	}
-	if len(m.Tags) != 2 || m.Tags[0] != "foo" || m.Tags[1] != "bar" {
-		t.Errorf("tags = %v", m.Tags)
-	}
 	if len(m.GCFlags) != 2 || m.GCFlags[0] != "-shared" || m.GCFlags[1] != "-N" {
 		t.Errorf("gcflags = %v", m.GCFlags)
 	}
@@ -96,7 +93,7 @@ func TestLoadCompileManifest_fields(t *testing.T) {
 
 func TestLoadCompileManifest_filesOmitted(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "manifest.json")
-	json := `{"version":1,"kind":"compile","importcfgParts":[],"tags":[],"gcflags":[],"pgoProfile":null}`
+	json := `{"version":2,"kind":"compile","importcfgParts":[],"gcflags":[],"pgoProfile":null}`
 	if err := os.WriteFile(path, []byte(json), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +108,7 @@ func TestLoadCompileManifest_filesOmitted(t *testing.T) {
 
 func TestLoadCompileManifest_files(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "manifest.json")
-	json := `{"version":1,"kind":"compile","importcfgParts":[],"tags":[],"gcflags":[],"pgoProfile":null,` +
+	json := `{"version":2,"kind":"compile","importcfgParts":[],"gcflags":[],"pgoProfile":null,` +
 		`"files":{"goFiles":["a.go","b.go"],"cgoFiles":["c.go"],"sFiles":["asm_amd64.s"],` +
 		`"hFiles":["x.h"],"embedPatterns":["data/*.txt"]}}`
 	if err := os.WriteFile(path, []byte(json), 0o644); err != nil {
@@ -250,11 +247,11 @@ func TestLoadTestManifest(t *testing.T) {
 	}{
 		{
 			name: "valid manifest",
-			json: `{"version":1,"kind":"test","importcfgParts":["/a/importcfg"],"localArchives":{"example.com/foo":"/nix/store/foo.a"},"moduleRoot":"/nix/store/src","tags":[],"gcflags":[],"checkFlags":["-v"]}`,
+			json: `{"version":2,"kind":"test","importcfgParts":["/a/importcfg"],"localArchives":{"example.com/foo":"/nix/store/foo.a"},"moduleRoot":"/nix/store/src","tags":[],"gcflags":[],"checkFlags":["-v"]}`,
 		},
 		{
 			name:    "wrong kind",
-			json:    `{"version":1,"kind":"compile","importcfgParts":[],"localArchives":{},"moduleRoot":"/src","tags":[],"gcflags":[],"checkFlags":[]}`,
+			json:    `{"version":2,"kind":"compile","importcfgParts":[],"localArchives":{},"moduleRoot":"/src","tags":[],"gcflags":[],"checkFlags":[]}`,
 			wantErr: `wrong kind "compile"`,
 		},
 		{
@@ -305,16 +302,16 @@ func TestLoadLinkManifest(t *testing.T) {
 	}{
 		{
 			name: "valid manifest",
-			json: `{"version":1,"kind":"link","importcfgParts":["/a/importcfg"],"localArchives":{"example.com/foo":"/nix/store/foo.a"},"subPackages":["./cmd/server"],"moduleRoot":"/nix/store/src","lockfile":"/nix/store/lockfile","pname":"myapp","goos":"linux","goarch":"amd64","ldflags":["-s","-w"],"gcflags":[],"tags":[],"pgoProfile":null}`,
+			json: `{"version":2,"kind":"link","importcfgParts":["/a/importcfg"],"localArchives":{"example.com/foo":"/nix/store/foo.a"},"subPackages":[{"path":"./cmd/server","files":{"goFiles":["main.go"]}}],"moduleRoot":"/nix/store/src","lockfile":"/nix/store/lockfile","pname":"myapp","goos":"linux","goarch":"amd64","ldflags":["-s","-w"],"gcflags":[],"tags":[],"pgoProfile":null}`,
 		},
 		{
 			name:    "wrong kind",
-			json:    `{"version":1,"kind":"compile","importcfgParts":[],"localArchives":{},"subPackages":["."],"moduleRoot":"/src","lockfile":"/lock","pname":"x","goos":null,"goarch":null,"ldflags":[],"gcflags":[],"tags":[],"pgoProfile":null}`,
+			json:    `{"version":2,"kind":"compile","importcfgParts":[],"localArchives":{},"subPackages":[{"path":"."}],"moduleRoot":"/src","lockfile":"/lock","pname":"x","goos":null,"goarch":null,"ldflags":[],"gcflags":[],"tags":[],"pgoProfile":null}`,
 			wantErr: `wrong kind "compile"`,
 		},
 		{
 			name:    "wrong version",
-			json:    `{"version":99,"kind":"link","importcfgParts":[],"localArchives":{},"subPackages":["."],"moduleRoot":"/src","lockfile":"/lock","pname":"x","goos":null,"goarch":null,"ldflags":[],"gcflags":[],"tags":[],"pgoProfile":null}`,
+			json:    `{"version":99,"kind":"link","importcfgParts":[],"localArchives":{},"subPackages":[{"path":"."}],"moduleRoot":"/src","lockfile":"/lock","pname":"x","goos":null,"goarch":null,"ldflags":[],"gcflags":[],"tags":[],"pgoProfile":null}`,
 			wantErr: "unsupported version 99",
 		},
 		{
@@ -350,8 +347,11 @@ func TestLoadLinkManifest(t *testing.T) {
 			if m.ModuleRoot != "/nix/store/src" {
 				t.Errorf("moduleRoot = %q", m.ModuleRoot)
 			}
-			if len(m.SubPackages) != 1 || m.SubPackages[0] != "./cmd/server" {
+			if len(m.SubPackages) != 1 || m.SubPackages[0].Path != "./cmd/server" {
 				t.Errorf("subPackages = %v", m.SubPackages)
+			}
+			if m.SubPackages[0].Files == nil || len(m.SubPackages[0].Files.GoFiles) != 1 || m.SubPackages[0].Files.GoFiles[0] != "main.go" {
+				t.Errorf("subPackages[0].files = %+v", m.SubPackages[0].Files)
 			}
 			if len(m.LDFlags) != 2 || m.LDFlags[0] != "-s" || m.LDFlags[1] != "-w" {
 				t.Errorf("ldflags = %v", m.LDFlags)
@@ -371,7 +371,7 @@ func TestLoadLinkManifest(t *testing.T) {
 
 func TestLoadLinkManifest_nullOptionals(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "manifest.json")
-	json := `{"version":1,"kind":"link","importcfgParts":[],"localArchives":{},"subPackages":["."],"moduleRoot":"/src","lockfile":"/lock","pname":"x","goos":null,"goarch":null,"ldflags":[],"gcflags":[],"tags":[],"pgoProfile":null}`
+	json := `{"version":2,"kind":"link","importcfgParts":[],"localArchives":{},"subPackages":[{"path":"."}],"moduleRoot":"/src","lockfile":"/lock","pname":"x","goos":null,"goarch":null,"ldflags":[],"gcflags":[],"tags":[],"pgoProfile":null}`
 	if err := os.WriteFile(path, []byte(json), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -397,12 +397,12 @@ func TestLoadLinkManifest_iface(t *testing.T) {
 	// (export data) files instead of the .a (link object) files used
 	// by the link step.
 	path := filepath.Join(t.TempDir(), "manifest.json")
-	json := `{"version":1,"kind":"link",` +
+	json := `{"version":2,"kind":"link",` +
 		`"importcfgParts":["/a/importcfg"],` +
 		`"localArchives":{"example.com/foo":"/nix/store/foo.a"},` +
 		`"compileImportcfgParts":["/i/importcfg"],` +
 		`"localIfaces":{"example.com/foo":"/nix/store/foo.x"},` +
-		`"subPackages":["."],"moduleRoot":"/src","lockfile":"/lock","pname":"x",` +
+		`"subPackages":[{"path":"."}],"moduleRoot":"/src","lockfile":"/lock","pname":"x",` +
 		`"goos":null,"goarch":null,"ldflags":[],"gcflags":[],"tags":[],"pgoProfile":null}`
 	if err := os.WriteFile(path, []byte(json), 0o644); err != nil {
 		t.Fatal(err)
@@ -430,7 +430,7 @@ func TestLoadLinkManifest_omitIface(t *testing.T) {
 	// When iface fields are omitted (default mode), they parse to
 	// zero values — link-binary will fall through to compileCfg = mergedCfg.
 	path := filepath.Join(t.TempDir(), "manifest.json")
-	json := `{"version":1,"kind":"link","importcfgParts":[],"localArchives":{},"subPackages":["."],"moduleRoot":"/src","lockfile":"/lock","pname":"x","goos":null,"goarch":null,"ldflags":[],"gcflags":[],"tags":[],"pgoProfile":null}`
+	json := `{"version":2,"kind":"link","importcfgParts":[],"localArchives":{},"subPackages":[{"path":"."}],"moduleRoot":"/src","lockfile":"/lock","pname":"x","goos":null,"goarch":null,"ldflags":[],"gcflags":[],"tags":[],"pgoProfile":null}`
 	if err := os.WriteFile(path, []byte(json), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/go/go2nix/pkg/resolve/builder_test.go
+++ b/go/go2nix/pkg/resolve/builder_test.go
@@ -152,7 +152,6 @@ func TestImportcfgPlaceholderRoundTrip(t *testing.T) {
 		Version:        compile.ManifestVersion,
 		Kind:           compile.ManifestKindCompile,
 		ImportcfgParts: []string{compile.ImportcfgPlaceholder},
-		Tags:           []string{"netgo", "osusergo"},
 		GCFlags:        []string{"-shared"},
 		PGOProfile:     &pgo,
 	}
@@ -185,9 +184,6 @@ func TestImportcfgPlaceholderRoundTrip(t *testing.T) {
 	}
 	if got.Version != compile.ManifestVersion {
 		t.Errorf("version = %d, want %d", got.Version, compile.ManifestVersion)
-	}
-	if len(got.Tags) != 2 || got.Tags[0] != "netgo" {
-		t.Errorf("tags = %v, want [netgo osusergo]", got.Tags)
 	}
 	if got.PGOProfile == nil || *got.PGOProfile != pgo {
 		t.Errorf("pgoProfile = %v, want %q", got.PGOProfile, pgo)

--- a/go/go2nix/pkg/resolve/resolve.go
+++ b/go/go2nix/pkg/resolve/resolve.go
@@ -545,10 +545,6 @@ func buildPackageDrv(
 	// Build compile manifest JSON (same contract as default mode).
 	// The bash script writes this to a file and passes --manifest.
 	gcflagList := buildCompileGCFlags(cfg.buildMode, cfg.GCFlags)
-	var tagList []string
-	if cfg.Tags != "" {
-		tagList = strings.Split(cfg.Tags, ",")
-	}
 	var pgoProfile *string
 	if cfg.PGOProfile != "" {
 		pgoProfile = &cfg.PGOProfile
@@ -558,7 +554,6 @@ func buildPackageDrv(
 		Version:        compile.ManifestVersion,
 		Kind:           compile.ManifestKindCompile,
 		ImportcfgParts: []string{compile.ImportcfgPlaceholder},
-		Tags:           tagList,
 		GCFlags:        gcflagList,
 		PGOProfile:     pgoProfile,
 		Files: &compile.ManifestFiles{

--- a/go/go2nix/pkg/testrunner/testrunner.go
+++ b/go/go2nix/pkg/testrunner/testrunner.go
@@ -243,7 +243,6 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 			Output:      internalArchive,
 			ImportCfg:   testCompileImportCfg,
 			TrimPath:    opts.TrimPath,
-			Tags:        opts.Tags,
 			GCFlagsList: opts.GCFlagsList,
 			Files:       &gofiles.PkgFiles{GoFiles: goFiles, EmbedCfg: mergedEmbedCfg},
 		}); err != nil {
@@ -296,7 +295,6 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 				Output:      recompArchive,
 				ImportCfg:   testCompileImportCfg,
 				TrimPath:    opts.TrimPath,
-				Tags:        opts.Tags,
 				GCFlagsList: opts.GCFlagsList,
 				Files:       &depPkg.PkgFiles,
 			}); err != nil {
@@ -342,7 +340,6 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 			Output:      externalArchive,
 			ImportCfg:   testCompileImportCfg,
 			TrimPath:    opts.TrimPath,
-			Tags:        opts.Tags,
 			GCFlagsList: opts.GCFlagsList,
 			Files:       &gofiles.PkgFiles{GoFiles: pkg.XTestGoFiles, EmbedCfg: pkg.XTestEmbedCfg},
 		}); err != nil {
@@ -387,7 +384,6 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 		Output:      testMainArchive,
 		ImportCfg:   testCompileImportCfg,
 		TrimPath:    opts.TrimPath,
-		Tags:        opts.Tags,
 		GCFlagsList: opts.GCFlagsList,
 		Files:       &gofiles.PkgFiles{GoFiles: []string{"_testmain.go"}},
 	}); err != nil {

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -210,10 +210,9 @@ let
     }:
     builtins.toJSON (
       {
-        version = 1;
+        version = 2;
         kind = "compile";
         importcfgParts = [ "${stdlib}/importcfg" ] ++ map depCompileCfg deps;
-        inherit tags;
         gcflags =
           let
             base = gcflags;
@@ -734,7 +733,7 @@ let
 
   linkManifestJSON = builtins.toJSON (
     {
-      version = 1;
+      version = 2;
       kind = "link";
       importcfgParts = [ "${depsImportcfg}/importcfg" ];
       localArchives = builtins.mapAttrs (importPath: pkg: "${pkg}/${importPath}.a") localPackages;
@@ -744,7 +743,20 @@ let
       localIfaces = builtins.mapAttrs (importPath: pkg: "${pkg.iface}/${importPath}.x") localPackages;
     }
     // {
-      subPackages = normalizedSubPackages;
+      subPackages =
+        let
+          inherit (goPackagesResult) modulePath;
+          spImportPath =
+            sp:
+            let
+              clean = lib.removePrefix "./" sp;
+            in
+            if sp == "." || clean == "" then modulePath else "${modulePath}/${clean}";
+        in
+        map (sp: {
+          path = sp;
+          files = goPackagesResult.localPackages.${spImportPath sp}.files or null;
+        }) normalizedSubPackages;
       inherit moduleRoot;
       lockfile =
         if goLock != null then
@@ -767,7 +779,7 @@ let
   testManifestJSON = lib.optionalString doCheck (
     builtins.toJSON (
       {
-        version = 1;
+        version = 2;
         kind = "test";
         importcfgParts =
           if hasTestDeps then [ "${testDepsImportcfg}/importcfg" ] else [ "${depsImportcfg}/importcfg" ];


### PR DESCRIPTION
Stacked on #45 (→ #44 → #43). **Merge only after #43–#45 are CI-green** — this is the one-way door.

## What

After #43/#44/#45, every dag/dynamic/testrunner `CompileGoPackage` caller supplies `Options.Files`. This PR migrates the last holdout (`link-binary`'s main-package compile loop) and then removes the `gofiles.ListFiles` fallback so the compile path has exactly one source of truth for file selection: the eval-time `go list`.

## Changes

- **`LinkManifest.SubPackages`** `[]string` → `[]LinkSubPackage{Path, Files}`. `nix/dag/default.nix` populates `files` from `goPackagesResult.localPackages.${importPath}.files`; `linkbinary.go` errors if `sp.Files == nil` and otherwise calls `sp.Files.ToPkgFiles(srcdir)`.
- **`compile.go`**: the `else { gofiles.ListFiles(...) }` branch is gone; `opts.Files == nil` is an error.
- **`Options.Tags` / `CompileManifest.Tags`** removed — their only consumer was the fallback's `BuildContext`. (`LinkManifest.Tags` / `TestManifest.Tags` are untouched.)
- **`ManifestVersion` 1 → 2**. The link/test manifest loaders share the constant, so their Nix emitters move to `version = 2` as well. An old plugin/builder pairing now fails the version check loudly instead of silently re-running `ImportDir`.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` (14/14, fresh cache)
- [x] `golangci-lint run ./...` — 0 issues
- [x] grep: all 6 `CompileGoPackage` callers set `Files`
- [x] `nix-instantiate --parse nix/dag/default.nix` + `nix fmt` idempotent
- [ ] `nix build .#test-fixture-testify-basic` (needs `recursive-nix`; deferring to CI)
- [ ] `nix build` a fixture with a `main` sub-package to exercise the new `LinkSubPackage` path end-to-end

## Follow-ups

- `LinkManifest.Tags` is now dead in Go (only consumer removed) but Nix still emits it; harmless `encoding/json` ignore. Can be cleaned alongside `TestManifest.Tags` if/when those become provably dead.
- Dynamic mode does not construct a `LinkManifest`; no resolve.go change needed for the SubPackages migration.

## Note for local testing

If your `nix` has `builtins.resolveGoPackages` compiled in (e.g. a patched build that bakes the plugin into libexpr), `--option plugin-files <new.so>` will **not** override it — `RegisterPrimOp` for an already-registered name is silently ignored. You'll see `manifest is missing files; rebuild the nix-plugin` even with the new plugin built. Use a vanilla nix binary (e.g. `nixVersions.nix_2_34` from nixpkgs) to test plugin changes locally, or rebuild the patched nix with the new plugin source.
