### PR TITLE
linkbinary,dag: reset cgo markers per subPackage; module-path override on local pkgs

### DIFF
--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -209,6 +209,12 @@ func linkBinary(manifestPath, output string) error {
 	}
 
 	for _, sp := range m.SubPackages {
+		// compileCgo writes .has_cgo / .has_cxx into NIX_BUILD_TOP; clear any
+		// markers left by the previous subpackage so a pure-Go binary built
+		// after a cgo one doesn't inherit -extld / -linkmode external.
+		_ = os.Remove(filepath.Join(tmpDir, ".has_cgo"))
+		_ = os.Remove(filepath.Join(tmpDir, ".has_cxx"))
+
 		var importpath, srcdir, binname string
 
 		clean := strings.TrimPrefix(sp.Path, "./")

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -508,10 +508,22 @@ let
       # on source touches and benefit from early-cutoff.
       mkDeriv = caMk (pickMk isCgo);
 
-      # Per-package overrides (e.g., nativeBuildInputs for cgo).
-      pkgOverride = packageOverrides.${importPath} or { };
+      # Per-package overrides (e.g., nativeBuildInputs for cgo libraries).
+      # Lookup order: exact import path, then module path, then empty.
+      isExactOverride = builtins.hasAttr importPath packageOverrides;
+      rawOverride =
+        packageOverrides.${importPath} or packageOverrides.${goPackagesResult.modulePath} or { };
       # nativeBuildInputs only reaches PATH via stdenv (cgo path);
-      # rawGoCompile (non-cgo) hardcodes goPath and discards it.
+      # rawGoCompile (non-cgo) hardcodes goPath and discards it. Reject
+      # for non-cgo so users get an error instead of a silent no-op —
+      # but only for exact-match overrides. A module-path override
+      # legitimately spans both cgo and non-cgo packages in the same
+      # module, so for the fallback case we silently drop the attr.
+      pkgOverride =
+        if isExactOverride || isCgo then
+          rawOverride
+        else
+          builtins.removeAttrs rawOverride [ "nativeBuildInputs" ];
       knownOverrideAttrs = [ "env" ] ++ lib.optional isCgo "nativeBuildInputs";
       unknownAttrs = builtins.attrNames (builtins.removeAttrs pkgOverride knownOverrideAttrs);
       extraNativeBuildInputs = pkgOverride.nativeBuildInputs or [ ];


### PR DESCRIPTION
## Summary

- **linkbinary**: clear `.has_cgo`/`.has_cxx` from `$NIX_BUILD_TOP` at the top of each `SubPackages` iteration. `compileCgo` writes these markers but the loop never reset them, so a pure-Go binary built after a cgo one in the same `link-binary` invocation inherited `-extld … -linkmode external`.
- **dag**: give the local-package `packageOverrides` block the same `${modulePath}` fallback and `isExactOverride`-gated `nativeBuildInputs` filtering that the third-party (≈393) and test-package (≈629) blocks already have, so a module-level override now reaches local packages as documented.

## Test plan

- [x] `go build ./... && go test ./cmd/go2nix/... ./pkg/compile/...` — pass
- [x] `nix eval .#packages.x86_64-linux.test-fixture-testify-basic.drvPath` — evaluates
- [x] `nix eval .#packages.x86_64-linux.test-fixture-torture-app-full.drvPath` — evaluates
- [x] `nix fmt` — no changes