### PR TITLE
dag: protect mkCompileEnv wiring keys from packageOverrides.env

### DIFF
--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -233,7 +233,10 @@ let
     );
 
   # Env attrset for per-package compile derivations. goEnv is the scope-level
-  # base; the hook-required keys overlay it; packageOverrides.<pkg>.env wins.
+  # base; packageOverrides.<pkg>.env overlays it; the hook-required wiring
+  # keys come last so a stray env.compileManifestJSON / goPackagePath /
+  # goPackageSrcDir / goLangVersion in an override can't silently break the
+  # build (rawGoCompile already protects builder/args/system the same way).
   mkCompileEnv =
     {
       importPath,
@@ -248,13 +251,13 @@ let
       goVersion ? "",
     }:
     goEnv
+    // extraEnv
     // {
       goPackagePath = importPath;
       goPackageSrcDir = srcDir;
       goLangVersion = goVersion;
       compileManifestJSON = mkCompileManifestJSON { inherit deps files; };
-    }
-    // extraEnv;
+    };
 
   # Target platform for `go tool compile`/`link`. goEnv wins so a user-set
   # GOOS/GOARCH (via mkGoEnv { goEnv = ...; }) is honoured everywhere the


### PR DESCRIPTION
## Summary

`mkCompileEnv` merged `goEnv // {wiring keys} // extraEnv`, where `extraEnv` is `packageOverrides.<pkg>.env or {}`. Right-wins, so a stray `env.compileManifestJSON` / `goPackagePath` / `goPackageSrcDir` / `goLangVersion` in a package override silently clobbered the hook inputs that `compile-go-pkg.sh` reads. #64 already protects `rawGoCompile`'s derivation keys (`builder`/`args`/`system`/`passAsFile`) the same way; this applies the same ordering at the env layer.

Reorder to `goEnv // extraEnv // {wiring}` so user env keys (`CGO_CFLAGS`, `GOEXPERIMENT`, etc.) still apply but the per-package wiring always wins.

## Verification

Before (origin/main), with `packageOverrides."…/greeter".env = { compileManifestJSON = "CLOBBERED"; goPackagePath = "wrong/path"; }`:
```
{"manifest":"CLOBBERED","path":"wrong/path"}
```

After:
```
{"langPreserved":true,"manifestIsJSON":true,"pathPreserved":true,"userEnvApplied":true}
```
(hostile keys ignored; `CGO_CFLAGS = "-DUSER_FLAG"` still applies)

## Test plan

- [x] `nix flake check` (formatting)
- [x] Adversarial eval against `tests/fixtures/testify-basic` with hostile `packageOverrides.env` — wiring keys survive, user keys still apply
- [x] Existing fixtures instantiate unchanged