### PR TITLE
compile: thread build tags to #cgo pkg-config constraint evaluation

### DIFF
--- a/go/go2nix/cmd/go2nix/compile.go
+++ b/go/go2nix/cmd/go2nix/compile.go
@@ -58,6 +58,7 @@ func runCompilePackageCmd(args []string) {
 		ImportCfg:   mergedCfg,
 		TrimPath:    *trimPath,
 		GCFlagsList: m.GCFlags,
+		Tags:        m.Tags,
 		GoVersion:   *goVersion,
 		PGOProfile:  pgo,
 	}

--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -247,6 +247,7 @@ func linkBinary(manifestPath, output string) error {
 			ImportCfg:   compileCfg,
 			TrimPath:    tmpDir,
 			GCFlagsList: gcflagsList,
+			Tags:        m.Tags,
 			PGOProfile:  pgoProfile,
 			Files:       pf,
 		}); err != nil {

--- a/go/go2nix/pkg/compile/cgo.go
+++ b/go/go2nix/pkg/compile/cgo.go
@@ -49,7 +49,7 @@ func compileCgo(opts Options, files gofiles.PkgFiles, embedFlag string) error {
 	// Resolve #cgo pkg-config: directives from source files.
 	// go tool cgo does not process pkg-config directives; that's done by cmd/go.
 	// We handle it here so packages with #cgo pkg-config: work correctly.
-	pkgCflags, pkgLdflags, err := resolvePkgConfig(opts.SrcDir, files.CgoFiles, opts.goos, opts.goarch, nil)
+	pkgCflags, pkgLdflags, err := resolvePkgConfig(opts.SrcDir, files.CgoFiles, opts.goos, opts.goarch, opts.Tags)
 	if err != nil {
 		return fmt.Errorf("pkg-config: %w", err)
 	}

--- a/go/go2nix/pkg/compile/cgo_test.go
+++ b/go/go2nix/pkg/compile/cgo_test.go
@@ -87,6 +87,44 @@ func TestMatchesCgoConstraint(t *testing.T) {
 	}
 }
 
+// Regression: resolvePkgConfig was called with tags=nil after CompileManifest
+// dropped Tags, so // #cgo <customtag> pkg-config: directives were silently
+// skipped. This pins that the tags slice actually gates directive matching
+// end-to-end (not just inside matchesCgoConstraint).
+func TestResolvePkgConfigCustomTag(t *testing.T) {
+	srcDir := t.TempDir()
+	src := "package foo\n\n// #cgo mytag pkg-config: libfoo\nimport \"C\"\n"
+	if err := os.WriteFile(filepath.Join(srcDir, "a.go"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stub pkg-config so the test doesn't depend on the real binary or libfoo.
+	binDir := t.TempDir()
+	stub := "#!/bin/sh\ncase \"$1\" in --cflags) echo -I/stub;; --libs) echo -lstub;; esac\n"
+	if err := os.WriteFile(filepath.Join(binDir, "pkg-config"), []byte(stub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// Without the tag, the constraint fails and pkg-config is not invoked.
+	cflags, ldflags, err := resolvePkgConfig(srcDir, []string{"a.go"}, "linux", "amd64", nil)
+	if err != nil || cflags != nil || ldflags != nil {
+		t.Fatalf("tags=nil: want (nil,nil,nil), got (%v,%v,%v)", cflags, ldflags, err)
+	}
+
+	// With the tag, the directive matches and pkg-config is invoked.
+	cflags, ldflags, err = resolvePkgConfig(srcDir, []string{"a.go"}, "linux", "amd64", []string{"mytag"})
+	if err != nil {
+		t.Fatalf("tags=[mytag]: %v", err)
+	}
+	if got, want := strings.Join(cflags, " "), "-I/stub"; got != want {
+		t.Errorf("cflags = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(ldflags, " "), "-lstub"; got != want {
+		t.Errorf("ldflags = %q, want %q", got, want)
+	}
+}
+
 func TestCgoPreamble(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/go/go2nix/pkg/compile/compile.go
+++ b/go/go2nix/pkg/compile/compile.go
@@ -23,6 +23,7 @@ type Options struct {
 	ImportCfg   string            // path to importcfg file
 	TrimPath    string            // path prefix to trim (defaults to $NIX_BUILD_TOP)
 	GCFlagsList []string          // extra flags for go tool compile
+	Tags        []string          // build tags for // #cgo constraint evaluation (file selection happened at eval time; this only gates #cgo CFLAGS/LDFLAGS/pkg-config lines)
 	GoVersion   string            // Go language version for -lang flag (e.g., "1.21"); auto-detected from go.mod if empty
 	PGOProfile  string            // path to pprof CPU profile for PGO; empty disables PGO
 	Files       *gofiles.PkgFiles // explicit file lists (bypasses ListFiles discovery; paths relative to SrcDir)

--- a/go/go2nix/pkg/compile/manifest.go
+++ b/go/go2nix/pkg/compile/manifest.go
@@ -31,6 +31,7 @@ type CompileManifest struct {
 	Version        int            `json:"version"`
 	Kind           string         `json:"kind"`
 	ImportcfgParts []string       `json:"importcfgParts"`
+	Tags           []string       `json:"tags"`
 	GCFlags        []string       `json:"gcflags"`
 	PGOProfile     *string        `json:"pgoProfile"`
 	Files          *ManifestFiles `json:"files,omitempty"`

--- a/go/go2nix/pkg/testrunner/testrunner.go
+++ b/go/go2nix/pkg/testrunner/testrunner.go
@@ -38,6 +38,13 @@ func (o Options) checkFlagsArgs() []string {
 	return o.CheckFlagsList
 }
 
+func (o Options) tagsList() []string {
+	if o.Tags == "" {
+		return nil
+	}
+	return strings.Split(o.Tags, ",")
+}
+
 // Run discovers testable packages and runs their tests.
 func Run(opts Options) error {
 	pkgs, err := localpkgs.ListLocalPackages(opts.ModuleRoot, opts.Tags, compile.ToolchainVersion())
@@ -247,6 +254,7 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 			ImportCfg:   testCompileImportCfg,
 			TrimPath:    opts.TrimPath,
 			GCFlagsList: opts.GCFlagsList,
+			Tags:        opts.tagsList(),
 			Files:       &internalFiles,
 		}); err != nil {
 			return fmt.Errorf("compiling internal test: %w", err)
@@ -299,6 +307,7 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 				ImportCfg:   testCompileImportCfg,
 				TrimPath:    opts.TrimPath,
 				GCFlagsList: opts.GCFlagsList,
+				Tags:        opts.tagsList(),
 				Files:       &depPkg.PkgFiles,
 			}); err != nil {
 				return fmt.Errorf("recompiling %s for test: %w", depIP, err)
@@ -344,6 +353,7 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 			ImportCfg:   testCompileImportCfg,
 			TrimPath:    opts.TrimPath,
 			GCFlagsList: opts.GCFlagsList,
+			Tags:        opts.tagsList(),
 			Files:       &gofiles.PkgFiles{GoFiles: pkg.XTestGoFiles, EmbedCfg: pkg.XTestEmbedCfg},
 		}); err != nil {
 			return fmt.Errorf("compiling external test: %w", err)
@@ -388,6 +398,7 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 		ImportCfg:   testCompileImportCfg,
 		TrimPath:    opts.TrimPath,
 		GCFlagsList: opts.GCFlagsList,
+		Tags:        opts.tagsList(),
 		Files:       &gofiles.PkgFiles{GoFiles: []string{"_testmain.go"}},
 	}); err != nil {
 		return fmt.Errorf("compiling test main: %w", err)

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -221,6 +221,7 @@ let
         version = 2;
         kind = "compile";
         importcfgParts = [ "${stdlib}/importcfg" ] ++ map depCompileCfg deps;
+        inherit tags;
         gcflags =
           let
             base = gcflags;


### PR DESCRIPTION
## Summary

`// #cgo mytag pkg-config: libfoo` directives were silently ignored in default/dag mode: `resolvePkgConfig` was called with `tags=nil` because `CompileManifest.Tags` was removed in #46 (its only consumer was the since-removed `ListFiles` fallback) and never re-threaded when #61 added custom-tag support to the cgo constraint matcher.

Restores the chain end-to-end:
- `nix/dag` `mkCompileManifestJSON` emits `tags`
- `CompileManifest.Tags` and `compile.Options.Tags` added back
- `cmd/go2nix compile-package` and the main-package compile in `link-binary` pass `m.Tags`
- `testrunner` passes `opts.tagsList()` (its `Tags` field is a comma-string for `localpkgs`; helper splits it) at all four `CompileGoPackage` call sites
- `cgo.go`: `nil` → `opts.Tags`

Adds `TestResolvePkgConfigCustomTag`: a stub `pkg-config` on PATH, source with `// #cgo mytag pkg-config: libfoo`; asserts the directive is ignored with `tags=nil` and applied with `tags=["mytag"]`.

**Out of scope:** tag-gated `// #cgo mytag CFLAGS:/LDFLAGS:` lines are processed by `go tool cgo` itself, which we don't pass `-tags` to. Separate gap.

## Test plan

- [x] `go test ./...` (14 packages)
- [x] `go vet ./...`
- [x] `nix flake check` (formatting)
- [x] `tests/fixtures/testify-basic/dag.nix` instantiates; per-package `compileManifestJSON` now contains `"tags": []`