### PR TITLE
dag: use buildPlatform.system; thread GOOS/GOARCH consistently

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -147,6 +147,7 @@
           };
           golangci-lint-go2nix-testgen = callPkg ./packages/golangci-lint-go2nix-testgen/default.nix;
           check-godebug-table = callPkg ./packages/check-godebug-table/default.nix;
+          cross-platform-env = callPkgWith ./tests/nix/cross_platform_test.nix { inherit pkgs; };
           # The --help check just confirms the binary links and the CLI
           # surface is intact. The benchmark itself can't run in nix's
           # build sandbox (it spawns a nested daemon and fetches from

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -31,8 +31,7 @@
   helpers,
   stdlib,
   goEnv,
-  bash,
-  coreutils,
+  buildPackages,
   ...
 }:
 
@@ -182,15 +181,18 @@ let
     derivation (
       {
         inherit name;
-        inherit (stdenv.hostPlatform) system;
-        builder = "${bash}/bin/bash";
+        # Raw derivations bypass stdenv's platform handling. The builder
+        # (bash + go tool compile) runs on the build machine; cross targets
+        # are selected via GOOS/GOARCH in `env`, not via drv `system`.
+        inherit (stdenv.buildPlatform) system;
+        builder = "${buildPackages.bash}/bin/bash";
         args = [ rawGoCompileScript ];
         # compileManifestJSON now carries per-file lists; pass it via a
         # temp file so packages with thousands of source files don't risk
         # MAX_ARG_STRLEN. (The stdenv/cgo path already avoids this via
         # __structuredAttrs.)
         passAsFile = [ "compileManifestJSON" ];
-        goPath = "${coreutils}/bin:${go}/bin";
+        goPath = "${buildPackages.coreutils}/bin:${go}/bin";
         go2nixBin = "${go2nix}/bin/go2nix";
       }
       // env
@@ -249,10 +251,16 @@ let
     }
     // extraEnv;
 
+  # Target platform for `go tool compile`/`link`. goEnv wins so a user-set
+  # GOOS/GOARCH (via mkGoEnv { goEnv = ...; }) is honoured everywhere the
+  # plugin/link manifest/buildMode look at the target.
+  targetGoos = goEnv.GOOS or stdenv.hostPlatform.go.GOOS or null;
+  targetGoarch = goEnv.GOARCH or stdenv.hostPlatform.go.GOARCH or null;
+
   # Match Go's internal/platform.DefaultPIE: PIE for darwin, windows, android, ios.
   buildMode =
     let
-      goos = stdenv.hostPlatform.go.GOOS;
+      goos = targetGoos;
     in
     if
       builtins.elem goos [
@@ -317,8 +325,8 @@ let
       # File lists in the manifest are computed at eval time by `go list`;
       # pass the same target platform here that the build derivations will
       # use so constraint evaluation matches.
-      goos = stdenv.hostPlatform.go.GOOS or null;
-      goarch = stdenv.hostPlatform.go.GOARCH or null;
+      goos = targetGoos;
+      goarch = targetGoarch;
     }
     // (if goProxy != null then { inherit goProxy; } else { })
     // (if CGO_ENABLED != null then { cgoEnabled = toString CGO_ENABLED; } else { })
@@ -570,10 +578,10 @@ let
   rawDepsImportcfg = derivation (
     {
       name = "${pname}-deps-importcfg";
-      inherit (stdenv.hostPlatform) system;
-      builder = "${bash}/bin/bash";
+      inherit (stdenv.buildPlatform) system;
+      builder = "${buildPackages.bash}/bin/bash";
       __structuredAttrs = true;
-      PATH = "${coreutils}/bin";
+      PATH = "${buildPackages.coreutils}/bin";
       inherit allPkgsImportcfg;
       stdlibCfg = "${stdlib}/importcfg";
       args = [
@@ -795,8 +803,8 @@ let
         else
           null;
       inherit pname;
-      goos = stdenv.hostPlatform.go.GOOS or null;
-      goarch = stdenv.hostPlatform.go.GOARCH or null;
+      goos = targetGoos;
+      goarch = targetGoarch;
       inherit ldflags;
       inherit tags;
       inherit gcflags;

--- a/nix/dynamic/default.nix
+++ b/nix/dynamic/default.nix
@@ -140,7 +140,7 @@ let
         --src ${src} \
         --mod-root ${lib.escapeShellArg modRoot} \
         --lockfile ${goLock} \
-        --system ${stdenv.hostPlatform.system} \
+        --system ${stdenv.buildPlatform.system} \
         --go ${go}/bin/go \
         --stdlib ${stdlib} \
         --nix ${nixPackage}/bin/nix \

--- a/nix/scope.nix
+++ b/nix/scope.nix
@@ -10,6 +10,7 @@
   go,
   go2nix,
   lib,
+  stdenv,
   newScope,
   tags ? [ ],
   netrcFile ? null,
@@ -22,6 +23,16 @@ let
   # Feature detection: dynamic derivations require builtins.outputOf
   # (available when Nix has the dynamic-derivations experimental feature).
   hasDynamicDerivations = builtins ? outputOf;
+
+  # Cross-compilation: Go selects the target via GOOS/GOARCH env, not via
+  # drv `system`. stdlib (`go install std`) and per-package compiles
+  # (`go tool compile`) both read these from goEnv, so default them from
+  # the Nix host platform when cross-compiling. User-supplied goEnv wins.
+  # Native builds keep goEnv untouched so derivation hashes don't change.
+  crossGoEnv = lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+    inherit (stdenv.hostPlatform.go) GOOS GOARCH;
+  };
+  goEnv' = crossGoEnv // goEnv;
 in
 lib.makeScope newScope (
   self:
@@ -46,12 +57,12 @@ lib.makeScope newScope (
       netrcFile
       nixPackage
       hasDynamicDerivations
-      goEnv
       ;
+    goEnv = goEnv';
 
     helpers = import ./helpers.nix;
 
-    stdlib = callPackage ./stdlib.nix { inherit goEnv; };
+    stdlib = callPackage ./stdlib.nix { goEnv = goEnv'; };
 
     hooks = callPackage ./dag/hooks { };
 

--- a/tests/nix/cross_platform_test.nix
+++ b/tests/nix/cross_platform_test.nix
@@ -1,0 +1,70 @@
+# tests/nix/cross_platform_test.nix — regression for findings #10/#12.
+#
+# Eval-only assertions that under a cross stdenv:
+#   - the scope's goEnv carries GOOS/GOARCH for the host platform
+#   - the stdlib derivation runs on the build platform
+#   - native scopes leave goEnv untouched (no hash churn)
+#
+# Does not exercise per-package compile drvs (those need the plugin); the
+# scope-level goEnv is what mkCompileEnv and stdlib both consume, so
+# asserting it here covers the threading.
+{
+  lib,
+  pkgs,
+  runCommand,
+}:
+let
+  go2nix = import ../../packages/go2nix { inherit pkgs; };
+
+  nativeScope = import ../../nix/mk-go-env.nix {
+    inherit (pkgs) go callPackage;
+    inherit go2nix;
+  };
+
+  # Cross to a target that differs from every supported flake system on at
+  # least one of GOOS/GOARCH.
+  crossPkgs = pkgs.pkgsCross.riscv64;
+  crossScope = import ../../nix/mk-go-env.nix {
+    inherit (pkgs) go;
+    inherit go2nix;
+    inherit (crossPkgs) callPackage;
+  };
+
+  assertions = [
+    {
+      msg = "native scope must not inject GOOS/GOARCH into goEnv";
+      ok = nativeScope.goEnv == { };
+    }
+    {
+      msg = "cross scope goEnv.GOOS must match hostPlatform";
+      ok = crossScope.goEnv.GOOS == crossPkgs.stdenv.hostPlatform.go.GOOS;
+    }
+    {
+      msg = "cross scope goEnv.GOARCH must match hostPlatform";
+      ok = crossScope.goEnv.GOARCH == crossPkgs.stdenv.hostPlatform.go.GOARCH;
+    }
+    {
+      msg = "cross stdlib must build on buildPlatform.system";
+      ok = crossScope.stdlib.system == crossPkgs.stdenv.buildPlatform.system;
+    }
+    {
+      msg = "user goEnv overrides cross-derived GOOS";
+      ok =
+        (import ../../nix/mk-go-env.nix {
+          inherit (pkgs) go;
+          inherit go2nix;
+          inherit (crossPkgs) callPackage;
+          goEnv.GOOS = "plan9";
+        }).goEnv.GOOS == "plan9";
+    }
+  ];
+
+  failures = lib.filter (a: !a.ok) assertions;
+in
+if failures != [ ] then
+  throw "cross-platform-test: ${lib.concatMapStringsSep "; " (a: a.msg) failures}"
+else
+  runCommand "cross-platform-test" { } ''
+    echo "cross-platform-test: ${toString (lib.length assertions)} assertions passed"
+    touch $out
+  ''


### PR DESCRIPTION
## Summary
- `rawGoCompile`/`rawDepsImportcfg` and dynamic mode's `--system` now use `stdenv.buildPlatform.system` (and `buildPackages` for bash/coreutils) so per-package compiles schedule on the build machine under `pkgsCross`.
- `scope.nix` defaults `goEnv.{GOOS,GOARCH}` from `hostPlatform.go` when cross-compiling; `nix/dag` reads a single `targetGoos`/`targetGoarch` for the plugin call, link manifest and buildMode, so stdlib, per-package compiles and link agree on the target.
- Adds an eval-only `cross-platform-env` flake check (5 assertions).

## Test plan
- [x] `nix flake check` — formatting + check-godebug-table + new `cross-platform-env` pass
- [x] Manual `pkgsCross.aarch64-multiplatform` eval: per-package drv has `system=x86_64-linux`, `GOOS=linux`, `GOARCH=arm64`
