### PR TITLE
sanitize: cap derivation name length consistently across Go/Rust/Nix

### DIFF
--- a/go/go2nix/pkg/nixdrv/sanitize.go
+++ b/go/go2nix/pkg/nixdrv/sanitize.go
@@ -1,11 +1,25 @@
 package nixdrv
 
-import "strings"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// maxSanitizedLen caps the sanitized component so that the full derivation
+// name (e.g. "gopkg-" + sanitized + "-" + 34-char pseudo-version) stays
+// comfortably under Nix's 211-char store-name limit. Mirrored in
+// rust/src/resolve.rs and nix/helpers.nix — keep all three in sync.
+const maxSanitizedLen = 160
 
 // SanitizeName converts a Go import path to a valid Nix store path name.
 // Valid characters: [a-zA-Z0-9+-._?=]
 // Replaces: / → -, + preserved, ~ → _, @ → _at_
 // Any other illegal characters are replaced with _.
+//
+// If the sanitized result exceeds maxSanitizedLen it is truncated to a
+// prefix plus an 8-hex-char sha256 of the original input, so very long
+// import paths still yield valid, deterministic, collision-resistant names.
 func SanitizeName(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
@@ -23,7 +37,13 @@ func SanitizeName(s string) string {
 			b.WriteByte('_')
 		}
 	}
-	return b.String()
+	san := b.String()
+	if len(san) <= maxSanitizedLen {
+		return san
+	}
+	sum := sha256.Sum256([]byte(s))
+	h := hex.EncodeToString(sum[:4])
+	return san[:maxSanitizedLen-9] + "-" + h
 }
 
 // PkgDrvName returns the derivation name for a package: gopkg-<sanitized>-<version>.

--- a/go/go2nix/pkg/nixdrv/sanitize_test.go
+++ b/go/go2nix/pkg/nixdrv/sanitize_test.go
@@ -1,6 +1,9 @@
 package nixdrv
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestSanitizeName(t *testing.T) {
 	tests := []struct {
@@ -31,5 +34,42 @@ func TestDrvNames(t *testing.T) {
 	}
 	if got := CollectDrvName("myapp"); got != "gocollect-myapp" {
 		t.Errorf("CollectDrvName = %q", got)
+	}
+}
+
+func TestSanitizeNameLengthCap(t *testing.T) {
+	// 300-char import path: "example.com/" + 288 'a's.
+	long := "example.com/" + strings.Repeat("a", 288)
+	if len(long) != 300 {
+		t.Fatalf("test setup: len(long) = %d", len(long))
+	}
+
+	got := SanitizeName(long)
+	if len(got) > maxSanitizedLen {
+		t.Errorf("SanitizeName len = %d, want <= %d", len(got), maxSanitizedLen)
+	}
+	// Deterministic: same input → same output.
+	if again := SanitizeName(long); again != got {
+		t.Errorf("SanitizeName not deterministic: %q vs %q", got, again)
+	}
+	// Cross-implementation parity: rust/src/resolve.rs and nix/helpers.nix
+	// must produce this exact string for the same input.
+	want := "example.com-" + strings.Repeat("a", 139) + "-2d904ea3"
+	if got != want {
+		t.Errorf("SanitizeName = %q, want %q", got, want)
+	}
+	// Distinct long inputs must not collide.
+	other := "example.com/" + strings.Repeat("b", 288)
+	if SanitizeName(other) == got {
+		t.Errorf("SanitizeName collision on distinct long inputs")
+	}
+	// Full derivation name with a worst-case pseudo-version still fits the
+	// Nix store-name limit (211) with room to spare.
+	drv := PkgDrvName(long, "v0.0.0-20230101120000-abcdef123456")
+	if len(drv) > 211 {
+		t.Errorf("PkgDrvName len = %d exceeds Nix store-name limit", len(drv))
+	}
+	if len(drv) > 201 {
+		t.Errorf("PkgDrvName len = %d, want <= 201", len(drv))
 	}
 }

--- a/nix/helpers.nix
+++ b/nix/helpers.nix
@@ -3,7 +3,23 @@ rec {
   # Make a string safe for use as a Nix derivation name.
   # Valid store-path characters: [a-zA-Z0-9+-._?=]
   # Go import paths may contain / ~ @, all of which are illegal.
-  sanitizeName = builtins.replaceStrings [ "/" "~" "@" ] [ "-" "_" "_at_" ];
+  #
+  # If the sanitized result exceeds maxSanitizedLen it is truncated to a
+  # prefix plus an 8-hex-char sha256 of the original input. The cap and
+  # algorithm are mirrored in go/go2nix/pkg/nixdrv/sanitize.go and
+  # packages/go2nix-nix-plugin/rust/src/resolve.rs — keep all three in sync.
+  maxSanitizedLen = 160;
+  sanitizeName =
+    s:
+    let
+      san = builtins.replaceStrings [ "/" "~" "@" ] [ "-" "_" "_at_" ] s;
+    in
+    if builtins.stringLength san <= maxSanitizedLen then
+      san
+    else
+      builtins.substring 0 (maxSanitizedLen - 9) san
+      + "-"
+      + builtins.substring 0 8 (builtins.hashString "sha256" s);
 
   # Remove a prefix from a string. Assumes prefix is actually a prefix.
   removePrefix =

--- a/packages/go2nix-nix-plugin/rust/src/resolve.rs
+++ b/packages/go2nix-nix-plugin/rust/src/resolve.rs
@@ -5,6 +5,7 @@
 
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::process::Command;
 
@@ -178,6 +179,12 @@ fn pkg_files_from(p: &GoPackage) -> PkgFiles {
     }
 }
 
+/// Cap on the sanitized component so the full derivation name (prefix +
+/// sanitized + version suffix) stays under Nix's 211-char store-name limit.
+/// Mirrored in go/go2nix/pkg/nixdrv/sanitize.go and nix/helpers.nix — keep
+/// all three in sync.
+const MAX_SANITIZED_LEN: usize = 160;
+
 fn sanitize_name(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
@@ -190,6 +197,15 @@ fn sanitize_name(s: &str) -> String {
             _ => out.push('_'),
         }
     }
+    if out.len() <= MAX_SANITIZED_LEN {
+        return out;
+    }
+    // Sanitized output is ASCII-only, so byte truncation is char-safe.
+    let d = Sha256::digest(s.as_bytes());
+    let h = format!("{:02x}{:02x}{:02x}{:02x}", d[0], d[1], d[2], d[3]);
+    out.truncate(MAX_SANITIZED_LEN - 9);
+    out.push('-');
+    out.push_str(&h);
     out
 }
 
@@ -1413,6 +1429,20 @@ mod tests {
             sanitize_name("example.com/@scope/pkg"),
             "example.com-_at_scope-pkg"
         );
+    }
+
+    #[test]
+    fn sanitize_name_length_cap() {
+        let long = format!("example.com/{}", "a".repeat(288));
+        assert_eq!(long.len(), 300);
+        let got = sanitize_name(&long);
+        assert_eq!(got.len(), MAX_SANITIZED_LEN);
+        assert_eq!(got, sanitize_name(&long), "deterministic");
+        // Cross-implementation parity: Go (pkg/nixdrv) and Nix (helpers.nix)
+        // must produce this exact string for the same input.
+        assert_eq!(got, format!("example.com-{}-2d904ea3", "a".repeat(139)));
+        let other = format!("example.com/{}", "b".repeat(288));
+        assert_ne!(sanitize_name(&other), got, "distinct inputs must differ");
     }
 
     // --- pkg_data_to_json_pkg ---


### PR DESCRIPTION
## Summary
- Names derived from import paths are capped at 160 chars (151-char prefix + `-` + 8-hex sha256 of the full input) so full drv names stay under Nix's 211-char limit even with `gopkg-` prefix and pseudo-versions.
- Same function in `pkg/nixdrv/sanitize.go`, `rust/src/resolve.rs`, and `nix/helpers.nix`, byte-for-byte parity asserted by tests.

## Test plan
- [x] `(cd go/go2nix && go test ./... && go vet ./...)`
- [x] `cargo test` (in `packages/go2nix-nix-plugin/rust`)
- [x] `nix eval` of `helpers.sanitizeName` on a 300-char path matches Go/Rust output
- [x] `nix flake check` — formatting + check-godebug-table pass
