### PR TITLE
localpkgs: stop at nested go.mod and skip dot-directories

### DIFF
--- a/go/go2nix/pkg/localpkgs/localpkgs.go
+++ b/go/go2nix/pkg/localpkgs/localpkgs.go
@@ -81,8 +81,19 @@ func ListLocalPackages(root string, tags string, goVersion string) ([]*LocalPkg,
 				return nil
 			}
 			name := d.Name()
-			if name == "vendor" || name == "testdata" || name == ".git" || strings.HasPrefix(name, "_") {
+			if name == "vendor" || name == "testdata" || strings.HasPrefix(name, "_") {
 				return filepath.SkipDir
+			}
+			if path != dir {
+				// Match cmd/go's `./...` semantics: skip all dot-directories
+				// (.git, .idea, .direnv, ...) and stop at nested module
+				// boundaries.
+				if strings.HasPrefix(name, ".") {
+					return filepath.SkipDir
+				}
+				if _, err := os.Stat(filepath.Join(path, "go.mod")); err == nil {
+					return filepath.SkipDir
+				}
 			}
 
 			pkg, importErr := ctx.ImportDir(path, build.IgnoreVendor)

--- a/go/go2nix/pkg/localpkgs/localpkgs_test.go
+++ b/go/go2nix/pkg/localpkgs/localpkgs_test.go
@@ -221,6 +221,56 @@ func TestListLocalPackages_SkipsVendorAndTestdata(t *testing.T) {
 	}
 }
 
+func TestListLocalPackages_SkipsDotDirs(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/test\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(root, "main.go"), "package main\n\nfunc main() {}\n")
+	writeFile(t, filepath.Join(root, ".vscode", "x.go"), "package vscode\n")
+	writeFile(t, filepath.Join(root, ".idea", "y.go"), "package idea\n")
+	writeFile(t, filepath.Join(root, ".direnv", "z.go"), "package direnv\n")
+
+	pkgs, err := ListLocalPackages(root, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	paths := importPaths(pkgs)
+	if len(paths) != 1 || paths[0] != "example.com/test" {
+		t.Fatalf("expected only root package, got %v", paths)
+	}
+}
+
+func TestListLocalPackages_SkipsNestedModules(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/parent\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(root, "main.go"), "package main\n\nfunc main() {}\n")
+	writeFile(t, filepath.Join(root, "lib", "lib.go"), "package lib\n")
+	// Nested module: has its own go.mod, must not be reported as part of parent.
+	writeFile(t, filepath.Join(root, "sub", "go.mod"), "module example.com/child\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(root, "sub", "child.go"), "package child\n")
+	writeFile(t, filepath.Join(root, "sub", "deeper", "d.go"), "package deeper\n")
+
+	pkgs, err := ListLocalPackages(root, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	paths := importPaths(pkgs)
+	for _, p := range paths {
+		if strings.HasPrefix(p, "example.com/parent/sub") {
+			t.Errorf("nested module package %q should have been skipped; got %v", p, paths)
+		}
+	}
+	if indexOf(paths, "example.com/parent") == -1 {
+		t.Errorf("expected root package in %v", paths)
+	}
+	if indexOf(paths, "example.com/parent/lib") == -1 {
+		t.Errorf("expected sibling lib package in %v", paths)
+	}
+}
+
 func TestListLocalPackages_NoGoMod(t *testing.T) {
 	root := t.TempDir()
 	_, err := ListLocalPackages(root, "", "")


### PR DESCRIPTION
## Summary
- `walkDir` now matches `go list ./...` semantics: skip any subdirectory containing its own `go.mod` (module boundary), and skip all dot-directories rather than only `.git`.
- Adds unit tests covering a nested-module fixture and `.idea`/`.vscode` dirs.

## Test plan
- [x] `(cd go/go2nix && go test ./... && go vet ./...)`
- [x] `nix flake check` — formatting + check-godebug-table pass
