### PR TITLE
tests: assert pure-Go subPackage stays static after cgo subPackage

### DIFF
--- a/packages/test-fixture-cgo-internal-test/default.nix
+++ b/packages/test-fixture-cgo-internal-test/default.nix
@@ -25,7 +25,10 @@ else
   in
   pkgs.runCommand "test-dag-fixture-cgo-internal-test"
     {
-      nativeBuildInputs = [ nix ];
+      nativeBuildInputs = [
+        nix
+        pkgs.file
+      ];
       requiredSystemFeatures = [ "recursive-nix" ];
     }
     ''
@@ -39,5 +42,13 @@ else
         --no-out-link)
 
       $result/bin/cgo-internal-test
+
+      echo "=== Asserting purebin (built after a cgo subPackage) is statically linked ==="
+      [ "$($result/bin/purebin)" = "pure" ] || { echo "FAIL: purebin output"; exit 1; }
+      file $result/bin/purebin | tee /dev/stderr | grep -q "statically linked" \
+        || { echo "FAIL: purebin should be statically linked (cgo marker leaked)"; exit 1; }
+      file $result/bin/cgo-internal-test | tee /dev/stderr | grep -q "dynamically linked" \
+        || { echo "FAIL: cgo-internal-test should be dynamically linked (uses cgo)"; exit 1; }
+
       echo "PASS: cgo-internal-test" > $out
     ''

--- a/tests/fixtures/cgo-internal-test/cmd/purebin/main.go
+++ b/tests/fixtures/cgo-internal-test/cmd/purebin/main.go
@@ -1,0 +1,10 @@
+// purebin is a pure-Go binary built in the same link-binary invocation as
+// the cgo root binary. Regression for the .has_cgo marker leaking across
+// SubPackages iterations: this must NOT be linked with -linkmode external.
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("pure")
+}

--- a/tests/fixtures/cgo-internal-test/dag.nix
+++ b/tests/fixtures/cgo-internal-test/dag.nix
@@ -16,4 +16,10 @@ goEnv.buildGoApplication {
   src = ./.;
   goLock = ./go2nix.toml;
   doCheck = true;
+  # Root binary first (imports cgo via internal/adder), pure-Go second:
+  # regression for .has_cgo marker leaking across SubPackages iterations.
+  subPackages = [
+    "."
+    "./cmd/purebin"
+  ];
 }

--- a/tests/fixtures/cgo-internal-test/main.go
+++ b/tests/fixtures/cgo-internal-test/main.go
@@ -1,5 +1,13 @@
 package main
 
+// The direct cgo import makes this main package's compile write the
+// .has_cgo marker; cmd/purebin (built next) must not inherit it.
+
+/*
+static int one(void) { return 1; }
+*/
+import "C"
+
 import (
 	"fmt"
 
@@ -7,6 +15,6 @@ import (
 )
 
 func main() {
-	fmt.Println(adder.Add(2, 3))
+	fmt.Println(adder.Add(2, 3) * int(C.one()))
 	fmt.Println(adder.Banner())
 }


### PR DESCRIPTION
## Summary

Regression fixture for #67's `.has_cgo`/`.has_cxx` marker reset. Extends `cgo-internal-test` with a second, pure-Go `cmd/purebin` and `subPackages = [ "." "./cmd/purebin" ]` (cgo root first, pure second — the bug-triggering order). The wrapper asserts via `file` that `purebin` is statically linked while `cgo-internal-test` is dynamic.

The root `main.go` gains a direct `import "C"` because only the *main package's own* `CgoFiles` cause `compileCgo` to write `.has_cgo`; the existing transitive cgo dependency via `internal/adder` wasn't sufficient to reproduce the original scenario.

## Test plan

- [x] `file` on built binaries: `cgo-internal-test` → `dynamically linked`, `purebin` → `statically linked`
- [x] `nix flake check` (formatting)
- [x] Wrapper evaluates; `pkgs.file` added to nativeBuildInputs