### PR TITLE
buildinfo: record main package import path, not module path

### DIFF
--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -156,25 +156,16 @@ func linkBinary(manifestPath, output string) error {
 		settings.GOARCHLevel = compile.GoEnvVar(key)
 	}
 
-	modinfo, err := buildinfo.GenerateModinfo(m.ModuleRoot, goVersion, deps, settings)
+	// Step 6: Read merged importcfg once; the per-binary modinfo line (which
+	// carries BuildInfo.Path = main package import path) is appended inside
+	// the SubPackages loop so each binary records its own path.
+	mergedCfgData, err := os.ReadFile(mergedCfg)
 	if err != nil {
-		return fmt.Errorf("generating modinfo: %w", err)
+		return err
 	}
-
-	// Step 6: Build link importcfg (compile importcfg + modinfo).
-	linkCfg := filepath.Join(tmpDir, "importcfg.link")
-	{
-		data, err := os.ReadFile(mergedCfg)
-		if err != nil {
-			return err
-		}
-		content := string(data)
-		if modinfo != "" {
-			content += modinfo + "\n"
-		}
-		if err := os.WriteFile(linkCfg, []byte(content), 0o644); err != nil {
-			return err
-		}
+	linkCfgDir := filepath.Join(tmpDir, "linkcfg")
+	if err := os.MkdirAll(linkCfgDir, 0o755); err != nil {
+		return err
 	}
 
 	// Build gcflags: PIE requires -shared, then append manifest gcflags.
@@ -288,6 +279,18 @@ func linkBinary(manifestPath, output string) error {
 		// GODEBUG default.
 		if godebugDefault != "" {
 			linkFlags = append(linkFlags, "-X=runtime.godebugDefault="+godebugDefault)
+		}
+
+		// Per-binary modinfo: BuildInfo.Path must be the main package's
+		// import path (matching `go build`), so each subPackage gets its
+		// own importcfg.link.
+		modinfo, err := buildinfo.GenerateModinfo(m.ModuleRoot, importpath, goVersion, deps, settings)
+		if err != nil {
+			return fmt.Errorf("generating modinfo for %s: %w", importpath, err)
+		}
+		linkCfg := filepath.Join(linkCfgDir, binname+".importcfg.link")
+		if err := os.WriteFile(linkCfg, append(mergedCfgData, []byte(modinfo+"\n")...), 0o644); err != nil {
+			return err
 		}
 
 		// Assemble linker command.

--- a/go/go2nix/cmd/go2nix/modinfo.go
+++ b/go/go2nix/cmd/go2nix/modinfo.go
@@ -17,6 +17,7 @@ func runModinfoCmd(args []string) {
 	fs := flag.NewFlagSet("build-modinfo", flag.ExitOnError)
 	lockfilePath := fs.String("lockfile", "", "path to go2nix.toml lockfile")
 	goBin := fs.String("go", "", "path to go binary (default: from PATH)")
+	mainPath := fs.String("main-path", "", "import path of the main package (default: module path)")
 	_ = fs.Parse(args)
 
 	moduleRoot := fs.Arg(0)
@@ -76,7 +77,7 @@ func runModinfoCmd(args []string) {
 		settings.GOARCHLevel = compile.GoEnvVar(key)
 	}
 
-	line, err := buildinfo.GenerateModinfo(moduleRoot, goVersion, deps, settings)
+	line, err := buildinfo.GenerateModinfo(moduleRoot, *mainPath, goVersion, deps, settings)
 	if err != nil {
 		slog.Error("generating modinfo", "err", err)
 		os.Exit(1)

--- a/go/go2nix/pkg/buildinfo/buildinfo.go
+++ b/go/go2nix/pkg/buildinfo/buildinfo.go
@@ -101,14 +101,17 @@ func (s BuildSettings) toDebugSettings() []debug.BuildSetting {
 // GenerateModinfo produces the modinfo importcfg line for the linker.
 //
 // moduleRoot is the path to the directory containing go.mod (and optionally
-// go.sum for checksums). goVersion is the full Go toolchain version string
+// go.sum for checksums). mainPath is the import path of the main package
+// being linked (recorded as debug.BuildInfo.Path so `go version -m` shows
+// the per-binary path, matching `go build`); when empty it falls back to
+// the module path. goVersion is the full Go toolchain version string
 // (e.g., "go1.21.5"). deps lists all third-party module dependencies.
 // settings supplies the `build` section so debug.ReadBuildInfo() consumers
 // (govulncheck, prometheus go_build_info, SBOM tools) see the same metadata
 // as a `go build -trimpath` binary.
 //
 // Returns a string like: modinfo "..."
-func GenerateModinfo(moduleRoot, goVersion string, deps []ModDep, settings BuildSettings) (string, error) {
+func GenerateModinfo(moduleRoot, mainPath, goVersion string, deps []ModDep, settings BuildSettings) (string, error) {
 	// Parse go.mod for the main module path.
 	goModPath := filepath.Join(moduleRoot, "go.mod")
 	goModData, err := os.ReadFile(goModPath)
@@ -122,6 +125,9 @@ func GenerateModinfo(moduleRoot, goVersion string, deps []ModDep, settings Build
 	if mf.Module == nil {
 		return "", fmt.Errorf("go.mod missing module directive")
 	}
+	if mainPath == "" {
+		mainPath = mf.Module.Mod.Path
+	}
 
 	// Read go.sum for checksums (optional).
 	sums := readGoSum(filepath.Join(moduleRoot, "go.sum"))
@@ -129,7 +135,7 @@ func GenerateModinfo(moduleRoot, goVersion string, deps []ModDep, settings Build
 	// Build debug.BuildInfo.
 	info := &debug.BuildInfo{
 		GoVersion: goVersion,
-		Path:      mf.Module.Mod.Path,
+		Path:      mainPath,
 		Main: debug.Module{
 			Path:    mf.Module.Mod.Path,
 			Version: "(devel)",

--- a/go/go2nix/pkg/buildinfo/buildinfo_test.go
+++ b/go/go2nix/pkg/buildinfo/buildinfo_test.go
@@ -28,7 +28,7 @@ golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq
 		{Path: "golang.org/x/crypto", Version: "v0.17.0"},
 	}
 
-	line, err := GenerateModinfo(dir, "go1.21.5", deps, BuildSettings{
+	line, err := GenerateModinfo(dir, "example.com/myapp/cmd/tool", "go1.21.5", deps, BuildSettings{
 		BuildMode:   "exe",
 		Tags:        "netgo,osusergo",
 		CGOEnabled:  "0",
@@ -43,8 +43,13 @@ golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq
 	if !strings.HasPrefix(line, "modinfo ") {
 		t.Errorf("expected modinfo prefix, got: %s", line)
 	}
-	if !strings.Contains(line, "example.com/myapp") {
-		t.Error("missing module path in modinfo")
+	// BuildInfo.Path = main package import path; Main.Path = module path.
+	// `go version -m` renders these as `path\t…` and `mod\t…\t(devel)`.
+	if !strings.Contains(line, "path\\texample.com/myapp/cmd/tool\\n") {
+		t.Errorf("BuildInfo.Path should be main package import path:\n%s", line)
+	}
+	if !strings.Contains(line, "mod\\texample.com/myapp\\t(devel)") {
+		t.Errorf("BuildInfo.Main.Path should be module path:\n%s", line)
 	}
 	if !strings.Contains(line, "golang.org/x/crypto") {
 		t.Error("missing dependency in modinfo")
@@ -90,7 +95,7 @@ go 1.21
 		{Path: "golang.org/x/net", Version: "v0.19.0"},
 	}
 
-	line, err := GenerateModinfo(dir, "go1.21.5", deps, BuildSettings{})
+	line, err := GenerateModinfo(dir, "", "go1.21.5", deps, BuildSettings{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,6 +103,10 @@ go 1.21
 	// Should still work without go.sum, just without hashes.
 	if !strings.Contains(line, "golang.org/x/net") {
 		t.Error("missing dependency in modinfo")
+	}
+	// Empty mainPath falls back to module path.
+	if !strings.Contains(line, "path\\texample.com/myapp\\n") {
+		t.Errorf("empty mainPath should fall back to module path:\n%s", line)
 	}
 }
 
@@ -121,7 +130,7 @@ go 1.21
 		},
 	}
 
-	line, err := GenerateModinfo(dir, "go1.21.5", deps, BuildSettings{})
+	line, err := GenerateModinfo(dir, "example.com/myapp", "go1.21.5", deps, BuildSettings{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/go2nix/pkg/resolve/resolve.go
+++ b/go/go2nix/pkg/resolve/resolve.go
@@ -945,7 +945,7 @@ func buildLinkDrv(
 	}
 
 	// Add modinfo so go version -m shows module dependencies.
-	modinfoLine, err := generateModinfo(cfg, sorted, mainPkg.DefaultGODEBUG)
+	modinfoLine, err := generateModinfo(cfg, sorted, mainPkg.ImportPath, mainPkg.DefaultGODEBUG)
 	if err != nil {
 		slog.Warn("modinfo generation failed, skipping", "err", err)
 	} else {
@@ -1187,7 +1187,7 @@ func loadGoEnv(goBin string) map[string]string {
 }
 
 // generateModinfo constructs the modinfo importcfg line from the package graph.
-func generateModinfo(cfg Config, sorted []*ResolvedPkg, defaultGODEBUG string) (string, error) {
+func generateModinfo(cfg Config, sorted []*ResolvedPkg, mainPath, defaultGODEBUG string) (string, error) {
 	// Get Go toolchain version.
 	goVersion := cfg.goEnv["GOVERSION"]
 
@@ -1236,7 +1236,7 @@ func generateModinfo(cfg Config, sorted []*ResolvedPkg, defaultGODEBUG string) (
 		deps = append(deps, dep)
 	}
 
-	return buildinfo.GenerateModinfo(filepath.Join(cfg.Src, cfg.ModRoot), goVersion, deps, settings)
+	return buildinfo.GenerateModinfo(filepath.Join(cfg.Src, cfg.ModRoot), mainPath, goVersion, deps, settings)
 }
 
 // createFilteredPkgDir creates a temporary directory containing only the files

--- a/packages/test-fixture-cgo-internal-test/default.nix
+++ b/packages/test-fixture-cgo-internal-test/default.nix
@@ -28,6 +28,7 @@ else
       nativeBuildInputs = [
         nix
         pkgs.file
+        pkgs.go
       ];
       requiredSystemFeatures = [ "recursive-nix" ];
     }
@@ -49,6 +50,14 @@ else
         || { echo "FAIL: purebin should be statically linked (cgo marker leaked)"; exit 1; }
       file $result/bin/cgo-internal-test | tee /dev/stderr | grep -q "dynamically linked" \
         || { echo "FAIL: cgo-internal-test should be dynamically linked (uses cgo)"; exit 1; }
+
+      echo "=== Asserting BuildInfo.Path is the per-binary main package path ==="
+      go version -m $result/bin/purebin | tee /dev/stderr \
+        | grep -qE '^[[:space:]]*path[[:space:]]+example.com/cgo-internal-test/cmd/purebin$' \
+        || { echo "FAIL: purebin BuildInfo.Path should be the main package import path"; exit 1; }
+      go version -m $result/bin/cgo-internal-test | tee /dev/stderr \
+        | grep -qE '^[[:space:]]*path[[:space:]]+example.com/cgo-internal-test$' \
+        || { echo "FAIL: root binary BuildInfo.Path should be the module path"; exit 1; }
 
       echo "PASS: cgo-internal-test" > $out
     ''


### PR DESCRIPTION
## Summary

`go version -m` showed the same `path` for every binary in a multi-subPackage build because `GenerateModinfo` always recorded the module path (parsed from `go.mod`) as `debug.BuildInfo.Path`. `go build` records the main package's import path, so consumers of `debug.ReadBuildInfo().Path` (including the binary's own self-identification) couldn't distinguish binaries.

- `GenerateModinfo` gains `mainPath`; `info.Path = mainPath` (falls back to module path when empty for the standalone CLI). `info.Main.Path` stays as the module path.
- `linkbinary.go`: modinfo + `importcfg.link` writing moved into the `SubPackages` loop, passing the per-binary `importpath`.
- `resolve.go` (dynamic mode): `generateModinfo` passes `mainPkg.ImportPath`.
- `cmd/go2nix/modinfo.go`: adds `--main-path` flag.
- Tests: buildinfo unit tests assert `path\t<mainPath>` and `mod\t<modulePath>` are distinct; `test-fixture-cgo-internal-test` asserts `go version -m` shows `…/cmd/purebin` for purebin.

No `nix/dag` change needed — `link-binary` already computes `importpath` from `m.SubPackages[i].Path` + `modulePath`.

## Test plan

- [x] `go test ./...` (14 packages), `go vet`
- [x] `nix-build tests/fixtures/cgo-internal-test/dag.nix` — `go version -m $result/bin/purebin` → `path example.com/cgo-internal-test/cmd/purebin` (was `path example.com/cgo-internal-test`)
- [x] `nix flake check` (formatting)