### PR TITLE
dag: union local-replace dirs into mainSrc so doCheck works with sibling replaces

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -151,6 +151,7 @@
           golangci-lint-go2nix-testgen = callPkg ./packages/golangci-lint-go2nix-testgen/default.nix;
           check-godebug-table = callPkg ./packages/check-godebug-table/default.nix;
           cross-platform-env = callPkgWith ./tests/nix/cross_platform_test.nix { inherit pkgs; };
+          mainsrc-replace = callPkgWith ./tests/nix/mainsrc_replace_test.nix { inherit pkgs; };
           # The --help check just confirms the binary links and the CLI
           # surface is intact. The benchmark itself can't run in nix's
           # build sandbox (it spawns a nested daemon and fetches from

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -66,10 +66,10 @@
   # without CA can't cut off anything (the input-addressed .x path
   # changes whenever src does).
   contentAddressed ? false,
-  # Phase 1: checks only supported for modRoot == "." (single-module case).
-  # When modRoot != ".", mainSrc doesn't include local replace targets outside
-  # the module root, so test discovery/compilation may fail. Users can override
-  # with doCheck = true if their layout doesn't use out-of-tree replaces.
+  # Defaults to (modRoot == ".") for back-compat: enabling tests changes
+  # the link drv hash, and modRoot != "." callers historically built
+  # without checks. mainSrc now includes sibling-replace dirs, so passing
+  # doCheck = true works for monorepo layouts.
   doCheck ? (modRoot == "."),
   checkFlags ? [ ],
   ...
@@ -725,7 +725,11 @@ let
     map (attrs: attrs.nativeBuildInputs or [ ]) (builtins.attrValues packageOverrides)
   );
 
-  # Source for the final link derivation: only the main package directories.
+  # Source for the final link derivation. The link step itself only needs
+  # the main-package directories plus go.mod, but the testrunner re-walks
+  # go.mod from ${mainSrc}/${modRoot}, so any local `replace => ../sibling`
+  # target must also be present (otherwise doCheck fails with
+  # "local replace target ... does not exist").
   mainSrc =
     let
       cleanModRoot = lib.removePrefix "./" modRoot;
@@ -736,8 +740,59 @@ let
         in
         if modRoot == "." then clean else "${cleanModRoot}/${clean}"
       ) normalizedSubPackages;
-      # Include modRoot for go.mod access.
-      allowedDirs = [ cleanModRoot ] ++ subPkgDirs;
+
+      # Resolve a/b/../c → a/c in src-relative string space. Kept here
+      # (not in helpers.nix) because it needs lib for string ops.
+      normalizeRelPath =
+        p:
+        let
+          folded = lib.foldl (
+            acc: seg:
+            if seg == "" || seg == "." then
+              acc
+            else if seg == ".." then
+              if acc == [ ] || lib.last acc == ".." then acc ++ [ ".." ] else lib.init acc
+            else
+              acc ++ [ seg ]
+          ) [ ] (lib.splitString "/" p);
+        in
+        if folded == [ ] then "." else lib.concatStringsSep "/" folded;
+
+      # Transitively collect local-replace target dirs, src-relative.
+      # Reads go.mod via the src store path so it works whether src is a
+      # literal path, a fileset.toSource result, or a builtin fetcher.
+      replaceDirsOf =
+        startDir:
+        map (x: x.key) (
+          builtins.genericClosure {
+            startSet = [ { key = startDir; } ];
+            operator =
+              { key, ... }:
+              let
+                goMod = "${src}/${key}/go.mod";
+                rels =
+                  if lib.hasPrefix ".." key then
+                    # Replace target escaped src — nothing more to read.
+                    [ ]
+                  else if builtins.pathExists goMod then
+                    helpers.parseLocalReplaces (builtins.readFile goMod)
+                  else
+                    [ ];
+              in
+              map (r: { key = normalizeRelPath "${key}/${r}"; }) rels;
+          }
+        );
+      # Only when tests run — keeps mainSrc (and so the link drv hash)
+      # unchanged for doCheck = false builds.
+      replaceDirs = lib.optionals doCheck (
+        lib.filter (d: d != cleanModRoot && d != "." && !(lib.hasPrefix ".." d)) (
+          replaceDirsOf cleanModRoot
+        )
+      );
+
+      # Include modRoot for go.mod access plus sibling-replace module roots
+      # so the testrunner can walk them.
+      allowedDirs = [ cleanModRoot ] ++ subPkgDirs ++ replaceDirs;
       # When modRoot is "." or any subPackage resolves to ".", the entire
       # source tree is needed — no filtering required.
       includeAll = builtins.elem "." allowedDirs;

--- a/tests/nix/mainsrc_replace_test.nix
+++ b/tests/nix/mainsrc_replace_test.nix
@@ -1,0 +1,72 @@
+# tests/nix/mainsrc_replace_test.nix — regression for mainSrc dropping
+# sibling-replace dirs.
+#
+# When modRoot != "." and go.mod has `replace => ../sibling`, the link
+# derivation's mainSrc must include those sibling module roots so the
+# testrunner (which re-walks go.mod from ${mainSrc}/${modRoot}) can
+# resolve them. torture-project/app-full has 14 such siblings under
+# ../internal/*.
+#
+# Eval-only: mainSrc is computed from go.mod parsing alone and does not
+# force goPackagesResult, so this check does not need the plugin.
+{
+  lib,
+  pkgs,
+  runCommand,
+}:
+let
+  go2nix = import ../../packages/go2nix { inherit pkgs; };
+  scope = import ../../nix/mk-go-env.nix {
+    inherit (pkgs) go callPackage;
+    inherit go2nix;
+  };
+  mkApp =
+    doCheck:
+    scope.buildGoApplication {
+      pname = "mainsrc-replace-test";
+      version = "0.0.1";
+      src = ../fixtures/torture-project;
+      goLock = ../fixtures/torture-project/app-full/go2nix.toml;
+      modRoot = "app-full";
+      subPackages = [ "cmd/app-full" ];
+      inherit doCheck;
+    };
+  ms = (mkApp true).passthru.mainSrc;
+  msNoCheck = (mkApp false).passthru.mainSrc;
+
+  assertions = [
+    {
+      msg = "modRoot's own go.mod must be present";
+      ok = builtins.pathExists "${ms}/app-full/go.mod";
+    }
+    {
+      msg = "sibling replace target ../internal/aws must be in mainSrc";
+      ok = builtins.pathExists "${ms}/internal/aws/go.mod";
+    }
+    {
+      msg = "sibling replace target ../internal/common must be in mainSrc";
+      ok = builtins.pathExists "${ms}/internal/common/go.mod";
+    }
+    {
+      msg = "non-replace sibling app-partial must NOT be in mainSrc";
+      ok = !(builtins.pathExists "${ms}/app-partial");
+    }
+    {
+      msg = "non-replace sibling app-replace must NOT be in mainSrc";
+      ok = !(builtins.pathExists "${ms}/app-replace");
+    }
+    {
+      msg = "doCheck=false mainSrc must NOT include sibling dirs (no hash churn)";
+      ok = !(builtins.pathExists "${msNoCheck}/internal");
+    }
+  ];
+
+  failures = lib.filter (a: !a.ok) assertions;
+in
+if failures != [ ] then
+  throw "mainsrc-replace-test: ${lib.concatMapStringsSep "; " (a: a.msg) failures}"
+else
+  runCommand "mainsrc-replace-test" { } ''
+    echo "mainsrc-replace-test: ${toString (lib.length assertions)} assertions passed"
+    touch $out
+  ''


### PR DESCRIPTION
## Summary

`doCheck = true` failed for any module with `replace … => ../sibling` directives: `mainSrc` filtered to `[modRoot] ++ subPackageDirs` only, then the testrunner re-ran `go list` from `${mainSrc}/${modRoot}` where `../sibling` no longer existed (`local replace target … does not exist`). This was the documented limitation behind `doCheck ? (modRoot == ".")`.

`mainSrc` now also includes the transitive set of local-replace module roots when `doCheck` is set:
- `replaceDirsOf` does a `genericClosure` over `helpers.parseLocalReplaces` of each `go.mod` (read via `"${src}/${dir}/go.mod"` so it works for path literals, `fileset.toSource`, and builtin fetchers).
- `normalizeRelPath` resolves `a/b/../c → a/c` in string space (no filesystem realpath).
- Result is filtered to drop `modRoot` itself, `.`, and anything escaping `src`.
- Gated on `doCheck`, so `doCheck=false` builds keep their existing `mainSrc` (verified: drv hashes for testify-basic, xtest-local-dep, modroot-nested, cgo-internal-test, and torture-project app-full unchanged).

New eval-only flake check `mainsrc-replace` (6 assertions; no plugin needed since `mainSrc` doesn't force `goPackagesResult`).

`doCheck` default stays `(modRoot == ".")` — wrappers can now opt in for monorepo-style modules.

## Test plan

- [x] `checks.mainsrc-replace`: modRoot/sibling go.mod present; unrelated apps excluded; `doCheck=false` mainSrc has no replaces
- [x] `go run ./cmd/go2nix list-packages "${mainSrc}/app-full"` (testrunner code path) → 15 packages (was: error)
- [x] Drv hashes for existing fixtures with `doCheck=false` byte-identical to main
- [x] `nix flake check` (formatting)