### PR TITLE
dag: don't reject module-level nativeBuildInputs on non-cgo packages

### DIFF
--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -377,10 +377,19 @@ let
 
       # Per-package overrides (e.g., nativeBuildInputs for cgo libraries).
       # Lookup order: exact import path, then module path, then empty.
-      pkgOverride = packageOverrides.${importPath} or packageOverrides.${minfo.path} or { };
+      isExactOverride = builtins.hasAttr importPath packageOverrides;
+      rawOverride = packageOverrides.${importPath} or packageOverrides.${minfo.path} or { };
       # nativeBuildInputs only reaches PATH via stdenv (cgo path);
       # rawGoCompile (non-cgo) hardcodes goPath and discards it. Reject
-      # for non-cgo so users get an error instead of a silent no-op.
+      # for non-cgo so users get an error instead of a silent no-op —
+      # but only for exact-match overrides. A module-path override
+      # legitimately spans both cgo and non-cgo packages in the same
+      # module, so for the fallback case we silently drop the attr.
+      pkgOverride =
+        if isExactOverride || isCgo then
+          rawOverride
+        else
+          builtins.removeAttrs rawOverride [ "nativeBuildInputs" ];
       knownOverrideAttrs = [ "env" ] ++ lib.optional isCgo "nativeBuildInputs";
       unknownAttrs = builtins.attrNames (builtins.removeAttrs pkgOverride knownOverrideAttrs);
       extraNativeBuildInputs = pkgOverride.nativeBuildInputs or [ ];
@@ -604,9 +613,17 @@ let
         cgoBuildInputs = if isCgo then [ stdenv.cc ] else [ ];
         mkDeriv = pickMk isCgo;
 
-        pkgOverride = packageOverrides.${importPath} or packageOverrides.${minfo.path} or { };
+        isExactOverride = builtins.hasAttr importPath packageOverrides;
+        rawOverride = packageOverrides.${importPath} or packageOverrides.${minfo.path} or { };
         # nativeBuildInputs only reaches PATH via stdenv (cgo path);
         # rawGoCompile (non-cgo) hardcodes goPath and discards it.
+        # Filter (don't throw) when matched via module-path fallback —
+        # module-level overrides legitimately span cgo and non-cgo packages.
+        pkgOverride =
+          if isExactOverride || isCgo then
+            rawOverride
+          else
+            builtins.removeAttrs rawOverride [ "nativeBuildInputs" ];
         knownOverrideAttrs = [ "env" ] ++ lib.optional isCgo "nativeBuildInputs";
         unknownAttrs = builtins.attrNames (builtins.removeAttrs pkgOverride knownOverrideAttrs);
         extraNativeBuildInputs = pkgOverride.nativeBuildInputs or [ ];


### PR DESCRIPTION
## Summary
- The non-cgo `nativeBuildInputs` rejection (from c89a10f) now filters the attribute instead of throwing when the override key matched via module-path fallback — module-level overrides legitimately span cgo and non-cgo packages within a module.
- Exact import-path overrides still hard-error on non-cgo packages.
- Unbreaks `test-package-nwg-drawer`.

## Test plan
- [x] `nix eval .#test-package-nwg-drawer.drvPath` succeeds (was throwing on main)
- [x] `nix flake check` — formatting + check-godebug-table pass
