### PR TITLE
golist: pass -pgo=off -mod=readonly to go list -deps

### DIFF
--- a/go/go2nix/pkg/golist/golist.go
+++ b/go/go2nix/pkg/golist/golist.go
@@ -122,7 +122,7 @@ func ListDeps(opts ListDepsOptions) ([]Pkg, error) {
 		patterns = []string{"./..."}
 	}
 
-	args := []string{"list", "-json", "-deps"}
+	args := []string{"list", "-json", "-deps", "-pgo=off", "-mod=readonly"}
 	if opts.Tags != "" {
 		args = append(args, "-tags", opts.Tags)
 	}

--- a/packages/go2nix-nix-plugin/rust/src/resolve.rs
+++ b/packages/go2nix-nix-plugin/rust/src/resolve.rs
@@ -266,6 +266,11 @@ fn run_go_list(
     cmd.arg("-deps");
     cmd.arg("-e");
     cmd.arg("-buildvcs=false");
+    // -pgo=off short-circuits cmd/go's per-main-package default.pgo walk
+    // (load/pkg.go setPGOProfilePath); -mod=readonly is the module-mode
+    // default but pinning it makes the env-independence explicit.
+    cmd.arg("-pgo=off");
+    cmd.arg("-mod=readonly");
 
     if !opts.tags.is_empty() {
         cmd.arg("-tags");
@@ -306,6 +311,8 @@ fn run_go_list_test(
     cmd.arg("-test");
     cmd.arg("-e");
     cmd.arg("-buildvcs=false");
+    cmd.arg("-pgo=off");
+    cmd.arg("-mod=readonly");
 
     if !opts.tags.is_empty() {
         cmd.arg("-tags");


### PR DESCRIPTION
## What

Add `-pgo=off` and `-mod=readonly` to both `go list -deps` invocations:

- `packages/go2nix-nix-plugin/rust/src/resolve.rs` (eval-time DAG resolver, both the main and `-test` invocations)
- `go/go2nix/pkg/golist/golist.go` (dynamic-mode resolver)

## Why

`-pgo=off` short-circuits `cmd/go`'s per-main-package `default.pgo` walk (`load/pkg.go setPGOProfilePath`). Without it, `go list -deps` traverses the entire dep tree once per main package looking for PGO profiles even when none exist — a known cliff for large modules ([golang/go#61983](https://github.com/golang/go/issues/61983)). We never want PGO to influence DAG discovery anyway; it's a build-time concern.

`-mod=readonly` is the module-mode default, but pinning it makes the invocation independent of an inherited `GOFLAGS=-mod=mod` and guarantees we never rewrite `go.mod` from inside the resolver.

## Test plan

- [x] `cargo build && cargo test` (38/38, only the 2 pre-existing clippy warnings)
- [x] `go build ./... && go vet ./... && go test ./pkg/golist/` clean
- [x] `golangci-lint run` 0 issues
- [x] Smoke-tested `go list -json=... -deps -e -buildvcs=false -pgo=off -mod=readonly ./...` accepts the flags

This is a no-behaviour-change quick win extracted from research on caching `resolveGoPackages`.