### PR TITLE
docs: fix accuracy drift after recent code changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ See [Architecture](docs/src/go2nix-architecture.md) for how the builder works,
 go2nix generate .
 ```
 
-`generate` is also the default command, so `go2nix .` works as well. This
-writes a `go2nix.toml` next to your `go.mod` — one NAR hash per module:
+`generate` is also the default when no subcommand is given, so bare `go2nix`
+is equivalent to `go2nix generate .`. This writes a `go2nix.toml` next to
+your `go.mod` — one NAR hash per module:
 
 ```toml
 [mod]
@@ -175,7 +176,7 @@ direnv allow   # or: nix develop
 
 ```bash
 cd go/go2nix && go test ./...                  # Go unit tests
-nix build .#test-dag-fixture-testify-basic     # Nix integration test (one fixture)
+nix build .#test-fixture-testify-basic         # Nix integration test (one fixture)
 nix run .#bench-incremental -- -fixture light  # incremental rebuild benchmark
 nix fmt                                        # format all files
 ```

--- a/docs/src/builder-api.md
+++ b/docs/src/builder-api.md
@@ -28,9 +28,21 @@ Requires `nixPackage` to be set in `mkGoEnv` and Nix >= 2.34 with
 
 ## Required attributes
 
+### `src` {#src}
+
+Source tree. For monorepos with `modRoot`, this should be the repository
+root.
+
+In default mode, `src` is passed to `builtins.resolveGoPackages`, which
+shells out to `go list` at eval time. To keep that call IFD-free, prefer a
+source path (`./.`) or an eval-time fetcher (`builtins.fetchTarball`,
+`builtins.fetchGit`). A derivation-backed value such as
+`pkgs.fetchFromGitHub` is accepted, but the plugin must realise it at eval
+time and emits an IFD warning.
+
 | Attribute | Type | Modes | Description |
 |-----------|------|-------|-------------|
-| `src` | path | both | Source tree. For monorepos with `modRoot`, this should be the repository root. |
+| `src` | path | both | See above. |
 | `pname` | string | both | Package name for the output derivation. |
 | `version` | string | default only | Package version. The experimental builder does not accept this attribute (its wrapper produces a CA `.drv` whose name is derived from `pname` alone). |
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -28,7 +28,7 @@ Examples:
 
 ```bash
 go2nix generate .                       # write go2nix.toml in the current module
-go2nix .                                # same — generate is the default command
+go2nix                                  # same — generate is the default when no subcommand is given
 go2nix generate -o lock.toml ./a ./b    # merged lockfile for two modules
 ```
 
@@ -102,8 +102,9 @@ Outputs JSON with each package's import path and dependencies.
 ### resolve
 
 Build-time command for experimental mode (the `nix/dynamic/` builder).
-Discovers the package graph, creates CA derivations via
-`nix derivation add`, and produces a `.drv` file as output. See
+Discovers the package graph, computes CA `.drv` paths in-process, registers
+them with the nix-daemon (falling back to `nix derivation add` if no daemon
+socket is reachable), and produces a `.drv` file as output. See
 [Experimental Mode](modes/experimental-mode.md).
 
 ```
@@ -133,7 +134,8 @@ go2nix resolve [flags]
 | `--overrides` | No | JSON-encoded packageOverrides |
 | `--cacert` | No | Path to CA certificate bundle |
 | `--netrc-file` | No | Path to .netrc for private modules |
-| `--nix-jobs` | No | Max concurrent `nix derivation add` calls |
+| `--nix-jobs` | No | Max concurrent derivation registrations |
+| `--daemon-socket` | No | nix-daemon Unix socket; default `$NIX_DAEMON_SOCKET_PATH`. When reachable, derivations are registered over the socket instead of via `nix` CLI subprocesses |
 
 This command is not intended for direct use — it is invoked by the
 experimental-mode Nix builder inside a recursive-nix build.

--- a/docs/src/modes/experimental-mode.md
+++ b/docs/src/modes/experimental-mode.md
@@ -126,8 +126,10 @@ The build-time logic lives in the `go2nix resolve` command
 
 - Requires Nix >= 2.34 with experimental features (`recursive-nix`,
   `ca-derivations`, `dynamic-derivations`)
-- Build-time overhead from `nix derivation add` calls (~32ms each)
-- Parallelism limited by SQLite write lock (saturates at ~4 concurrent adds)
+- Build-time overhead from derivation registration: `.drv` paths are
+  computed in-process (microseconds each) and registered concurrently over
+  the nix-daemon socket; the per-derivation `nix derivation add` subprocess
+  is only used as a fallback when no daemon is reachable
 
 Performance and scaling characteristics depend on recursive-nix support,
-content-addressed derivations, and the overhead of `nix derivation add`.
+content-addressed derivations, and daemon round-trip latency.

--- a/docs/src/nix-plugin.md
+++ b/docs/src/nix-plugin.md
@@ -15,7 +15,6 @@ The plugin registers a single primop:
 
 ```nix
 builtins.resolveGoPackages {
-  go          = "${go}/bin/go";  # path to the Go binary
   src         = ./.;             # source tree
   subPackages = [ "./..." ];     # optional, default ["./..."]
   modRoot     = ".";             # optional
@@ -29,6 +28,12 @@ builtins.resolveGoPackages {
 }
 ```
 
+`go` is intentionally omitted: the plugin defaults to the Go toolchain baked
+in at its own build time, so the call carries no derivation context and the
+default-mode evaluation stays IFD-free. You may pass
+`go = "/path/to/bin/go"` to override the toolchain (e.g. a `nix-shell` Go),
+but a derivation-backed value like `"${pkgs.go}/bin/go"` will be rejected.
+
 It runs `go list -json -deps` against `src` and returns:
 
 - `packages` — third-party package metadata (`modKey`, `subdir`,
@@ -36,6 +41,8 @@ It runs `go list -json -deps` against `src` and returns:
 - `localPackages` — local package metadata (`dir`, `localImports`,
   `thirdPartyImports`, `isCgo`)
 - `modulePath` — the main module's import path
+- `goVersion` — the main module's `go` directive (e.g. `"1.25"`); the dag
+  builder threads this as `-lang` to local-package compiles
 - `replacements` — `replace` directives from `go.mod`
 - `testPackages` — test-only third-party packages (when `doCheck = true`)
 - `moduleHashes` — module NAR hashes (when `resolveHashes = true`; see

--- a/packages/go2nix-nix-plugin/plugin/resolveGoPackages.cc
+++ b/packages/go2nix-nix-plugin/plugin/resolveGoPackages.cc
@@ -145,8 +145,8 @@ static RegisterPrimOp rp(PrimOp {
     modules from go.sum + GOMODCACHE, enabling lockfile-free builds.
     Returns `moduleHashes` in the output (default: false)
 
-  Returns: { packages, localPackages, modulePath, replacements, testPackages,
-    moduleHashes (when resolveHashes=true) }
+  Returns: { packages, localPackages, modulePath, goVersion, replacements,
+    testPackages, moduleHashes (when resolveHashes=true) }
 )",
 #ifdef NIX_PRIMOP_HAS_IMPL
     .impl = prim_resolveGoPackages,


### PR DESCRIPTION
## Summary

Fixes doc statements that drifted behind the code over the last batch of merges. All verified against `d7b65b2`. Two passes — the second executed every example.

### First pass (b41be39)
- **README / cli-reference**: bare `go2nix` defaults to `generate`; `go2nix .` errors (`unknown command: .`). Reworded both.
- **README**: `nix build` example attr is `test-fixture-testify-basic`, not `test-dag-fixture-…`.
- **nix-plugin.md**: lead example no longer passes `go = "${go}/bin/go"` — the plugin defaults to its build-time toolchain so the call stays IFD-free; documented `go` as an optional plain-path override. Added `goVersion` to the return-shape list.
- **cli-reference.md (resolve)**: added `--daemon-socket`; updated the description and `--nix-jobs` wording to match in-process drv-path computation + daemon-socket registration.
- **modes/experimental-mode.md**: replaced the stale "~32ms `nix derivation add` / SQLite write lock" cons with the current daemon-socket path; subprocess is the fallback.
- **builder-api.md**: added a `### src {#src}` heading so the IFD warning's `builder-api.md#src` link resolves.
- **resolveGoPackages.cc**: added `goVersion` to the documented return keys.

### Second pass (45d099b)
- **nix-plugin.md**: dropped `goos/goarch/cgoEnabled = null` from the example — those are non-`Option` strings on the Rust side, so `null` is rejected; they must be omitted. Documented the optional `cgoPkgConfig`/`cgoCflags`/`cgoLdflags`/`files` per-package keys.
- **modes/default-mode.md**: lockfile is optional (`goLock ? null`); linked to lockfile-free builds.
- **lockfile-format.md**: generation parses `go.mod`/`go.sum` directly, not `go list -json -deps`.
- **go2nix-architecture.md**: corrected `sanitizeName` (no whitelist; `replaceStrings` + 160-char cap with sha256 suffix); added `normalizeSubPackages`, `parseLocalReplaces`, `goModLocalReplaceDirs`.
- **builder-api.md**: noted that unrecognised attrs are forwarded to `mkDerivation`, with `env`/`buildInputs`/`passthru`/`disallowedReferences` merged.
- **package-overrides.md**: dropped the "module-path fallback is third-party only" caveat — pairs with #67, which adds the fallback to local packages.

## Test plan
- [x] `mdbook build` succeeds; rendered HTML contains `id="src"` and `id="lockfile-free-builds"`
- [x] `nix build .#checks.x86_64-linux.formatting` — 0 changed
- [x] All cross-reference anchors resolve in `docs/book/`