### PR TITLE
misc: sorted embed lists, dup TestMain error, glob escape, pkgconfig

### DIFF
--- a/go/go2nix/pkg/gofiles/gofiles.go
+++ b/go/go2nix/pkg/gofiles/gofiles.go
@@ -166,7 +166,7 @@ func ResolveEmbedCfg(dir string, patterns []string) (*EmbedCfg, error) {
 			return nil, fmt.Errorf("pattern %q: invalid pattern syntax", pattern)
 		}
 
-		match, err := filepath.Glob(filepath.Join(dir, filepath.FromSlash(glob)))
+		match, err := filepath.Glob(filepath.Join(quoteGlob(dir), filepath.FromSlash(glob)))
 		if err != nil {
 			return nil, fmt.Errorf("pattern %q: %w", pattern, err)
 		}
@@ -323,6 +323,24 @@ func sliceEqual(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// quoteGlob returns s with all filepath.Glob metacharacters quoted so they
+// match literally. Ported from cmd/go/internal/str.QuoteGlob. Backslash is
+// not escaped (it is the path separator on Windows).
+func quoteGlob(s string) string {
+	if !strings.ContainsAny(s, `*?[`) {
+		return s
+	}
+	var sb strings.Builder
+	for _, c := range s {
+		switch c {
+		case '*', '?', '[':
+			sb.WriteByte('\\')
+		}
+		sb.WriteRune(c)
+	}
+	return sb.String()
 }
 
 // validEmbedPattern reports whether pattern is a valid //go:embed pattern.

--- a/go/go2nix/pkg/gofiles/gofiles_test.go
+++ b/go/go2nix/pkg/gofiles/gofiles_test.go
@@ -293,6 +293,28 @@ func TestResolveEmbedCfg_DirModuleBoundary(t *testing.T) {
 	}
 }
 
+func TestResolveEmbedCfg_DirWithGlobMeta(t *testing.T) {
+	// Package directory path contains glob metacharacters; they must be
+	// matched literally, not as a glob, when resolving embed patterns.
+	base := t.TempDir()
+	dir := filepath.Join(base, "proj[v2]")
+	writeFile(t, filepath.Join(dir, "a.txt"), "a")
+	writeFile(t, filepath.Join(dir, "b.txt"), "b")
+
+	cfg, err := ResolveEmbedCfg(dir, []string{"*.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	matched := cfg.Patterns["*.txt"]
+	slices.Sort(matched)
+	if !slices.Equal(matched, []string{"a.txt", "b.txt"}) {
+		t.Errorf("Patterns[*.txt] = %v, want [a.txt b.txt]", matched)
+	}
+	if cfg.Files["a.txt"] != filepath.Join(dir, "a.txt") {
+		t.Errorf("Files[a.txt] = %q, want %q", cfg.Files["a.txt"], filepath.Join(dir, "a.txt"))
+	}
+}
+
 func TestResolveEmbedCfg_Deduplication(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "readme.txt"), "hello")

--- a/go/go2nix/pkg/localpkgs/localpkgs.go
+++ b/go/go2nix/pkg/localpkgs/localpkgs.go
@@ -135,6 +135,7 @@ func ListLocalPackages(root string, tags string, goVersion string) ([]*LocalPkg,
 				for f := range cfg.Files {
 					testEmbedFiles = append(testEmbedFiles, f)
 				}
+				slices.Sort(testEmbedFiles)
 			}
 			var xtestEmbedFiles []string
 			var xtestEmbedCfg *gofiles.EmbedCfg
@@ -147,6 +148,7 @@ func ListLocalPackages(root string, tags string, goVersion string) ([]*LocalPkg,
 				for f := range cfg.Files {
 					xtestEmbedFiles = append(xtestEmbedFiles, f)
 				}
+				slices.Sort(xtestEmbedFiles)
 			}
 
 			localPkg := &LocalPkg{

--- a/go/go2nix/pkg/localpkgs/localpkgs_test.go
+++ b/go/go2nix/pkg/localpkgs/localpkgs_test.go
@@ -3,6 +3,7 @@ package localpkgs
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -331,5 +332,56 @@ func TestAdd(t *testing.T) {
 	}
 	if pkg.TestGoFiles[0] != "foo_test.go" {
 		t.Errorf("TestGoFiles[0] = %q, want foo_test.go", pkg.TestGoFiles[0])
+	}
+}
+
+func TestListLocalPackages_TestEmbedFilesSorted(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/test\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(root, "lib.go"), "package test\n")
+	writeFile(t, filepath.Join(root, "lib_test.go"), `package test
+
+import (
+	"embed"
+	"testing"
+)
+
+//go:embed *.txt
+var fs embed.FS
+
+func TestEmbed(t *testing.T) { _ = fs }
+`)
+	writeFile(t, filepath.Join(root, "ext_test.go"), `package test_test
+
+import (
+	"embed"
+	"testing"
+)
+
+//go:embed *.txt
+var fs embed.FS
+
+func TestExtEmbed(t *testing.T) { _ = fs }
+`)
+	for _, name := range []string{"c.txt", "a.txt", "d.txt", "b.txt", "e.txt"} {
+		writeFile(t, filepath.Join(root, name), "x")
+	}
+
+	pkgs, err := ListLocalPackages(root, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pkgs) != 1 {
+		t.Fatalf("expected 1 package, got %d", len(pkgs))
+	}
+	pkg := pkgs[0]
+
+	want := []string{"a.txt", "b.txt", "c.txt", "d.txt", "e.txt"}
+	if !slices.Equal(pkg.TestEmbedFiles, want) {
+		t.Errorf("TestEmbedFiles = %v, want %v (sorted)", pkg.TestEmbedFiles, want)
+	}
+	if !slices.Equal(pkg.XTestEmbedFiles, want) {
+		t.Errorf("XTestEmbedFiles = %v, want %v (sorted)", pkg.XTestEmbedFiles, want)
 	}
 }

--- a/go/go2nix/pkg/resolve/resolve.go
+++ b/go/go2nix/pkg/resolve/resolve.go
@@ -1073,6 +1073,9 @@ func discoverInputPaths(storePaths []string) InputPaths {
 		if isDir(p + "/lib/pkgconfig") {
 			result.PkgConfigDirs = append(result.PkgConfigDirs, p+"/lib/pkgconfig")
 		}
+		if isDir(p + "/share/pkgconfig") {
+			result.PkgConfigDirs = append(result.PkgConfigDirs, p+"/share/pkgconfig")
+		}
 
 		// Follow propagated-build-inputs (space-separated store paths).
 		data, err := os.ReadFile(p + "/nix-support/propagated-build-inputs")

--- a/go/go2nix/pkg/testmain/testmain.go
+++ b/go/go2nix/pkg/testmain/testmain.go
@@ -11,6 +11,7 @@ package testmain
 
 import (
 	"bytes"
+	"errors"
 	"go/ast"
 	"go/doc"
 	"go/parser"
@@ -107,7 +108,7 @@ func (t *testFuncs) load(fset *token.FileSet, filename, pkg string, doImport, se
 			}
 			if isTestFunc(n, "M") {
 				if t.TestMain != nil {
-					continue // multiple TestMain — skip
+					return errors.New("multiple definitions of TestMain")
 				}
 				t.TestMain = &testFunc{pkg, name, "", false}
 				*doImport, *seen = true, true

--- a/go/go2nix/pkg/testmain/testmain_test.go
+++ b/go/go2nix/pkg/testmain/testmain_test.go
@@ -115,6 +115,40 @@ func TestFoo(t *testing.T) {}
 	}
 }
 
+func TestGenerateDuplicateTestMain(t *testing.T) {
+	dir := t.TempDir()
+	intFile := filepath.Join(dir, "a_test.go")
+	if err := os.WriteFile(intFile, []byte(`package foo
+
+import "testing"
+
+func TestMain(m *testing.M) { m.Run() }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	extFile := filepath.Join(dir, "b_test.go")
+	if err := os.WriteFile(extFile, []byte(`package foo_test
+
+import "testing"
+
+func TestMain(m *testing.M) { m.Run() }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Generate(Options{
+		ImportPath:   "example.com/foo",
+		TestGoFiles:  []string{intFile},
+		XTestGoFiles: []string{extFile},
+	})
+	if err == nil {
+		t.Fatal("expected error for duplicate TestMain, got nil")
+	}
+	if !strings.Contains(err.Error(), "multiple definitions of TestMain") {
+		t.Errorf("expected 'multiple definitions of TestMain' in error, got: %v", err)
+	}
+}
+
 func TestGenerateExamples(t *testing.T) {
 	dir := t.TempDir()
 	testFile := filepath.Join(dir, "example_test.go")


### PR DESCRIPTION
## Summary
- Sort `TestEmbedFiles`/`XTestEmbedFiles` for deterministic output.
- `testmain` errors on duplicate `TestMain(*testing.M)` (matching `cmd/go`).
- Port `str.QuoteGlob` so `ResolveEmbedCfg` handles package dirs containing glob metacharacters.
- `discoverInputPaths` also probes `<input>/share/pkgconfig`.

## Test plan
- [x] `(cd go/go2nix && go test ./... && go vet ./...)`
- [x] `nix flake check` — formatting + check-godebug-table pass
