### PR TITLE
fix replace handling: modKey, version-qualified, EscapeVersion

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,11 @@
           test-fixture-torture-app-full = callPkgWith ./packages/test-fixture-torture-app-full/default.nix {
             inherit flake system;
           };
+          test-fixture-torture-app-replace =
+            callPkgWith ./packages/test-fixture-torture-app-replace/default.nix
+              {
+                inherit flake system;
+              };
 
           go2nix-testgen = callPkgWith ./packages/go2nix-testgen/default.nix {
             inherit flake system;

--- a/go/go2nix/pkg/golist/golist.go
+++ b/go/go2nix/pkg/golist/golist.go
@@ -211,9 +211,12 @@ func CollectGoModModules(dir string) ([]ModInfo, error) {
 		return nil, fmt.Errorf("parsing go.mod: %w", err)
 	}
 
-	replaces := make(map[string]*modfile.Replace, len(mf.Replace))
+	// Key by (Old.Path, Old.Version): a replace with Old.Version != "" applies
+	// only when the module resolves to exactly that version. The wildcard form
+	// (Old.Version == "") applies to any version. Mirrors modfile semantics.
+	replaces := make(map[module.Version]*modfile.Replace, len(mf.Replace))
 	for _, r := range mf.Replace {
-		replaces[r.Old.Path] = r
+		replaces[r.Old] = r
 	}
 
 	seen := map[string]bool{}
@@ -223,7 +226,11 @@ func CollectGoModModules(dir string) ([]ModInfo, error) {
 		version := req.Mod.Version
 		fetchPath := modPath
 
-		if r, ok := replaces[modPath]; ok {
+		r, ok := replaces[req.Mod]
+		if !ok {
+			r, ok = replaces[module.Version{Path: modPath}]
+		}
+		if ok {
 			if r.New.Version == "" {
 				// Local replace — skip.
 				continue

--- a/go/go2nix/pkg/golist/golist_test.go
+++ b/go/go2nix/pkg/golist/golist_test.go
@@ -1,6 +1,10 @@
 package golist
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestModuleIsLocal(t *testing.T) {
 	tests := []struct {
@@ -98,6 +102,52 @@ func TestInjectCgoImports(t *testing.T) {
 	// SwigCXX: already has all 3, should not duplicate
 	if len(pkgs[3].Imports) != 3 {
 		t.Errorf("uses/swigcxx: expected 3 imports (no duplicates), got %v", pkgs[3].Imports)
+	}
+}
+
+func TestCollectGoModModulesVersionQualifiedReplace(t *testing.T) {
+	dir := t.TempDir()
+	goMod := `module example.com/test
+go 1.23
+require (
+	github.com/foo/bar v1.0.0
+	github.com/baz/qux v0.2.0
+	github.com/local/mod v0.5.0
+)
+replace (
+	// Matches: applies, fork path + version.
+	github.com/foo/bar v1.0.0 => github.com/fork/bar v1.5.0
+	// Does NOT match required v0.2.0: must NOT apply.
+	github.com/baz/qux v0.9.9 => github.com/baz/qux v0.3.0
+	// Does NOT match required v0.5.0: must NOT skip as local.
+	github.com/local/mod v0.9.9 => ../localdir
+)
+`
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mods, err := CollectGoModModules(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := map[string]ModInfo{}
+	for _, m := range mods {
+		got[m.Key] = m
+	}
+
+	if m, ok := got["github.com/foo/bar@v1.5.0"]; !ok || m.FetchPath != "github.com/fork/bar" {
+		t.Errorf("foo/bar: matching version-qualified replace not applied; got %+v", got)
+	}
+	if m, ok := got["github.com/baz/qux@v0.2.0"]; !ok || m.FetchPath != "github.com/baz/qux" {
+		t.Errorf("baz/qux: non-matching version-qualified replace was applied; got %+v", got)
+	}
+	if _, ok := got["github.com/local/mod@v0.5.0"]; !ok {
+		t.Errorf("local/mod: non-matching local replace caused skip; got %+v", got)
+	}
+	if len(mods) != 3 {
+		t.Errorf("expected 3 modules, got %d: %+v", len(mods), mods)
 	}
 }
 

--- a/go/go2nix/pkg/mvscheck/mvscheck.go
+++ b/go/go2nix/pkg/mvscheck/mvscheck.go
@@ -33,9 +33,12 @@ func CheckLockfile(dir string, lockfilePath string) error {
 		return err
 	}
 
-	replaces := make(map[string]*modfile.Replace, len(mf.Replace))
+	// Key by (Old.Path, Old.Version): a replace with Old.Version != "" applies
+	// only when the module resolves to exactly that version. The wildcard form
+	// (Old.Version == "") applies to any version. Mirrors modfile semantics.
+	replaces := make(map[module.Version]*modfile.Replace, len(mf.Replace))
 	for _, r := range mf.Replace {
-		replaces[r.Old.Path] = r
+		replaces[r.Old] = r
 	}
 
 	var missing []string
@@ -43,7 +46,11 @@ func CheckLockfile(dir string, lockfilePath string) error {
 		modPath := req.Mod.Path
 		version := req.Mod.Version
 
-		if r, ok := replaces[modPath]; ok {
+		r, ok := replaces[req.Mod]
+		if !ok {
+			r, ok = replaces[module.Version{Path: modPath}]
+		}
+		if ok {
 			if r.New.Version == "" {
 				// Local replace (directory path, no version) — not in lockfile.
 				continue

--- a/go/go2nix/pkg/mvscheck/mvscheck_test.go
+++ b/go/go2nix/pkg/mvscheck/mvscheck_test.go
@@ -73,6 +73,41 @@ replace github.com/local/mod => ../localdir
 		}
 	})
 
+	t.Run("version-qualified replace not matching is ignored", func(t *testing.T) {
+		writeFile("go.mod", `module example.com/test
+go 1.23
+require (
+	github.com/foo/bar v1.0.0
+	github.com/local/mod v0.5.0
+)
+replace github.com/local/mod v0.9.9 => ../localdir
+`)
+		// Replace targets v0.9.9 but require is v0.5.0 — must NOT apply,
+		// so local/mod@v0.5.0 is checked against the lockfile and missing.
+		err := CheckLockfile(dir, lockfilePath)
+		if err == nil {
+			t.Fatal("expected error: version-qualified replace should not match v0.5.0")
+		}
+		if !strings.Contains(err.Error(), "github.com/local/mod@v0.5.0") {
+			t.Errorf("error should mention github.com/local/mod@v0.5.0:\n%s", err)
+		}
+	})
+
+	t.Run("wildcard replace wins over no match", func(t *testing.T) {
+		writeFile("go.mod", `module example.com/test
+go 1.23
+require github.com/remote/replace v1.0.0
+replace (
+	github.com/remote/replace v0.9.9 => github.com/remote/replace v0.8.8
+	github.com/remote/replace => github.com/remote/replace v3.0.0
+)
+`)
+		// v0.9.9 directive does not match; wildcard does → v3.0.0, in lockfile.
+		if err := CheckLockfile(dir, lockfilePath); err != nil {
+			t.Fatalf("wildcard replace should apply: %v", err)
+		}
+	})
+
 	t.Run("versioned replace uses replacement version", func(t *testing.T) {
 		writeFile("go.mod", `module example.com/test
 go 1.23

--- a/go/go2nix/pkg/resolve/resolve.go
+++ b/go/go2nix/pkg/resolve/resolve.go
@@ -692,7 +692,11 @@ func setupPkgSource(
 	if err != nil {
 		return fmt.Errorf("escaping module path %s: %w", pkg.FetchPath, err)
 	}
-	relDir := escapedPath + "@" + pkg.Version
+	escapedVersion, err := module.EscapeVersion(pkg.Version)
+	if err != nil {
+		return fmt.Errorf("escaping module version %s: %w", pkg.Version, err)
+	}
+	relDir := escapedPath + "@" + escapedVersion
 	if pkg.Subdir != "" {
 		relDir += "/" + pkg.Subdir
 	}

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -345,7 +345,7 @@ let
     mod
     // {
       inherit fetchPath;
-      dirSuffix = "${helpers.escapeModPath fetchPath}@${version}";
+      dirSuffix = "${helpers.escapeModPath fetchPath}@${helpers.escapeModPath version}";
     }
   ) allModules;
 

--- a/nix/dag/fetch-go-module.nix
+++ b/nix/dag/fetch-go-module.nix
@@ -33,7 +33,8 @@ in
 }:
 let
   escapedPath = escapeModPath fetchPath;
-  dirSuffix = "${escapedPath}@${version}";
+  # Both path and version are case-escaped on disk (module.EscapeVersion).
+  dirSuffix = "${escapedPath}@${escapeModPath version}";
 in
 stdenvNoCC.mkDerivation {
   name = "gomod-${sanitizeName fetchPath}-${version}";

--- a/packages/go2nix-nix-plugin/rust/src/module_hashes.rs
+++ b/packages/go2nix-nix-plugin/rust/src/module_hashes.rs
@@ -129,17 +129,19 @@ fn parse_go_sum(path: &Path) -> Result<Vec<GoSumEntry>> {
 
 /// Construct the path to a module's extracted source tree in GOMODCACHE.
 ///
-/// GOMODCACHE layout: `<escaped-path>@<version>/`
+/// GOMODCACHE layout: `<escaped-path>@<escaped-version>/`
 /// e.g. `$GOMODCACHE/github.com/foo/bar@v1.2.3/`
 ///
-/// Go escapes uppercase letters in module paths: `A` → `!a`.
+/// Go escapes uppercase letters in both segments: `A` → `!a`
+/// (module.EscapePath / module.EscapeVersion).
 fn module_source_dir(gomodcache: &Path, mod_path: &str, version: &str) -> PathBuf {
-    let escaped = escape_mod_path(mod_path);
-    gomodcache.join(format!("{escaped}@{version}"))
+    let escaped_path = escape_mod_path(mod_path);
+    let escaped_version = escape_mod_path(version);
+    gomodcache.join(format!("{escaped_path}@{escaped_version}"))
 }
 
-/// Go module path case-escaping: uppercase → `!` + lowercase.
-/// Matches golang.org/x/mod/module.EscapePath().
+/// Go module path/version case-escaping: uppercase → `!` + lowercase.
+/// Matches golang.org/x/mod/module.EscapePath() / EscapeVersion().
 fn escape_mod_path(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
@@ -224,6 +226,20 @@ mod tests {
     fn escape_mod_path_basic() {
         assert_eq!(escape_mod_path("github.com/BurntSushi/toml"), "github.com/!burnt!sushi/toml");
         assert_eq!(escape_mod_path("github.com/foo/bar"), "github.com/foo/bar");
+    }
+
+    #[test]
+    fn module_source_dir_escapes_version() {
+        let base = Path::new("/cache");
+        // Uppercase pre-release identifiers are case-escaped on disk.
+        assert_eq!(
+            module_source_dir(base, "github.com/Foo/bar", "v1.0.0-RC1"),
+            Path::new("/cache/github.com/!foo/bar@v1.0.0-!r!c1")
+        );
+        assert_eq!(
+            module_source_dir(base, "github.com/foo/bar", "v1.2.3"),
+            Path::new("/cache/github.com/foo/bar@v1.2.3")
+        );
     }
 }
 

--- a/packages/go2nix-nix-plugin/rust/src/resolve.rs
+++ b/packages/go2nix-nix-plugin/rust/src/resolve.rs
@@ -922,6 +922,26 @@ pub(crate) fn package_graph_to_json(
         })
         .collect();
 
+    // Re-key module_hashes by modKey (origPath@effectiveVersion). go.sum lists
+    // modules under their *fetch* path, so for a fork replace `foo => fork v2`
+    // it contains `fork@v2` while the per-package modKey is `foo@v2`. Insert an
+    // alias so nix/dag's `moduleInfo.${pkg.modKey}` lookup hits. The original
+    // entry is left in place — Nix evaluates lazily, and same-path replaces
+    // (modKey == fetch key) make this a no-op.
+    let mut module_hashes = module_hashes;
+    for (mod_key, (repl_path, repl_ver)) in &graph.replacements {
+        if repl_ver.is_empty() {
+            continue; // local replace — no fetch, no go.sum entry
+        }
+        let fetch_key = format!("{repl_path}@{repl_ver}");
+        if fetch_key == *mod_key {
+            continue;
+        }
+        if let Some(h) = module_hashes.get(&fetch_key).cloned() {
+            module_hashes.insert(mod_key.clone(), h);
+        }
+    }
+
     // Build test_packages map.
     let test_packages: BTreeMap<String, JsonPkg> = graph
         .test_packages
@@ -1087,6 +1107,42 @@ mod tests {
         let (path, version) = &graph.replacements["github.com/old/pkg@v2.0.0"];
         assert_eq!(path, "github.com/new/pkg");
         assert_eq!(version, "v2.0.0");
+    }
+
+    #[test]
+    fn module_hashes_rekeyed_by_mod_key_for_fork_replace() {
+        // Fork replace: old/pkg => new/pkg v2.0.0. go.sum (and thus the
+        // incoming module_hashes map) keys this as new/pkg@v2.0.0, but the
+        // per-package modKey is old/pkg@v2.0.0. The JSON output must alias
+        // the hash under the modKey so nix/dag's moduleInfo lookup hits.
+        let input = replaced_json(
+            "github.com/old/pkg",
+            "github.com/old/pkg",
+            "v1.0.0",
+            "github.com/new/pkg",
+            "v2.0.0",
+        );
+        let graph = parse_go_packages(input.as_bytes()).unwrap();
+
+        let mut hashes = BTreeMap::new();
+        hashes.insert("github.com/new/pkg@v2.0.0".to_owned(), "sha256-fork".to_owned());
+
+        let src = tempfile::tempdir().unwrap();
+        let json = package_graph_to_json(&graph, src.path().to_str().unwrap(), hashes).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        let mod_hashes = &v["moduleHashes"];
+        assert_eq!(
+            mod_hashes["github.com/old/pkg@v2.0.0"], "sha256-fork",
+            "hash must be aliased under origPath@effectiveVersion"
+        );
+        // Original go.sum key is still present (harmless under lazy eval).
+        assert_eq!(mod_hashes["github.com/new/pkg@v2.0.0"], "sha256-fork");
+        // And the package's modKey matches the alias.
+        assert_eq!(
+            v["packages"]["github.com/old/pkg"]["modKey"],
+            "github.com/old/pkg@v2.0.0"
+        );
     }
 
     #[test]

--- a/packages/test-fixture-torture-app-replace/default.nix
+++ b/packages/test-fixture-torture-app-replace/default.nix
@@ -1,0 +1,66 @@
+# default mode fixture test: lockfile-free + fork-style replace directive.
+#
+# app-replace's go.mod has `replace go.uber.org/atomic => github.com/uber-go/atomic`,
+# so go.sum lists only the replacement path while the modKey nix/dag looks up
+# is "go.uber.org/atomic@v1.11.0". Regression for plugin moduleHashes re-keying.
+{
+  flake,
+  pkgs,
+  system,
+  ...
+}:
+if !(flake.packages.${system} ? go2nix-nix-plugin) then
+  pkgs.runCommand "test-dag-fixture-torture-app-replace-unsupported"
+    { meta.platforms = pkgs.lib.platforms.linux; }
+    ''
+      echo "test-dag-fixture-torture-app-replace requires go2nix-nix-plugin (Linux only)" >&2
+      exit 1
+    ''
+else
+  let
+    plugin = flake.packages.${system}.go2nix-nix-plugin;
+    nix = pkgs.nixVersions.nix_2_34;
+    go = pkgs.go_1_26;
+
+    nixpkgsPath = pkgs.path;
+    go2nixSrc = flake;
+
+    goModules = pkgs.stdenvNoCC.mkDerivation {
+      name = "torture-app-replace-gomodcache";
+      outputHashMode = "recursive";
+      outputHashAlgo = "sha256";
+      outputHash = "sha256-0kSvZbvcdFZfA/2DrFqbt3zw14K0jrYSgXEBZkjv7Cs=";
+      nativeBuildInputs = [
+        go
+        pkgs.cacert
+      ];
+      dontUnpack = true;
+      buildPhase = ''
+        export HOME=$TMPDIR
+        export GOMODCACHE=$out
+        cd ${go2nixSrc}/tests/fixtures/torture-project/app-replace
+        go mod download
+      '';
+      installPhase = "true";
+    };
+  in
+  pkgs.runCommand "test-dag-fixture-torture-app-replace"
+    {
+      nativeBuildInputs = [ nix ];
+      requiredSystemFeatures = [ "recursive-nix" ];
+    }
+    ''
+      export HOME=$(mktemp -d)
+      export NIX_CONFIG="extra-experimental-features = nix-command recursive-nix"
+
+      echo "=== Building torture app-replace fixture (lockfile-free, fork replace) ==="
+      result=$(GOMODCACHE=${goModules} \
+        nix-build ${go2nixSrc}/tests/fixtures/torture-project/dag-app-replace.nix \
+        -I nixpkgs=${nixpkgsPath} \
+        --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
+        --no-out-link)
+
+      out_val=$($result/bin/app-replace)
+      [ "$out_val" = "42" ] || { echo "FAIL: expected 42, got $out_val"; exit 1; }
+      echo "PASS: torture-app-replace" > $out
+    ''

--- a/tests/fixtures/torture-project/app-replace/cmd/app-replace/main.go
+++ b/tests/fixtures/torture-project/app-replace/cmd/app-replace/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	"go.uber.org/atomic"
+)
+
+func main() {
+	fmt.Println(atomic.NewInt64(42).Load())
+}

--- a/tests/fixtures/torture-project/app-replace/go.mod
+++ b/tests/fixtures/torture-project/app-replace/go.mod
@@ -1,0 +1,10 @@
+module github.com/numtide/go2nix/torture/app-replace
+
+go 1.23
+
+require go.uber.org/atomic v1.11.0
+
+// Fork replace: original path != replacement path. go.sum lists the
+// replacement path, while modKey is "go.uber.org/atomic@v1.11.0".
+// Regression fixture for lockfile-free moduleHashes re-keying.
+replace go.uber.org/atomic => github.com/uber-go/atomic v1.11.0

--- a/tests/fixtures/torture-project/app-replace/go.sum
+++ b/tests/fixtures/torture-project/app-replace/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/uber-go/atomic v1.11.0 h1:C56ZebT85RcftFIqIDlII7SdwyOZmV4Te5aV170QFhk=
+github.com/uber-go/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=

--- a/tests/fixtures/torture-project/dag-app-replace.nix
+++ b/tests/fixtures/torture-project/dag-app-replace.nix
@@ -1,0 +1,22 @@
+# Test: default mode, lockfile-free, with a fork-style replace directive.
+#
+# go.mod has `replace go.uber.org/atomic => github.com/uber-go/atomic v1.11.0`,
+# so go.sum lists only the replacement path. Regression for moduleHashes
+# re-keying: the plugin must return hashes keyed by "go.uber.org/atomic@v1.11.0"
+# (the modKey nix/dag looks up), not the replacement path.
+let
+  pkgs = import <nixpkgs> { };
+  go = pkgs.go_1_26;
+  go2nix = import ../../../packages/go2nix { inherit pkgs; };
+  goEnv = import ../../../nix/mk-go-env.nix {
+    inherit go go2nix;
+    inherit (pkgs) callPackage;
+  };
+in
+goEnv.buildGoApplication {
+  pname = "torture-app-replace";
+  version = "0.0.1";
+  src = ./.;
+  modRoot = "app-replace";
+  subPackages = [ "cmd/app-replace" ];
+}


### PR DESCRIPTION
## Summary
- Re-key the plugin's `moduleHashes` by `origPath@effectiveVersion` so `nix/dag`'s `modKey` lookup matches when `go.mod` has a fork-style replace.
- Key replace maps by `(Old.Path, Old.Version)` with wildcard fallback in `golist` and `mvscheck` — version-qualified replaces were applied unconditionally.
- Case-escape the version segment per `module.EscapeVersion` in `dirSuffix`/GOMODCACHE source-dir paths (Nix and Go sides).
- Adds a torture sub-fixture with a fork replace.

## Test plan
- [x] `(cd go/go2nix && go test ./... && go vet ./...)`
- [x] `cargo test` (in `packages/go2nix-nix-plugin/rust`)
- [x] `nix flake check` — formatting + check-godebug-table pass
