### PR TITLE
compile: godebug default ordering, cgo constraint OR, surface ObjC/SWIG

### DIFF
--- a/go/go2nix/pkg/buildinfo/godebug.go
+++ b/go/go2nix/pkg/buildinfo/godebug.go
@@ -86,7 +86,22 @@ func DefaultGODEBUG(moduleRoot string) string {
 		return ""
 	}
 
-	// Build defaults map: for each godebug entry where the module's
+	// cmd/go resolves the base version first (go directive, optionally
+	// overridden by any `godebug default=goX.Y` directive), then layers
+	// every explicit `godebug key=value` directive on top regardless of
+	// its position relative to `default=`. Do the same: first scan for
+	// `default=` to fix the base minor, then apply non-default directives.
+	for _, gd := range mf.Godebug {
+		if gd.Key != "default" {
+			continue
+		}
+		v := strings.TrimPrefix(gd.Value, "go")
+		if newMinor := parseGoMinor(v); newMinor >= 0 {
+			minor = newMinor
+		}
+	}
+
+	// Build defaults map: for each godebug entry where the effective
 	// go version < Changed, use the old value.
 	m := make(map[string]string)
 	for _, entry := range godebugTable {
@@ -98,17 +113,6 @@ func DefaultGODEBUG(moduleRoot string) string {
 	// Apply explicit godebug directives from go.mod on top.
 	for _, gd := range mf.Godebug {
 		if gd.Key == "default" {
-			// "default goX.Y" overrides the go version used for defaults.
-			v := strings.TrimPrefix(gd.Value, "go")
-			if newMinor := parseGoMinor(v); newMinor >= 0 {
-				// Recompute with the new version.
-				m = make(map[string]string)
-				for _, entry := range godebugTable {
-					if newMinor < entry.Changed {
-						m[entry.Name] = entry.Old
-					}
-				}
-			}
 			continue
 		}
 		m[gd.Key] = gd.Value

--- a/go/go2nix/pkg/buildinfo/godebug_test.go
+++ b/go/go2nix/pkg/buildinfo/godebug_test.go
@@ -119,6 +119,63 @@ func TestDefaultGODEBUG_DefaultDirective(t *testing.T) {
 	}
 }
 
+func TestDefaultGODEBUG_ExplicitSurvivesLaterDefault(t *testing.T) {
+	// Regression for finding #9: explicit `godebug k=v` directives must
+	// persist even when a `godebug default=goX.Y` directive appears later
+	// in go.mod, matching cmd/go's defaultGODEBUG.
+	tests := []struct {
+		name  string
+		gomod string
+		want  map[string]string // substrings that must appear as "k=v"
+		not   []string          // substrings that must NOT appear
+	}{
+		{
+			name: "explicit before default",
+			gomod: "module example.com/test\n\ngo 1.21\n\n" +
+				"godebug panicnil=1\n" +
+				"godebug default=go1.24\n",
+			want: map[string]string{"panicnil": "1", "containermaxprocs": "0"},
+			not:  []string{"asynctimerchan="},
+		},
+		{
+			name: "explicit after default",
+			gomod: "module example.com/test\n\ngo 1.21\n\n" +
+				"godebug default=go1.24\n" +
+				"godebug panicnil=1\n",
+			want: map[string]string{"panicnil": "1", "containermaxprocs": "0"},
+			not:  []string{"asynctimerchan="},
+		},
+		{
+			name: "explicit overrides table default regardless of position",
+			gomod: "module example.com/test\n\ngo 1.24\n\n" +
+				"godebug asynctimerchan=0\n" +
+				"godebug default=go1.21\n",
+			// default=go1.21 would set asynctimerchan=1 from the table,
+			// but the explicit directive must win.
+			want: map[string]string{"asynctimerchan": "0"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(tt.gomod), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			result := DefaultGODEBUG(dir)
+			for k, v := range tt.want {
+				if !contains(result, k+"="+v) {
+					t.Errorf("expected %s=%s in %q", k, v, result)
+				}
+			}
+			for _, s := range tt.not {
+				if contains(result, s) {
+					t.Errorf("did not expect %q in %q", s, result)
+				}
+			}
+		})
+	}
+}
+
 func TestParseGoMinor(t *testing.T) {
 	tests := []struct {
 		v    string

--- a/go/go2nix/pkg/compile/cgo.go
+++ b/go/go2nix/pkg/compile/cgo.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/numtide/go2nix/pkg/gofiles"
@@ -549,19 +550,14 @@ func matchCgoGroup(group, goos, goarch string, tags []string) bool {
 
 // matchCgoTerm reports whether a single constraint term is satisfied.
 func matchCgoTerm(term, goos, goarch string, tags []string) bool {
-	switch {
-	case term == goos || term == goarch:
+	switch term {
+	case goos, goarch:
 		return true
-	case term == "unix":
+	case "unix":
 		return unixOS[goos]
-	case term == "cgo", term == "gc":
+	case "cgo", "gc":
 		// We are the gc toolchain compiling a cgo package.
 		return true
 	}
-	for _, t := range tags {
-		if t == term {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(tags, term)
 }

--- a/go/go2nix/pkg/compile/cgo.go
+++ b/go/go2nix/pkg/compile/cgo.go
@@ -48,7 +48,7 @@ func compileCgo(opts Options, files gofiles.PkgFiles, embedFlag string) error {
 	// Resolve #cgo pkg-config: directives from source files.
 	// go tool cgo does not process pkg-config directives; that's done by cmd/go.
 	// We handle it here so packages with #cgo pkg-config: work correctly.
-	pkgCflags, pkgLdflags, err := resolvePkgConfig(opts.SrcDir, files.CgoFiles, opts.goos, opts.goarch)
+	pkgCflags, pkgLdflags, err := resolvePkgConfig(opts.SrcDir, files.CgoFiles, opts.goos, opts.goarch, nil)
 	if err != nil {
 		return fmt.Errorf("pkg-config: %w", err)
 	}
@@ -402,7 +402,7 @@ func filterCppFlags(flags []string) []string {
 // runs pkg-config to resolve them, and returns the resulting CFLAGS and LDFLAGS.
 // This is necessary because go tool cgo does not process pkg-config directives;
 // that processing is normally done by cmd/go (go build).
-func resolvePkgConfig(srcDir string, cgoFiles []string, goos, goarch string) (cflags, ldflags []string, err error) {
+func resolvePkgConfig(srcDir string, cgoFiles []string, goos, goarch string, tags []string) (cflags, ldflags []string, err error) {
 	var pkgNames []string
 
 	for _, f := range cgoFiles {
@@ -418,7 +418,7 @@ func resolvePkgConfig(srcDir string, cgoFiles []string, goos, goarch string) (cf
 			// Check for platform constraint before "pkg-config:".
 			if idx := strings.Index(line, "pkg-config:"); idx >= 0 {
 				constraint := strings.TrimSpace(line[:idx])
-				if constraint != "" && !matchesCgoConstraint(constraint, goos, goarch) {
+				if constraint != "" && !matchesCgoConstraint(constraint, goos, goarch, tags) {
 					continue
 				}
 				pkgs := strings.TrimSpace(line[idx+len("pkg-config:"):])
@@ -490,22 +490,53 @@ func trimFileExt(name string) string {
 	return name
 }
 
-// matchesCgoConstraint checks if a #cgo constraint (e.g., "linux", "!windows",
-// "linux,amd64") matches the current build target.
-func matchesCgoConstraint(constraint, goos, goarch string) bool {
-	// Handle comma-separated AND constraints: "linux,amd64"
-	parts := strings.Split(constraint, ",")
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
+// unixOS is the set of GOOS values for which the build tag "unix" is
+// satisfied, mirroring go/build's unixOS map.
+var unixOS = map[string]bool{
+	"aix": true, "android": true, "darwin": true, "dragonfly": true,
+	"freebsd": true, "hurd": true, "illumos": true, "ios": true,
+	"linux": true, "netbsd": true, "openbsd": true, "solaris": true,
+}
+
+// matchesCgoConstraint checks if a #cgo constraint matches the current build
+// target. The syntax (per cmd/cgo and go/build.matchAuto) is a
+// space-separated OR of comma-separated AND terms; each term may be a GOOS,
+// GOARCH, "unix", "cgo", "gc"/"gccgo", or any active build tag, optionally
+// negated with a leading '!'. Examples:
+//
+//	"linux,amd64 darwin"  → (linux AND amd64) OR darwin
+//	"!windows"            → NOT windows
+//	"mytag"               → satisfied iff -tags=mytag is set
+func matchesCgoConstraint(constraint, goos, goarch string, tags []string) bool {
+	groups := strings.Fields(constraint)
+	if len(groups) == 0 {
+		return true
+	}
+	for _, group := range groups {
+		if matchCgoGroup(group, goos, goarch, tags) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchCgoGroup evaluates one comma-separated AND group.
+func matchCgoGroup(group, goos, goarch string, tags []string) bool {
+	for _, term := range strings.Split(group, ",") {
+		if term == "" {
+			// Empty term (e.g., trailing comma) makes the group fail,
+			// matching go/build.matchTag("").
+			return false
 		}
 		negate := false
-		if strings.HasPrefix(part, "!") {
+		if strings.HasPrefix(term, "!") {
 			negate = true
-			part = part[1:]
+			term = term[1:]
+			if term == "" {
+				return false // "!" alone is a syntax error → no match
+			}
 		}
-		match := part == goos || part == goarch
+		match := matchCgoTerm(term, goos, goarch, tags)
 		if negate {
 			match = !match
 		}
@@ -514,4 +545,23 @@ func matchesCgoConstraint(constraint, goos, goarch string) bool {
 		}
 	}
 	return true
+}
+
+// matchCgoTerm reports whether a single constraint term is satisfied.
+func matchCgoTerm(term, goos, goarch string, tags []string) bool {
+	switch {
+	case term == goos || term == goarch:
+		return true
+	case term == "unix":
+		return unixOS[goos]
+	case term == "cgo", term == "gc":
+		// We are the gc toolchain compiling a cgo package.
+		return true
+	}
+	for _, t := range tags {
+		if t == term {
+			return true
+		}
+	}
+	return false
 }

--- a/go/go2nix/pkg/compile/cgo_test.go
+++ b/go/go2nix/pkg/compile/cgo_test.go
@@ -41,26 +41,47 @@ func TestMatchesCgoConstraint(t *testing.T) {
 		constraint string
 		goos       string
 		goarch     string
+		tags       []string
 		want       bool
 	}{
-		{"os match", "linux", "linux", "amd64", true},
-		{"os mismatch", "darwin", "linux", "amd64", false},
-		{"arch match", "amd64", "linux", "amd64", true},
-		{"arch mismatch", "arm64", "linux", "amd64", false},
-		{"os,arch match", "linux,amd64", "linux", "amd64", true},
-		{"os,arch partial", "linux,arm64", "linux", "amd64", false},
-		{"negated os match", "!windows", "linux", "amd64", true},
-		{"negated os mismatch", "!linux", "linux", "amd64", false},
-		{"negated arch", "!arm64", "linux", "amd64", true},
-		{"combined negated", "!windows,amd64", "linux", "amd64", true},
-		{"empty constraint", "", "linux", "amd64", true},
+		{"os match", "linux", "linux", "amd64", nil, true},
+		{"os mismatch", "darwin", "linux", "amd64", nil, false},
+		{"arch match", "amd64", "linux", "amd64", nil, true},
+		{"arch mismatch", "arm64", "linux", "amd64", nil, false},
+		{"os,arch match", "linux,amd64", "linux", "amd64", nil, true},
+		{"os,arch partial", "linux,arm64", "linux", "amd64", nil, false},
+		{"negated os match", "!windows", "linux", "amd64", nil, true},
+		{"negated os mismatch", "!linux", "linux", "amd64", nil, false},
+		{"negated arch", "!arm64", "linux", "amd64", nil, true},
+		{"combined negated", "!windows,amd64", "linux", "amd64", nil, true},
+		{"empty constraint", "", "linux", "amd64", nil, true},
+		// Space = OR of comma-AND groups (regression for finding #20).
+		{"space OR first matches", "linux darwin", "linux", "amd64", nil, true},
+		{"space OR second matches", "linux darwin", "darwin", "arm64", nil, true},
+		{"space OR none match", "linux darwin", "windows", "amd64", nil, false},
+		{"AND-OR mix linux", "linux,amd64 darwin", "linux", "amd64", nil, true},
+		{"AND-OR mix darwin", "linux,amd64 darwin", "darwin", "arm64", nil, true},
+		{"AND-OR mix linux/arm fails AND", "linux,amd64 darwin", "linux", "arm64", nil, false},
+		// Well-known tags.
+		{"unix on linux", "unix", "linux", "amd64", nil, true},
+		{"unix on windows", "unix", "windows", "amd64", nil, false},
+		{"cgo always true", "cgo", "linux", "amd64", nil, true},
+		{"gc always true", "gc", "linux", "amd64", nil, true},
+		// Custom build tags.
+		{"custom tag set", "mytag", "linux", "amd64", []string{"mytag"}, true},
+		{"custom tag unset", "mytag", "linux", "amd64", nil, false},
+		{"custom tag in AND", "linux,mytag", "linux", "amd64", []string{"mytag"}, true},
+		{"custom tag negated", "!mytag", "linux", "amd64", []string{"mytag"}, false},
+		// Edge cases.
+		{"bare bang fails", "!", "linux", "amd64", nil, false},
+		{"trailing comma fails group", "linux,", "linux", "amd64", nil, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := matchesCgoConstraint(tt.constraint, tt.goos, tt.goarch)
+			got := matchesCgoConstraint(tt.constraint, tt.goos, tt.goarch, tt.tags)
 			if got != tt.want {
-				t.Errorf("matchesCgoConstraint(%q, %q, %q) = %v, want %v",
-					tt.constraint, tt.goos, tt.goarch, got, tt.want)
+				t.Errorf("matchesCgoConstraint(%q, %q, %q, %v) = %v, want %v",
+					tt.constraint, tt.goos, tt.goarch, tt.tags, got, tt.want)
 			}
 		})
 	}

--- a/go/go2nix/pkg/compile/compile.go
+++ b/go/go2nix/pkg/compile/compile.go
@@ -94,6 +94,17 @@ func CompileGoPackage(opts Options) error {
 		return fmt.Errorf("no Go files found in %s (package %s)", opts.SrcDir, opts.ImportPath)
 	}
 
+	// Objective-C and SWIG sources are surfaced so we can fail fast with a
+	// clear message rather than producing an archive that is missing object
+	// code (which would only blow up at final link with cryptic
+	// undefined-symbol errors). Full support is tracked separately.
+	if len(files.MFiles) > 0 {
+		return fmt.Errorf("package %s contains Objective-C sources (%v): not yet supported by go2nix", opts.ImportPath, files.MFiles)
+	}
+	if len(files.SwigFiles) > 0 || len(files.SwigCXXFiles) > 0 {
+		return fmt.Errorf("package %s contains SWIG sources (%v %v): not yet supported by go2nix", opts.ImportPath, files.SwigFiles, files.SwigCXXFiles)
+	}
+
 	// Create output directories.
 	if err := os.MkdirAll(filepath.Dir(opts.Output), 0o755); err != nil {
 		return err

--- a/go/go2nix/pkg/compile/compile_test.go
+++ b/go/go2nix/pkg/compile/compile_test.go
@@ -2,7 +2,10 @@ package compile
 
 import (
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/numtide/go2nix/pkg/gofiles"
 )
 
 func TestOptions_outputFlags(t *testing.T) {
@@ -32,6 +35,51 @@ func TestOptions_outputFlags(t *testing.T) {
 			got := tt.opts.outputFlags()
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("outputFlags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Regression for finding #22: Objective-C and SWIG sources must not be
+// silently dropped. Until full support lands, CompileGoPackage must fail
+// fast with a clear error rather than producing an archive missing the
+// corresponding object code.
+func TestCompileGoPackage_RejectsUnsupportedSources(t *testing.T) {
+	tests := []struct {
+		name  string
+		files gofiles.PkgFiles
+		want  string
+	}{
+		{
+			name:  "objective-c",
+			files: gofiles.PkgFiles{GoFiles: []string{"a.go"}, MFiles: []string{"foo.m"}},
+			want:  "Objective-C",
+		},
+		{
+			name:  "swig",
+			files: gofiles.PkgFiles{GoFiles: []string{"a.go"}, SwigFiles: []string{"foo.swig"}},
+			want:  "SWIG",
+		},
+		{
+			name:  "swigcxx",
+			files: gofiles.PkgFiles{GoFiles: []string{"a.go"}, SwigCXXFiles: []string{"foo.swigcxx"}},
+			want:  "SWIG",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := tt.files
+			err := CompileGoPackage(Options{
+				ImportPath: "example.com/p",
+				SrcDir:     t.TempDir(),
+				Output:     t.TempDir() + "/out.a",
+				Files:      &f,
+			})
+			if err == nil {
+				t.Fatalf("expected error mentioning %q, got nil", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error %q does not mention %q", err, tt.want)
 			}
 		})
 	}

--- a/go/go2nix/pkg/compile/manifest.go
+++ b/go/go2nix/pkg/compile/manifest.go
@@ -46,9 +46,12 @@ type ManifestFiles struct {
 	SFiles        []string `json:"sFiles,omitempty"`
 	CFiles        []string `json:"cFiles,omitempty"`
 	CXXFiles      []string `json:"cxxFiles,omitempty"`
+	MFiles        []string `json:"mFiles,omitempty"`
 	FFiles        []string `json:"fFiles,omitempty"`
 	HFiles        []string `json:"hFiles,omitempty"`
 	SysoFiles     []string `json:"sysoFiles,omitempty"`
+	SwigFiles     []string `json:"swigFiles,omitempty"`
+	SwigCXXFiles  []string `json:"swigCxxFiles,omitempty"`
 	EmbedPatterns []string `json:"embedPatterns,omitempty"`
 }
 
@@ -58,14 +61,17 @@ type ManifestFiles struct {
 // paths.
 func (mf *ManifestFiles) ToPkgFiles(srcDir string) (*gofiles.PkgFiles, error) {
 	pf := &gofiles.PkgFiles{
-		GoFiles:   mf.GoFiles,
-		CgoFiles:  mf.CgoFiles,
-		SFiles:    mf.SFiles,
-		CFiles:    mf.CFiles,
-		CXXFiles:  mf.CXXFiles,
-		FFiles:    mf.FFiles,
-		HFiles:    mf.HFiles,
-		SysoFiles: mf.SysoFiles,
+		GoFiles:      mf.GoFiles,
+		CgoFiles:     mf.CgoFiles,
+		SFiles:       mf.SFiles,
+		CFiles:       mf.CFiles,
+		CXXFiles:     mf.CXXFiles,
+		MFiles:       mf.MFiles,
+		FFiles:       mf.FFiles,
+		HFiles:       mf.HFiles,
+		SysoFiles:    mf.SysoFiles,
+		SwigFiles:    mf.SwigFiles,
+		SwigCXXFiles: mf.SwigCXXFiles,
 	}
 	if len(mf.EmbedPatterns) > 0 {
 		cfg, err := gofiles.ResolveEmbedCfg(srcDir, mf.EmbedPatterns)

--- a/go/go2nix/pkg/gofiles/gofiles.go
+++ b/go/go2nix/pkg/gofiles/gofiles.go
@@ -20,17 +20,20 @@ import (
 // PkgFiles describes the files in a Go package, resolved for the current
 // platform's build constraints.
 type PkgFiles struct {
-	GoFiles    []string  `json:"go_files"`
-	CgoFiles   []string  `json:"cgo_files"`
-	SFiles     []string  `json:"s_files"`
-	CFiles     []string  `json:"c_files"`
-	CXXFiles   []string  `json:"cxx_files"`
-	FFiles     []string  `json:"f_files"` // .f, .F, .for, .f90 Fortran source files
-	HFiles     []string  `json:"h_files"`
-	SysoFiles  []string  `json:"syso_files"` // .syso system object files to pack into archive
-	EmbedFiles []string  `json:"embed_files"`
-	EmbedCfg   *EmbedCfg `json:"embed_cfg,omitempty"`
-	IsCommand  bool      `json:"is_command"`
+	GoFiles      []string  `json:"go_files"`
+	CgoFiles     []string  `json:"cgo_files"`
+	SFiles       []string  `json:"s_files"`
+	CFiles       []string  `json:"c_files"`
+	CXXFiles     []string  `json:"cxx_files"`
+	MFiles       []string  `json:"m_files"` // .m Objective-C source files
+	FFiles       []string  `json:"f_files"` // .f, .F, .for, .f90 Fortran source files
+	HFiles       []string  `json:"h_files"`
+	SysoFiles    []string  `json:"syso_files"`     // .syso system object files to pack into archive
+	SwigFiles    []string  `json:"swig_files"`     // .swig files
+	SwigCXXFiles []string  `json:"swig_cxx_files"` // .swigcxx files
+	EmbedFiles   []string  `json:"embed_files"`
+	EmbedCfg     *EmbedCfg `json:"embed_cfg,omitempty"`
+	IsCommand    bool      `json:"is_command"`
 }
 
 // EmbedCfg is the format expected by go tool compile -embedcfg.
@@ -98,15 +101,18 @@ func ReleaseTagsForVersion(goVersion string) []string {
 // embed patterns if present.
 func BuildPkgFiles(pkg *build.Package, dir string) (PkgFiles, error) {
 	result := PkgFiles{
-		GoFiles:   nonNil(pkg.GoFiles),
-		CgoFiles:  nonNil(pkg.CgoFiles),
-		SFiles:    nonNil(pkg.SFiles),
-		CFiles:    nonNil(pkg.CFiles),
-		CXXFiles:  nonNil(pkg.CXXFiles),
-		FFiles:    nonNil(pkg.FFiles),
-		HFiles:    nonNil(pkg.HFiles),
-		SysoFiles: nonNil(pkg.SysoFiles),
-		IsCommand: pkg.IsCommand(),
+		GoFiles:      nonNil(pkg.GoFiles),
+		CgoFiles:     nonNil(pkg.CgoFiles),
+		SFiles:       nonNil(pkg.SFiles),
+		CFiles:       nonNil(pkg.CFiles),
+		CXXFiles:     nonNil(pkg.CXXFiles),
+		MFiles:       nonNil(pkg.MFiles),
+		FFiles:       nonNil(pkg.FFiles),
+		HFiles:       nonNil(pkg.HFiles),
+		SysoFiles:    nonNil(pkg.SysoFiles),
+		SwigFiles:    nonNil(pkg.SwigFiles),
+		SwigCXXFiles: nonNil(pkg.SwigCXXFiles),
+		IsCommand:    pkg.IsCommand(),
 	}
 
 	if len(pkg.EmbedPatterns) > 0 {

--- a/go/go2nix/pkg/golist/golist.go
+++ b/go/go2nix/pkg/golist/golist.go
@@ -24,6 +24,7 @@ type Pkg struct {
 	CgoFiles       []string `json:"CgoFiles"`
 	CFiles         []string `json:"CFiles"`
 	CXXFiles       []string `json:"CXXFiles"`
+	MFiles         []string `json:"MFiles"` // .m Objective-C source files
 	FFiles         []string `json:"FFiles"` // .f, .F, .for, .f90 Fortran source files
 	SFiles         []string `json:"SFiles"`
 	HFiles         []string `json:"HFiles"`

--- a/packages/go2nix-nix-plugin/rust/src/resolve.rs
+++ b/packages/go2nix-nix-plugin/rust/src/resolve.rs
@@ -53,12 +53,18 @@ struct GoPackage {
     c_files: Vec<String>,
     #[serde(rename = "CXXFiles")]
     cxx_files: Vec<String>,
+    #[serde(rename = "MFiles")]
+    m_files: Vec<String>,
     #[serde(rename = "FFiles")]
     f_files: Vec<String>,
     #[serde(rename = "HFiles")]
     h_files: Vec<String>,
     #[serde(rename = "SysoFiles")]
     syso_files: Vec<String>,
+    #[serde(rename = "SwigFiles")]
+    swig_files: Vec<String>,
+    #[serde(rename = "SwigCXXFiles")]
+    swig_cxx_files: Vec<String>,
     #[serde(rename = "EmbedPatterns")]
     embed_patterns: Vec<String>,
     #[serde(rename = "CgoPkgConfig")]
@@ -123,11 +129,17 @@ pub(crate) struct PkgFiles {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     cxx_files: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    m_files: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     f_files: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     h_files: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     syso_files: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    swig_files: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    swig_cxx_files: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     embed_patterns: Vec<String>,
 }
@@ -139,9 +151,12 @@ impl PkgFiles {
             && self.s_files.is_empty()
             && self.c_files.is_empty()
             && self.cxx_files.is_empty()
+            && self.m_files.is_empty()
             && self.f_files.is_empty()
             && self.h_files.is_empty()
             && self.syso_files.is_empty()
+            && self.swig_files.is_empty()
+            && self.swig_cxx_files.is_empty()
             && self.embed_patterns.is_empty()
     }
 }
@@ -153,9 +168,12 @@ fn pkg_files_from(p: &GoPackage) -> PkgFiles {
         s_files: p.s_files.clone(),
         c_files: p.c_files.clone(),
         cxx_files: p.cxx_files.clone(),
+        m_files: p.m_files.clone(),
         f_files: p.f_files.clone(),
         h_files: p.h_files.clone(),
         syso_files: p.syso_files.clone(),
+        swig_files: p.swig_files.clone(),
+        swig_cxx_files: p.swig_cxx_files.clone(),
         embed_patterns: p.embed_patterns.clone(),
     }
 }
@@ -1173,7 +1191,7 @@ mod tests {
 
     #[test]
     fn parse_file_lists_round_trip_to_json() {
-        let input = r#"{"ImportPath":"github.com/f/p","Module":{"Path":"github.com/f/p","Version":"v1.0.0"},"Imports":[],"GoFiles":["a.go","b.go"],"CgoFiles":["c.go"],"SFiles":["asm.s"],"CFiles":["x.c"],"CXXFiles":["x.cc"],"FFiles":["x.f90"],"HFiles":["x.h"],"SysoFiles":["x.syso"],"EmbedPatterns":["data/*"]}"#;
+        let input = r#"{"ImportPath":"github.com/f/p","Module":{"Path":"github.com/f/p","Version":"v1.0.0"},"Imports":[],"GoFiles":["a.go","b.go"],"CgoFiles":["c.go"],"SFiles":["asm.s"],"CFiles":["x.c"],"CXXFiles":["x.cc"],"MFiles":["x.m"],"FFiles":["x.f90"],"HFiles":["x.h"],"SysoFiles":["x.syso"],"SwigFiles":["x.swig"],"SwigCXXFiles":["x.swigcxx"],"EmbedPatterns":["data/*"]}"#;
         let graph = parse_go_packages(input.as_bytes()).unwrap();
         let f = &graph.packages[0].files;
         assert_eq!(f.go_files, vec!["a.go", "b.go"]);
@@ -1181,9 +1199,12 @@ mod tests {
         assert_eq!(f.s_files, vec!["asm.s"]);
         assert_eq!(f.c_files, vec!["x.c"]);
         assert_eq!(f.cxx_files, vec!["x.cc"]);
+        assert_eq!(f.m_files, vec!["x.m"]);
         assert_eq!(f.f_files, vec!["x.f90"]);
         assert_eq!(f.h_files, vec!["x.h"]);
         assert_eq!(f.syso_files, vec!["x.syso"]);
+        assert_eq!(f.swig_files, vec!["x.swig"]);
+        assert_eq!(f.swig_cxx_files, vec!["x.swigcxx"]);
         assert_eq!(f.embed_patterns, vec!["data/*"]);
 
         let jp = pkg_data_to_json_pkg(&graph.packages[0], &|_| true);
@@ -1194,9 +1215,12 @@ mod tests {
         assert_eq!(files["sFiles"], serde_json::json!(["asm.s"]));
         assert_eq!(files["cFiles"], serde_json::json!(["x.c"]));
         assert_eq!(files["cxxFiles"], serde_json::json!(["x.cc"]));
+        assert_eq!(files["mFiles"], serde_json::json!(["x.m"]));
         assert_eq!(files["fFiles"], serde_json::json!(["x.f90"]));
         assert_eq!(files["hFiles"], serde_json::json!(["x.h"]));
         assert_eq!(files["sysoFiles"], serde_json::json!(["x.syso"]));
+        assert_eq!(files["swigFiles"], serde_json::json!(["x.swig"]));
+        assert_eq!(files["swigCxxFiles"], serde_json::json!(["x.swigcxx"]));
         assert_eq!(files["embedPatterns"], serde_json::json!(["data/*"]));
     }
 


### PR DESCRIPTION
## Summary
- `DefaultGODEBUG` resolves `godebug default=goX.Y` first so explicit `godebug k=v` directives survive regardless of position.
- `matchesCgoConstraint` rewritten to match `go/build`: comma=AND, space=OR within a group; `unix`/`cgo`/`gc` and custom build tags now consulted.
- `MFiles`/`SwigFiles`/`SwigCXXFiles` are plumbed through `gofiles`/`compile`/`golist` and the Rust plugin, with a clear "not yet supported" error at compile time instead of being silently dropped.

## Test plan
- [x] `(cd go/go2nix && go test ./... && go vet ./...)`
- [x] `cargo test` (in `packages/go2nix-nix-plugin/rust`)
- [x] `nix flake check` — formatting + check-godebug-table pass
