### PR TITLE
plugin: restore No-IFD on default path; warn on derivation-backed src

### DIFF
--- a/go/bench-incremental/main.go
+++ b/go/bench-incremental/main.go
@@ -231,7 +231,6 @@ func (t *nixTool) build(srcPath string) (buildResult, error) {
 	baseArgs := []string{
 		"-I", "nixpkgs=" + t.nixpkgsPath,
 		"--option", "plugin-files", t.pluginPath,
-		"--option", "allow-import-from-derivation", "true",
 	}
 	baseArgs = append(baseArgs, t.extraOpts...)
 

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -295,7 +295,9 @@ let
   # modules from go.sum + GOMODCACHE, returned as moduleHashes.
   goPackagesResult = builtins.resolveGoPackages (
     {
-      go = "${go}/bin/go";
+      # `go` is intentionally omitted: the plugin uses the toolchain baked in
+      # at its own build time. Passing "${go}/bin/go" would carry derivation
+      # context, which the plugin rejects to keep this path IFD-free.
       inherit
         src
         tags

--- a/packages/benchmark-build/default.nix
+++ b/packages/benchmark-build/default.nix
@@ -147,7 +147,7 @@ pkgs.writeShellApplication {
     SRC_CHANGE_RUNS=''${BENCH_SRC_CHANGE_RUNS:-3}
 
     NIXPKGS_OPT="-I nixpkgs=${nixpkgsPath}"
-    IFD_OPT="--option allow-import-from-derivation true"
+    IFD_OPT=""
     GOMODCACHE="${goModules}"
     export GOMODCACHE IFD_OPT
 

--- a/packages/go2nix-nix-plugin/default.nix
+++ b/packages/go2nix-nix-plugin/default.nix
@@ -10,6 +10,7 @@ let
     boost
     nlohmann_json
     nixVersions
+    go
     ;
   nixComponents = nixVersions.nix_2_34.libs;
 
@@ -19,6 +20,10 @@ let
     src = ./rust;
     cargoLock.lockFile = ./rust/Cargo.lock;
     doCheck = false;
+    # Baked into the binary via option_env!("GO2NIX_DEFAULT_GO") so the
+    # eval-time builtin never needs to realise a derivation for the Go
+    # toolchain — that would be IFD.
+    GO2NIX_DEFAULT_GO = "${go}/bin/go";
   };
 in
 stdenv.mkDerivation {

--- a/packages/go2nix-nix-plugin/plugin/resolveGoPackages.cc
+++ b/packages/go2nix-nix-plugin/plugin/resolveGoPackages.cc
@@ -53,31 +53,43 @@ static void prim_resolveGoPackages(EvalState &state, const PosIdx pos,
     NixStringContext context;
     auto inputJson = printValueAsJSON(state, true, *args[0], pos, context, false);
 
-    // resolveGoPackages must be evaluable with allow-import-from-derivation
-    // = false. Reject any derivation-output context instead of building it;
-    // opaque (already-copied) source paths are validated but never built.
+    // The default-mode call site (nix/dag/default.nix) passes only source
+    // paths, so this loop sees Opaque context only and evaluation stays
+    // IFD-free. When a caller passes a derivation-backed value
+    // (e.g. src = pkgs.fetchFromGitHub {...}), warn and fall through to
+    // realiseContext so it still works — that is opt-in IFD by construction
+    // and remains gated by allow-import-from-derivation.
+    bool needRealise = false;
     for (const auto &c : context) {
         std::visit(overloaded {
             [&](const NixStringContextElem::Opaque &o) {
                 state.store->ensurePath(o.path);
             },
             [&](const NixStringContextElem::Built &) {
-                state.error<EvalError>(
-                    "resolveGoPackages: input refers to derivation output '%s'; "
-                    "pass a source path. The Go toolchain path is baked into the "
-                    "plugin at build time, so 'go' should be omitted (or set to a "
-                    "context-free string).",
-                    c.display(*state.store))
-                    .atPos(pos).debugThrow();
+                warn("resolveGoPackages: realising derivation '%s' at eval time "
+                     "(IFD). For IFD-free evaluation, use builtins.fetchTarball/"
+                     "fetchGit for 'src' instead of pkgs.fetchFromGitHub. "
+                     "See go2nix docs: builder-api.md#src.",
+                     c.display(*state.store));
+                needRealise = true;
             },
             [&](const NixStringContextElem::DrvDeep &) {
-                state.error<EvalError>(
-                    "resolveGoPackages: input refers to derivation closure '%s'; "
-                    "pass a source path.",
-                    c.display(*state.store))
-                    .atPos(pos).debugThrow();
+                warn("resolveGoPackages: realising derivation closure '%s' at "
+                     "eval time (IFD).",
+                     c.display(*state.store));
+                needRealise = true;
             },
         }, c.raw);
+    }
+    if (needRealise) {
+        try {
+            auto _ = state.realiseContext(context);
+        } catch (InvalidPathError &e) {
+            state.error<EvalError>(
+                "resolveGoPackages: cannot realise context for '%s': %s",
+                e.path.to_string(), e.what())
+                .atPos(pos).debugThrow();
+        }
     }
 
     for (const auto &key : {"src", "go"}) {
@@ -114,9 +126,13 @@ static RegisterPrimOp rp(PrimOp {
   Discover the Go package graph at eval time by running `go list`.
 
   Accepts an attrset with:
-  - `go` (optional): Path to the Go binary (context-free string only;
-    defaults to the Go toolchain baked into the plugin at build time)
-  - `src`: Path to the Go source directory
+  - `go` (optional): Path to the Go binary. Defaults to the toolchain
+    baked into the plugin at build time; omit it to keep evaluation
+    IFD-free.
+  - `src`: Path to the Go source directory. Source paths (./. or
+    builtins.fetchTarball/fetchGit) keep evaluation IFD-free; a
+    derivation-backed value (pkgs.fetchFromGitHub) is realised at eval
+    time with a warning.
   - `tags` (optional): List of build tags
   - `subPackages` (optional): List of package patterns (default: ["./..."])
   - `modRoot` (optional): Subdirectory containing go.mod (default: ".")

--- a/packages/go2nix-nix-plugin/plugin/resolveGoPackages.cc
+++ b/packages/go2nix-nix-plugin/plugin/resolveGoPackages.cc
@@ -10,6 +10,7 @@
 #include <nix/expr/json-to-value.hh>
 #include <nix/expr/value-to-json.hh>
 #include <nix/store/local-fs-store.hh>
+#include <nix/util/util.hh>
 #include <nlohmann/json.hpp>
 
 extern "C" {
@@ -52,15 +53,31 @@ static void prim_resolveGoPackages(EvalState &state, const PosIdx pos,
     NixStringContext context;
     auto inputJson = printValueAsJSON(state, true, *args[0], pos, context, false);
 
-    // Realise string context — ensures derivation-backed store paths (e.g.,
-    // go = "${go}/bin/go") actually exist before we invoke them.
-    try {
-        auto _ = state.realiseContext(context);
-    } catch (InvalidPathError &e) {
-        state.error<EvalError>(
-            "resolveGoPackages: cannot realise context for '%s': %s",
-            e.path.to_string(), e.what())
-            .atPos(pos).debugThrow();
+    // resolveGoPackages must be evaluable with allow-import-from-derivation
+    // = false. Reject any derivation-output context instead of building it;
+    // opaque (already-copied) source paths are validated but never built.
+    for (const auto &c : context) {
+        std::visit(overloaded {
+            [&](const NixStringContextElem::Opaque &o) {
+                state.store->ensurePath(o.path);
+            },
+            [&](const NixStringContextElem::Built &) {
+                state.error<EvalError>(
+                    "resolveGoPackages: input refers to derivation output '%s'; "
+                    "pass a source path. The Go toolchain path is baked into the "
+                    "plugin at build time, so 'go' should be omitted (or set to a "
+                    "context-free string).",
+                    c.display(*state.store))
+                    .atPos(pos).debugThrow();
+            },
+            [&](const NixStringContextElem::DrvDeep &) {
+                state.error<EvalError>(
+                    "resolveGoPackages: input refers to derivation closure '%s'; "
+                    "pass a source path.",
+                    c.display(*state.store))
+                    .atPos(pos).debugThrow();
+            },
+        }, c.raw);
     }
 
     for (const auto &key : {"src", "go"}) {
@@ -97,7 +114,8 @@ static RegisterPrimOp rp(PrimOp {
   Discover the Go package graph at eval time by running `go list`.
 
   Accepts an attrset with:
-  - `go`: Path to the Go binary
+  - `go` (optional): Path to the Go binary (context-free string only;
+    defaults to the Go toolchain baked into the plugin at build time)
   - `src`: Path to the Go source directory
   - `tags` (optional): List of build tags
   - `subPackages` (optional): List of package patterns (default: ["./..."])

--- a/packages/go2nix-nix-plugin/tests/eval-test.nix
+++ b/packages/go2nix-nix-plugin/tests/eval-test.nix
@@ -35,10 +35,10 @@ pkgs.runCommand "go2nix-nix-plugin-eval-test"
 
     result=$(nix-instantiate --eval --strict --json --read-write-mode \
       --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
+      --option allow-import-from-derivation false \
       --expr "
         let
           r = builtins.resolveGoPackages {
-            go = \"${pkgs.go}/bin/go\";
             src = (toString $TMPDIR/torture-project);
             doCheck = true;
           };
@@ -76,6 +76,22 @@ pkgs.runCommand "go2nix-nix-plugin-eval-test"
       val=$(echo "$result" | jq -r ".$f")
       [ "$val" = "true" ] || { echo "FAIL: $f = $val"; exit 1; }
     done
+
+    echo "=== No-IFD: derivation-backed input is rejected ==="
+    err=$(nix-instantiate --eval --read-write-mode \
+      --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
+      --option allow-import-from-derivation false \
+      --expr '
+        builtins.resolveGoPackages {
+          go = "''${derivation { name = "bogus-go"; system = builtins.currentSystem; builder = "/no"; }}/bin/go";
+          src = ./.;
+        }
+      ' 2>&1 || true)
+    echo "$err"
+    case "$err" in
+      *"derivation output"*) echo "OK: derivation-output context rejected with clear error" ;;
+      *) echo "FAIL: expected 'derivation output' rejection, got: $err"; exit 1 ;;
+    esac
 
     echo "PASS: $pkgCount packages, $localPkgCount local packages, modulePath=$modulePath" > $out
   ''

--- a/packages/go2nix-nix-plugin/tests/eval-test.nix
+++ b/packages/go2nix-nix-plugin/tests/eval-test.nix
@@ -77,20 +77,45 @@ pkgs.runCommand "go2nix-nix-plugin-eval-test"
       [ "$val" = "true" ] || { echo "FAIL: $f = $val"; exit 1; }
     done
 
-    echo "=== No-IFD: derivation-backed input is rejected ==="
-    err=$(nix-instantiate --eval --read-write-mode \
+    echo "=== Case 2: derivation-backed input warns then realises (IFD allowed) ==="
+    # Use a trivially-buildable derivation as src so realiseContext succeeds.
+    # The Rust side will then fail (not a Go module), but the warning is what
+    # we assert on — it must surface before realisation.
+    out2=$(nix-instantiate --eval --read-write-mode \
+      --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
+      --option allow-import-from-derivation true \
+      --expr '
+        builtins.resolveGoPackages {
+          src = "''${derivation {
+            name = "drv-src"; system = builtins.currentSystem;
+            builder = "/bin/sh"; args = [ "-c" "mkdir $out" ];
+          }}";
+        }
+      ' 2>&1 || true)
+    echo "$out2"
+    case "$out2" in
+      *"realising derivation"*"at eval time (IFD)"*)
+        echo "OK: warning surfaced for derivation-backed src" ;;
+      *) echo "FAIL: expected IFD warning, got: $out2"; exit 1 ;;
+    esac
+
+    echo "=== Case 3: derivation-backed input under IFD=false → IFDError (Nix gate) ==="
+    out3=$(nix-instantiate --eval --read-write-mode \
       --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
       --option allow-import-from-derivation false \
       --expr '
         builtins.resolveGoPackages {
-          go = "''${derivation { name = "bogus-go"; system = builtins.currentSystem; builder = "/no"; }}/bin/go";
-          src = ./.;
+          src = "''${derivation {
+            name = "drv-src"; system = builtins.currentSystem;
+            builder = "/bin/sh"; args = [ "-c" "mkdir $out" ];
+          }}";
         }
       ' 2>&1 || true)
-    echo "$err"
-    case "$err" in
-      *"derivation output"*) echo "OK: derivation-output context rejected with clear error" ;;
-      *) echo "FAIL: expected 'derivation output' rejection, got: $err"; exit 1 ;;
+    echo "$out3"
+    case "$out3" in
+      *"allow-import-from-derivation"*)
+        echo "OK: Nix's IFD gate still applies" ;;
+      *) echo "FAIL: expected allow-import-from-derivation error, got: $out3"; exit 1 ;;
     esac
 
     echo "PASS: $pkgCount packages, $localPkgCount local packages, modulePath=$modulePath" > $out

--- a/packages/go2nix-nix-plugin/tests/resolve-hashes-test.nix
+++ b/packages/go2nix-nix-plugin/tests/resolve-hashes-test.nix
@@ -44,10 +44,10 @@ pkgs.runCommand "go2nix-nix-plugin-resolve-hashes-test"
     echo "=== Test 1: resolveHashes = true returns moduleHashes ==="
     result=$(nix-instantiate --eval --strict --json --read-write-mode \
       --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
+      --option allow-import-from-derivation false \
       --expr "
         let
           r = builtins.resolveGoPackages {
-            go = \"${pkgs.go}/bin/go\";
             src = (toString $TMPDIR/torture-project);
             resolveHashes = true;
           };
@@ -124,10 +124,10 @@ pkgs.runCommand "go2nix-nix-plugin-resolve-hashes-test"
     echo "=== Test 3: resolveHashes = false (default) omits moduleHashes ==="
     result_no_hashes=$(nix-instantiate --eval --strict --json --read-write-mode \
       --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
+      --option allow-import-from-derivation false \
       --expr "
         let
           r = builtins.resolveGoPackages {
-            go = \"${pkgs.go}/bin/go\";
             src = (toString $TMPDIR/torture-project);
           };
         in {

--- a/tests/test-ca.sh
+++ b/tests/test-ca.sh
@@ -36,7 +36,6 @@ cat >"$ca_store/daemon.sh" <<SCRIPT
 exec nix daemon --stdio \
   --option experimental-features "nix-command ca-derivations" \
   --option sandbox true \
-  --option allow-import-from-derivation true \
   --store "local?root=$ca_store"
 SCRIPT
 chmod +x "$ca_store/daemon.sh"
@@ -55,7 +54,6 @@ result=$(
     -I "nixpkgs=$nixpkgs_path" \
     --option extra-experimental-features 'ca-derivations' \
     --option sandbox true \
-    --option allow-import-from-derivation true \
     --option plugin-files "$plugin/lib/nix/plugins/libgo2nix_plugin.so" \
     --option substituters 'https://cache.nixos.org https://cache.numtide.com https://nix-community.cachix.org' \
     --option trusted-public-keys 'cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.numtide.com-1:bf/T+iRCVpNgNStXCXTiUMsdMfEfhaQzExC9NG28oIg= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=' \
@@ -72,7 +70,6 @@ top_drv=$(
     nix-instantiate "$repo_root/tests/fixtures/xtest-local-dep/dag-ca.nix" \
     -I "nixpkgs=$nixpkgs_path" \
     --option extra-experimental-features 'ca-derivations' \
-    --option allow-import-from-derivation true \
     --option plugin-files "$plugin/lib/nix/plugins/libgo2nix_plugin.so" \
     --add-root /dev/null --indirect 2>/dev/null
 )


### PR DESCRIPTION
## Summary

Restores the No-IFD invariant for the default-mode build path while keeping `src = pkgs.fetchFromGitHub {...}` working for local development.

**Problem:** commit 01489ce added `state.realiseContext(context)` to the C++ shim so that `go = "${go}/bin/go"` (and any derivation-backed `src`) would exist before the Rust side execs `go list`. `realiseContext` is the IFD primitive — it builds derivation outputs during evaluation. Since `nix/dag/default.nix` always passed `${go}`, every default-mode `buildGoApplication` evaluation built the Go toolchain and broke under `allow-import-from-derivation = false`.

**Fix (two commits):**

1. `0312a5e` — Stop passing `go = "${go}/bin/go"` from `nix/dag`; the plugin already bakes the Go path at its own build time via `GO2NIX_DEFAULT_GO` (added in 3d6697f) and carries `go` in its runtime closure. Replace `realiseContext` with a per-element `std::visit`: `Opaque` → `ensurePath`, `Built`/`DrvDeep` → error. Remove the `--option allow-import-from-derivation true` workarounds from `tests/test-ca.sh`, `packages/benchmark-build/`, `go/bench-incremental/`. The eval-test and resolve-hashes-test now run with `allow-import-from-derivation = false`.

2. `665688f` — Soften `Built`/`DrvDeep` from error to **warn-then-realise**, so callers passing a derivation-backed `src` (e.g. the `packages/test-package-*` fixtures) keep working. The warning points to `builtins.fetchTarball`/`fetchGit` as the IFD-free alternative. Nix's own `allow-import-from-derivation` gate still applies — the plugin never bypasses it.

**Net behaviour:**
- Default-mode `buildGoApplication` with a source-path `src` (local checkout, fileset, `builtins.fetchGit`) evaluates with `allow-import-from-derivation = false` and emits no warning.
- `src = pkgs.fetchFromGitHub {...}` still works under default settings, with a one-line warning explaining the IFD and how to avoid it.
- Under `allow-import-from-derivation = false`, derivation-backed `src` fails with Nix's own gate error (the warning prints first, which usefully tells the user the fix).

## Test plan

- [x] `nix build .#go2nix-nix-plugin` — `strings` shows the baked `go-1.26.1/bin/go` path; `nix-store -qR` shows go in runtime closure
- [x] `tests/fixtures/xtest-local-dep/dag.nix` instantiates under `--option allow-import-from-derivation false` with no warning
- [x] `tests/packages/yubikey-agent/dag.nix` (`pkgs.fetchFromGitHub`) instantiates under default settings with the warning
- [x] Derivation-backed input under `allow-import-from-derivation = false` fails with Nix's gate error
- [x] Warning fires deterministically on context type, not realisation state (re-eval after build still warns)
- [x] `nix build .#checks.x86_64-linux.formatting`
- [x] eval-test cases 1/2/3 cover positive, warn, and gated paths