### PR TITLE
linkbinary: preserve quoted ldflags via cmd/internal/quoted.Split

### DIFF
--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"unicode"
 
 	"github.com/numtide/go2nix/pkg/buildinfo"
 	"github.com/numtide/go2nix/pkg/compile"
@@ -289,7 +290,11 @@ func linkBinary(manifestPath, output string) error {
 			"-buildmode=" + buildMode,
 			"-importcfg", linkCfg,
 		}
-		linkArgs = append(linkArgs, expandLDFlags(m.LDFlags)...)
+		ldflags, err := expandLDFlags(m.LDFlags)
+		if err != nil {
+			return fmt.Errorf("parsing ldflags for %s: %w", importpath, err)
+		}
+		linkArgs = append(linkArgs, ldflags...)
 		linkArgs = append(linkArgs, linkFlags...)
 		linkArgs = append(linkArgs, "-o", filepath.Join(binDir, binname))
 		linkArgs = append(linkArgs, mainArchive)
@@ -333,14 +338,89 @@ func fileExists(path string) bool {
 	return err == nil
 }
 
-// expandLDFlags splits each ldflag element by whitespace into separate args.
-// Nix users write ldflags like ["-X main.Version=1.6"] (one string with a
-// space). When invoking the linker directly (not via `go build`), each token
-// must be a separate exec arg.
-func expandLDFlags(flags []string) []string {
+// expandLDFlags splits each ldflag element into separate exec arguments using
+// shell-style quoting rules.
+//
+// Nix users write ldflags like ["-X main.Version=1.6"] or
+// ["-extldflags '-static -L/foo/lib'"] and expect the quoted value to stay
+// intact when invoking the linker directly.
+func expandLDFlags(flags []string) ([]string, error) {
 	var out []string
 	for _, f := range flags {
-		out = append(out, strings.Fields(f)...)
+		parts, err := splitShellFields(f)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, parts...)
 	}
-	return out
+	return out, nil
+}
+
+func splitShellFields(s string) ([]string, error) {
+	var (
+		out          []string
+		token        strings.Builder
+		quote        rune
+		escaped      bool
+		tokenStarted bool
+	)
+
+	flush := func() {
+		if !tokenStarted {
+			return
+		}
+		out = append(out, token.String())
+		token.Reset()
+		tokenStarted = false
+	}
+
+	for _, r := range s {
+		if escaped {
+			token.WriteRune(r)
+			escaped = false
+			continue
+		}
+
+		switch quote {
+		case '\'':
+			if r == '\'' {
+				quote = 0
+				continue
+			}
+			token.WriteRune(r)
+		case '"':
+			switch r {
+			case '"':
+				quote = 0
+			case '\\':
+				escaped = true
+			default:
+				token.WriteRune(r)
+			}
+		default:
+			switch {
+			case unicode.IsSpace(r):
+				flush()
+			case r == '\'' || r == '"':
+				tokenStarted = true
+				quote = r
+			case r == '\\':
+				tokenStarted = true
+				escaped = true
+			default:
+				tokenStarted = true
+				token.WriteRune(r)
+			}
+		}
+	}
+
+	if escaped {
+		return nil, fmt.Errorf("unterminated escape sequence")
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated quoted string")
+	}
+
+	flush()
+	return out, nil
 }

--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"unicode"
 
 	"github.com/numtide/go2nix/pkg/buildinfo"
 	"github.com/numtide/go2nix/pkg/compile"
@@ -339,7 +338,7 @@ func fileExists(path string) bool {
 }
 
 // expandLDFlags splits each ldflag element into separate exec arguments using
-// shell-style quoting rules.
+// the same quoting rules as `go build -ldflags` (cmd/internal/quoted.Split).
 //
 // Nix users write ldflags like ["-X main.Version=1.6"] or
 // ["-extldflags '-static -L/foo/lib'"] and expect the quoted value to stay
@@ -347,7 +346,7 @@ func fileExists(path string) bool {
 func expandLDFlags(flags []string) ([]string, error) {
 	var out []string
 	for _, f := range flags {
-		parts, err := splitShellFields(f)
+		parts, err := quotedSplit(f)
 		if err != nil {
 			return nil, err
 		}
@@ -356,71 +355,49 @@ func expandLDFlags(flags []string) ([]string, error) {
 	return out, nil
 }
 
-func splitShellFields(s string) ([]string, error) {
-	var (
-		out          []string
-		token        strings.Builder
-		quote        rune
-		escaped      bool
-		tokenStarted bool
-	)
-
-	flush := func() {
-		if !tokenStarted {
-			return
+// quotedSplit is copied from src/cmd/internal/quoted/quoted.go (Go 1.26.1,
+// BSD-3-Clause) so go2nix's ldflags parsing matches go build -ldflags exactly.
+// Upstream ships an identical copy in cmd/dist/quoted.go for the same reason.
+//
+// Split splits s into a list of fields, allowing single or double quotes
+// around elements. There is no unescaping or other processing within
+// quoted fields.
+func quotedSplit(s string) ([]string, error) {
+	// Split fields allowing '' or "" around elements.
+	// Quotes further inside the string do not count.
+	var f []string
+	for len(s) > 0 {
+		for len(s) > 0 && isSpaceByte(s[0]) {
+			s = s[1:]
 		}
-		out = append(out, token.String())
-		token.Reset()
-		tokenStarted = false
-	}
-
-	for _, r := range s {
-		if escaped {
-			token.WriteRune(r)
-			escaped = false
+		if len(s) == 0 {
+			break
+		}
+		// Accepted quoted string. No unescaping inside.
+		if s[0] == '"' || s[0] == '\'' {
+			quote := s[0]
+			s = s[1:]
+			i := 0
+			for i < len(s) && s[i] != quote {
+				i++
+			}
+			if i >= len(s) {
+				return nil, fmt.Errorf("unterminated %c string", quote)
+			}
+			f = append(f, s[:i])
+			s = s[i+1:]
 			continue
 		}
-
-		switch quote {
-		case '\'':
-			if r == '\'' {
-				quote = 0
-				continue
-			}
-			token.WriteRune(r)
-		case '"':
-			switch r {
-			case '"':
-				quote = 0
-			case '\\':
-				escaped = true
-			default:
-				token.WriteRune(r)
-			}
-		default:
-			switch {
-			case unicode.IsSpace(r):
-				flush()
-			case r == '\'' || r == '"':
-				tokenStarted = true
-				quote = r
-			case r == '\\':
-				tokenStarted = true
-				escaped = true
-			default:
-				tokenStarted = true
-				token.WriteRune(r)
-			}
+		i := 0
+		for i < len(s) && !isSpaceByte(s[i]) {
+			i++
 		}
+		f = append(f, s[:i])
+		s = s[i:]
 	}
+	return f, nil
+}
 
-	if escaped {
-		return nil, fmt.Errorf("unterminated escape sequence")
-	}
-	if quote != 0 {
-		return nil, fmt.Errorf("unterminated quoted string")
-	}
-
-	flush()
-	return out, nil
+func isSpaceByte(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
 }

--- a/go/go2nix/cmd/go2nix/linkbinary_test.go
+++ b/go/go2nix/cmd/go2nix/linkbinary_test.go
@@ -68,6 +68,21 @@ func TestExpandLDFlags(t *testing.T) {
 			flags:   []string{"-extldflags '-static -L/foo/lib"},
 			wantErr: true,
 		},
+		{
+			name:  "literal backslash preserved",
+			flags: []string{"-X main.Path=C:\\Users\\me"},
+			want:  []string{"-X", "main.Path=C:\\Users\\me"},
+		},
+		{
+			name:  "mid-token quote is literal",
+			flags: []string{`a"b c"d`},
+			want:  []string{`a"b`, `c"d`},
+		},
+		{
+			name:  "adjacent quoted fields",
+			flags: []string{`"hello" "world"`},
+			want:  []string{"hello", "world"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/go/go2nix/cmd/go2nix/linkbinary_test.go
+++ b/go/go2nix/cmd/go2nix/linkbinary_test.go
@@ -8,9 +8,10 @@ import (
 
 func TestExpandLDFlags(t *testing.T) {
 	tests := []struct {
-		name  string
-		flags []string
-		want  []string
+		name    string
+		flags   []string
+		want    []string
+		wantErr bool
 	}{
 		{
 			name:  "nil input",
@@ -43,6 +44,16 @@ func TestExpandLDFlags(t *testing.T) {
 			want:  []string{"-s", "-X", "main.Version=1.6", "-w", "-X", "main.Commit=abc"},
 		},
 		{
+			name:  "quoted extldflags are preserved as one value",
+			flags: []string{"-extldflags '-static -L/foo/lib '"},
+			want:  []string{"-extldflags", "-static -L/foo/lib "},
+		},
+		{
+			name:  "double-quoted values are preserved",
+			flags: []string{`-X "main.Message=hello world"`},
+			want:  []string{"-X", "main.Message=hello world"},
+		},
+		{
 			name:  "extra whitespace is collapsed",
 			flags: []string{"  -s  ", "  -X   main.Version=1.6  "},
 			want:  []string{"-s", "-X", "main.Version=1.6"},
@@ -52,11 +63,25 @@ func TestExpandLDFlags(t *testing.T) {
 			flags: []string{"", "-s", ""},
 			want:  []string{"-s"},
 		},
+		{
+			name:    "unterminated quoted string returns error",
+			flags:   []string{"-extldflags '-static -L/foo/lib"},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := expandLDFlags(tt.flags)
+			got, err := expandLDFlags(tt.flags)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expandLDFlags(%v) returned nil error, want error", tt.flags)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expandLDFlags(%v) returned unexpected error: %v", tt.flags, err)
+			}
 			if !slicesEqual(got, tt.want) {
 				t.Errorf("expandLDFlags(%v) = %v, want %v", tt.flags, got, tt.want)
 			}


### PR DESCRIPTION
## Summary

Supersedes #42. The first commit is @ryantm's original (authorship preserved); the second applies the review feedback from that PR.

- **Commit 1 (@ryantm):** parse `ldflags` with quote-aware splitting so values like `-extldflags '-static -L/foo/lib'` reach the linker as a single argument instead of being split on the inner space.
- **Commit 2:** replace the POSIX-sh-style splitter with a port of [`cmd/internal/quoted.Split`](https://cs.opensource.google/go/go/+/refs/tags/go1.26.1:src/cmd/internal/quoted/quoted.go) so go2nix matches `go build -ldflags` exactly. The key differences from the original splitter:
  - **No backslash escaping** — `\` is always literal (`-X main.Path=C:\Users` is preserved, not stripped to `C:Users`). `quoted.Split`'s doc comment is explicit: *"There is no unescaping or other processing within quoted fields."*
  - Quotes are only special at the **start** of a field; mid-token quotes are literal. Matches `go build`; the motivating `-extldflags '...'` case is unaffected since the quote is at field start.

Go itself ships an identical copy in `cmd/dist/quoted.go` for the same bootstrap-dependency reason; the port carries a BSD-3 attribution comment.

## Test plan

- [x] `go test ./cmd/go2nix/...` — covers all of #42's cases plus new ones for literal backslash, mid-token quote, and adjacent quoted fields
- [x] `go vet ./...`
- [x] `nix flake check` (formatting)