### PR TITLE
buildinfo: emit build settings in go version -m

### DIFF
--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -97,7 +97,25 @@ func linkBinary(manifestPath, output string) error {
 		}
 	}
 
-	// Step 4: Compute modinfo.
+	// Step 4: Determine target platform and build mode (needed for modinfo
+	// build settings as well as the link step).
+	goos := ""
+	goarch := ""
+	if m.GOOS != nil {
+		goos = *m.GOOS
+	}
+	if m.GOARCH != nil {
+		goarch = *m.GOARCH
+	}
+	if goos == "" {
+		goos = compile.GoEnvVar("GOOS")
+	}
+	if goarch == "" {
+		goarch = compile.GoEnvVar("GOARCH")
+	}
+	buildMode := compile.DefaultBuildMode(goos, goarch)
+
+	// Step 5: Compute modinfo.
 	goVersion, err := goToolchainVersion()
 	if err != nil {
 		return fmt.Errorf("getting Go version: %w", err)
@@ -123,14 +141,27 @@ func linkBinary(manifestPath, output string) error {
 		}
 	}
 
-	modinfo, err := buildinfo.GenerateModinfo(m.ModuleRoot, goVersion, deps)
+	godebugDefault := buildinfo.DefaultGODEBUG(m.ModuleRoot)
+
+	settings := buildinfo.BuildSettings{
+		BuildMode:      buildMode,
+		LDFlags:        strings.Join(m.LDFlags, " "),
+		Tags:           strings.Join(m.Tags, ","),
+		DefaultGODEBUG: godebugDefault,
+		CGOEnabled:     compile.GoEnvVar("CGO_ENABLED"),
+		GOARCH:         goarch,
+		GOOS:           goos,
+	}
+	if key := buildinfo.ArchLevelVar(goarch); key != "" {
+		settings.GOARCHLevel = compile.GoEnvVar(key)
+	}
+
+	modinfo, err := buildinfo.GenerateModinfo(m.ModuleRoot, goVersion, deps, settings)
 	if err != nil {
 		return fmt.Errorf("generating modinfo: %w", err)
 	}
 
-	godebugDefault := buildinfo.DefaultGODEBUG(m.ModuleRoot)
-
-	// Step 5: Build link importcfg (compile importcfg + modinfo).
+	// Step 6: Build link importcfg (compile importcfg + modinfo).
 	linkCfg := filepath.Join(tmpDir, "importcfg.link")
 	{
 		data, err := os.ReadFile(mergedCfg)
@@ -145,23 +176,6 @@ func linkBinary(manifestPath, output string) error {
 			return err
 		}
 	}
-
-	// Step 6: Determine build mode.
-	goos := ""
-	goarch := ""
-	if m.GOOS != nil {
-		goos = *m.GOOS
-	}
-	if m.GOARCH != nil {
-		goarch = *m.GOARCH
-	}
-	if goos == "" {
-		goos = compile.GoEnvVar("GOOS")
-	}
-	if goarch == "" {
-		goarch = compile.GoEnvVar("GOARCH")
-	}
-	buildMode := compile.DefaultBuildMode(goos, goarch)
 
 	// Build gcflags: PIE requires -shared, then append manifest gcflags.
 	var gcflagsList []string

--- a/go/go2nix/cmd/go2nix/modinfo.go
+++ b/go/go2nix/cmd/go2nix/modinfo.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/numtide/go2nix/pkg/buildinfo"
+	"github.com/numtide/go2nix/pkg/compile"
 	"github.com/numtide/go2nix/pkg/lockfile"
 )
 
@@ -62,7 +63,20 @@ func runModinfoCmd(args []string) {
 		deps = append(deps, dep)
 	}
 
-	line, err := buildinfo.GenerateModinfo(moduleRoot, goVersion, deps)
+	goos := compile.GoEnvVar("GOOS")
+	goarch := compile.GoEnvVar("GOARCH")
+	settings := buildinfo.BuildSettings{
+		BuildMode:      compile.DefaultBuildMode(goos, goarch),
+		DefaultGODEBUG: buildinfo.DefaultGODEBUG(moduleRoot),
+		CGOEnabled:     compile.GoEnvVar("CGO_ENABLED"),
+		GOARCH:         goarch,
+		GOOS:           goos,
+	}
+	if key := buildinfo.ArchLevelVar(goarch); key != "" {
+		settings.GOARCHLevel = compile.GoEnvVar(key)
+	}
+
+	line, err := buildinfo.GenerateModinfo(moduleRoot, goVersion, deps, settings)
 	if err != nil {
 		slog.Error("generating modinfo", "err", err)
 		os.Exit(1)

--- a/go/go2nix/pkg/buildinfo/buildinfo.go
+++ b/go/go2nix/pkg/buildinfo/buildinfo.go
@@ -32,14 +32,83 @@ type ModDep struct {
 	Replace *ModDep // non-nil if this module is replaced
 }
 
+// BuildSettings holds the build configuration to embed as `build` lines in
+// the binary's modinfo, matching the subset of cmd/go's setBuildInfo that
+// go2nix can determine. Empty string fields are omitted from the output
+// (except -compiler and -trimpath, which are always emitted).
+type BuildSettings struct {
+	BuildMode      string // -buildmode (e.g., "exe", "pie")
+	LDFlags        string // -ldflags as a single space-joined string
+	Tags           string // -tags as a comma-separated list
+	DefaultGODEBUG string // from go.mod's go directive
+	CGOEnabled     string // "0" or "1"
+	GOARCH         string
+	GOARCHLevel    string // value of GO<ARCH> (e.g., "v1" for GOAMD64); key derived from GOARCH
+	GOOS           string
+}
+
+// archLevelVar maps GOARCH to the GO<ARCH> environment variable name,
+// matching cmd/go's cfg.GOGOARCH().
+var archLevelVar = map[string]string{
+	"386": "GO386", "amd64": "GOAMD64", "arm": "GOARM", "arm64": "GOARM64",
+	"mips": "GOMIPS", "mipsle": "GOMIPS", "mips64": "GOMIPS64", "mips64le": "GOMIPS64",
+	"ppc64": "GOPPC64", "ppc64le": "GOPPC64", "riscv64": "GORISCV64", "wasm": "GOWASM",
+}
+
+// ArchLevelVar returns the GO<ARCH> environment variable name for goarch
+// (e.g., "GOAMD64" for "amd64"), or "" if there is none.
+func ArchLevelVar(goarch string) string {
+	return archLevelVar[goarch]
+}
+
+// toDebugSettings converts BuildSettings to the ordered slice cmd/go emits
+// (see src/cmd/go/internal/load/pkg.go:setBuildInfo).
+func (s BuildSettings) toDebugSettings() []debug.BuildSetting {
+	var out []debug.BuildSetting
+	add := func(k, v string) {
+		out = append(out, debug.BuildSetting{Key: k, Value: v})
+	}
+	if s.BuildMode != "" {
+		add("-buildmode", s.BuildMode)
+	}
+	add("-compiler", "gc")
+	if s.LDFlags != "" {
+		add("-ldflags", s.LDFlags)
+	}
+	if s.Tags != "" {
+		add("-tags", s.Tags)
+	}
+	// go2nix always builds with trimpath semantics.
+	add("-trimpath", "true")
+	if s.DefaultGODEBUG != "" {
+		add("DefaultGODEBUG", s.DefaultGODEBUG)
+	}
+	if s.CGOEnabled != "" {
+		add("CGO_ENABLED", s.CGOEnabled)
+	}
+	if s.GOARCH != "" {
+		add("GOARCH", s.GOARCH)
+		if key := archLevelVar[s.GOARCH]; key != "" && s.GOARCHLevel != "" {
+			add(key, s.GOARCHLevel)
+		}
+	}
+	if s.GOOS != "" {
+		add("GOOS", s.GOOS)
+	}
+	return out
+}
+
 // GenerateModinfo produces the modinfo importcfg line for the linker.
 //
 // moduleRoot is the path to the directory containing go.mod (and optionally
 // go.sum for checksums). goVersion is the full Go toolchain version string
 // (e.g., "go1.21.5"). deps lists all third-party module dependencies.
+// settings supplies the `build` section so debug.ReadBuildInfo() consumers
+// (govulncheck, prometheus go_build_info, SBOM tools) see the same metadata
+// as a `go build -trimpath` binary.
 //
 // Returns a string like: modinfo "..."
-func GenerateModinfo(moduleRoot, goVersion string, deps []ModDep) (string, error) {
+func GenerateModinfo(moduleRoot, goVersion string, deps []ModDep, settings BuildSettings) (string, error) {
 	// Parse go.mod for the main module path.
 	goModPath := filepath.Join(moduleRoot, "go.mod")
 	goModData, err := os.ReadFile(goModPath)
@@ -65,6 +134,7 @@ func GenerateModinfo(moduleRoot, goVersion string, deps []ModDep) (string, error
 			Path:    mf.Module.Mod.Path,
 			Version: "(devel)",
 		},
+		Settings: settings.toDebugSettings(),
 	}
 
 	// Sort deps for deterministic output.

--- a/go/go2nix/pkg/buildinfo/buildinfo_test.go
+++ b/go/go2nix/pkg/buildinfo/buildinfo_test.go
@@ -28,7 +28,14 @@ golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq
 		{Path: "golang.org/x/crypto", Version: "v0.17.0"},
 	}
 
-	line, err := GenerateModinfo(dir, "go1.21.5", deps)
+	line, err := GenerateModinfo(dir, "go1.21.5", deps, BuildSettings{
+		BuildMode:   "exe",
+		Tags:        "netgo,osusergo",
+		CGOEnabled:  "0",
+		GOARCH:      "amd64",
+		GOARCHLevel: "v1",
+		GOOS:        "linux",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,6 +55,26 @@ golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq
 	if !strings.Contains(line, "h1:") {
 		t.Error("missing go.sum hash in modinfo")
 	}
+	// Regression for finding #23: build settings must be embedded so
+	// `go version -m` shows -compiler/CGO_ENABLED/GOOS/GOARCH/-tags lines.
+	for _, want := range []string{
+		"build\\t-buildmode=exe",
+		"build\\t-compiler=gc",
+		"build\\t-tags=netgo,osusergo",
+		"build\\t-trimpath=true",
+		"build\\tCGO_ENABLED=0",
+		"build\\tGOARCH=amd64",
+		"build\\tGOAMD64=v1",
+		"build\\tGOOS=linux",
+	} {
+		if !strings.Contains(line, want) {
+			t.Errorf("missing build setting %q in modinfo:\n%s", want, line)
+		}
+	}
+	// LDFlags/DefaultGODEBUG were empty — must be omitted.
+	if strings.Contains(line, "-ldflags") || strings.Contains(line, "DefaultGODEBUG") {
+		t.Errorf("empty optional settings should be omitted:\n%s", line)
+	}
 }
 
 func TestGenerateModinfoNoGoSum(t *testing.T) {
@@ -63,7 +90,7 @@ go 1.21
 		{Path: "golang.org/x/net", Version: "v0.19.0"},
 	}
 
-	line, err := GenerateModinfo(dir, "go1.21.5", deps)
+	line, err := GenerateModinfo(dir, "go1.21.5", deps, BuildSettings{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +121,7 @@ go 1.21
 		},
 	}
 
-	line, err := GenerateModinfo(dir, "go1.21.5", deps)
+	line, err := GenerateModinfo(dir, "go1.21.5", deps, BuildSettings{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/go2nix/pkg/resolve/resolve.go
+++ b/go/go2nix/pkg/resolve/resolve.go
@@ -829,12 +829,9 @@ func buildFinalDrv(
 		return nil, nil, err
 	}
 
-	// Modinfo and GOROOT are invariant across mains; compute once.
-	modinfoLine, err := generateModinfo(cfg, sorted)
-	if err != nil {
-		slog.Warn("modinfo generation failed, skipping", "err", err)
-		modinfoLine = ""
-	}
+	// GOROOT is invariant across mains; compute once. Modinfo is per-main
+	// (DefaultGODEBUG is derived from the main package's //go:debug
+	// directives), so it's computed inside buildLinkDrv.
 	goroot := cfg.goEnv["GOROOT"]
 
 	// Build a link derivation for each main package
@@ -843,7 +840,7 @@ func buildFinalDrv(
 	var drvs []*nixdrv.Derivation
 
 	for _, mainPkg := range mainPkgs {
-		drvPath, drv, err := buildLinkDrv(cfg, graph, mainPkg, len(mainPkgs), stdlibImports, modinfoLine, goroot)
+		drvPath, drv, err := buildLinkDrv(cfg, graph, sorted, mainPkg, len(mainPkgs), stdlibImports, goroot)
 		if err != nil {
 			return nil, nil, fmt.Errorf("building link for %s: %w", mainPkg.ImportPath, err)
 		}
@@ -876,10 +873,10 @@ func buildFinalDrv(
 func buildLinkDrv(
 	cfg Config,
 	graph map[string]*ResolvedPkg,
+	sorted []*ResolvedPkg,
 	mainPkg *ResolvedPkg,
 	numMains int,
 	stdlibImports []string,
-	modinfoLine string,
 	goroot string,
 ) (*storepath.StorePath, *nixdrv.Derivation, error) {
 	// For single binary, use pname. For multiple binaries, derive name from import path.
@@ -948,7 +945,10 @@ func buildLinkDrv(
 	}
 
 	// Add modinfo so go version -m shows module dependencies.
-	if modinfoLine != "" {
+	modinfoLine, err := generateModinfo(cfg, sorted, mainPkg.DefaultGODEBUG)
+	if err != nil {
+		slog.Warn("modinfo generation failed, skipping", "err", err)
+	} else {
 		importcfgEntries = append(importcfgEntries, modinfoLine)
 	}
 
@@ -1187,9 +1187,28 @@ func loadGoEnv(goBin string) map[string]string {
 }
 
 // generateModinfo constructs the modinfo importcfg line from the package graph.
-func generateModinfo(cfg Config, sorted []*ResolvedPkg) (string, error) {
+func generateModinfo(cfg Config, sorted []*ResolvedPkg, defaultGODEBUG string) (string, error) {
 	// Get Go toolchain version.
 	goVersion := cfg.goEnv["GOVERSION"]
+
+	goos := cfg.goEnv["GOOS"]
+	goarch := cfg.goEnv["GOARCH"]
+	cgoEnabled := cfg.CGOEnabled
+	if cgoEnabled == "" {
+		cgoEnabled = cfg.goEnv["CGO_ENABLED"]
+	}
+	settings := buildinfo.BuildSettings{
+		BuildMode:      cfg.buildMode,
+		LDFlags:        cfg.LDFlags,
+		Tags:           cfg.Tags,
+		DefaultGODEBUG: defaultGODEBUG,
+		CGOEnabled:     cgoEnabled,
+		GOARCH:         goarch,
+		GOOS:           goos,
+	}
+	if key := buildinfo.ArchLevelVar(goarch); key != "" {
+		settings.GOARCHLevel = cfg.goEnv[key]
+	}
 
 	// Collect unique third-party modules from the graph.
 	seen := make(map[string]bool)
@@ -1217,7 +1236,7 @@ func generateModinfo(cfg Config, sorted []*ResolvedPkg) (string, error) {
 		deps = append(deps, dep)
 	}
 
-	return buildinfo.GenerateModinfo(filepath.Join(cfg.Src, cfg.ModRoot), goVersion, deps)
+	return buildinfo.GenerateModinfo(filepath.Join(cfg.Src, cfg.ModRoot), goVersion, deps, settings)
 }
 
 // createFilteredPkgDir creates a temporary directory containing only the files

--- a/go/go2nix/pkg/resolve/resolve_test.go
+++ b/go/go2nix/pkg/resolve/resolve_test.go
@@ -337,8 +337,9 @@ func TestBuildLinkDrvClosureOnly(t *testing.T) {
 		ccDir:        "/nix/store/00000000000000000000000000000000-cc",
 	}
 	cfg.coreutilsDir = storeDirOf(cfg.CoreutilsBin)
+	cfg.goEnv = map[string]string{}
 
-	_, drv, err := buildLinkDrv(cfg, graph, graph["m/cmd/a"], 1, nil, "", "")
+	_, drv, err := buildLinkDrv(cfg, graph, nil, graph["m/cmd/a"], 1, nil, "")
 	if err != nil {
 		t.Fatalf("buildLinkDrv: %v", err)
 	}

--- a/packages/test-fixture-testify-basic/default.nix
+++ b/packages/test-fixture-testify-basic/default.nix
@@ -45,7 +45,10 @@ else
   in
   pkgs.runCommand "test-dag-fixture-testify-basic"
     {
-      nativeBuildInputs = [ nix ];
+      nativeBuildInputs = [
+        nix
+        go
+      ];
       requiredSystemFeatures = [ "recursive-nix" ];
     }
     ''
@@ -60,5 +63,15 @@ else
         --no-out-link)
 
       $result/bin/testify-basic
+
+      echo "=== Checking embedded build info ==="
+      # Regression for finding #23: go2nix binaries must embed build settings
+      # so debug.ReadBuildInfo() consumers (govulncheck, SBOM tools) work.
+      go version -m "$result/bin/testify-basic" | tee buildinfo.txt
+      for key in "-compiler=gc" "CGO_ENABLED=" "GOARCH=" "GOOS="; do
+        grep -P "^\tbuild\t''${key}" buildinfo.txt \
+          || { echo "FAIL: missing 'build $key' in go version -m output"; exit 1; }
+      done
+
       echo "PASS: testify-basic" > $out
     ''


### PR DESCRIPTION
## Summary
- `GenerateModinfo` now emits `debug.BuildInfo.Settings` (`-buildmode`, `-compiler`, `-ldflags`, `-tags`, `-trimpath`, `DefaultGODEBUG`, `CGO_ENABLED`, `GOOS`, `GOARCH`, `GO<ARCH>`) in `cmd/go` order, wired from all three callers.
- Adds a unit test asserting `build\tGOOS=` lines and updates the testify-basic fixture to grep `go version -m` output.

## Test plan
- [x] `(cd go/go2nix && go test ./... && go vet ./...)`
- [x] `nix flake check` — formatting + check-godebug-table pass
