### PR TITLE
dag: thread goProxy to fetchGoModule FODs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -152,6 +152,14 @@
           check-godebug-table = callPkg ./packages/check-godebug-table/default.nix;
           cross-platform-env = callPkgWith ./tests/nix/cross_platform_test.nix { inherit pkgs; };
           mainsrc-replace = callPkgWith ./tests/nix/mainsrc_replace_test.nix { inherit pkgs; };
+          # tests/nix/{helpers,fetch_go_module}_test.nix return `true` or
+          # throw. seq forces them at eval time so a failure breaks the
+          # check; the runCommand body is just the success marker.
+          nix-unit-tests = builtins.seq (import ./tests/nix/helpers_test.nix) (
+            builtins.seq (import ./tests/nix/fetch_go_module_test.nix { inherit pkgs; }) (
+              pkgs.runCommand "nix-unit-tests" { } "echo OK > $out"
+            )
+          );
           # The --help check just confirms the binary links and the CLI
           # surface is intact. The benchmark itself can't run in nix's
           # build sandbox (it spawns a nested daemon and fetches from

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -383,6 +383,7 @@ let
     let
       src = fetchers.fetchGoModule {
         inherit (mod) hash fetchPath version;
+        inherit goProxy;
         sourceOnly = !hasLockfile;
       };
     in

--- a/nix/dag/fetch-go-module.nix
+++ b/nix/dag/fetch-go-module.nix
@@ -30,6 +30,13 @@ in
   fetchPath,
   version,
   sourceOnly ? false,
+  # Explicit GOPROXY for the FOD's `go mod download`. When null, the
+  # impureEnvVars path below still lets the build environment's GOPROXY
+  # bleed through (matching nixpkgs buildGoModule). Set this for private
+  # modules so the proxy is part of the derivation env rather than relying
+  # on the daemon's environment — under daemon nix or remote builders the
+  # impure path sees no GOPROXY and falls back to proxy.golang.org,direct.
+  goProxy ? null,
 }:
 let
   escapedPath = escapeModPath fetchPath;
@@ -60,33 +67,40 @@ stdenvNoCC.mkDerivation {
   # No source — we download in the build phase.
   dontUnpack = true;
 
-  buildPhase = ''
-    export HOME=$TMPDIR
-    export GOSUMDB=off
-    export GONOSUMCHECK='*'
-    ${
-      if netrcFile != null then
+  # When goProxy is null the prefix is "", so buildPhase is byte-identical
+  # and the FOD .drv path doesn't change. When set, the explicit export
+  # wins over whatever impureEnvVars let through from the builder env.
+  buildPhase =
+    lib.optionalString (goProxy != null) ''
+      export GOPROXY=${lib.escapeShellArg goProxy}
+    ''
+    + ''
+      export HOME=$TMPDIR
+      export GOSUMDB=off
+      export GONOSUMCHECK='*'
+      ${
+        if netrcFile != null then
+          ''
+            cp ${netrcFile} $HOME/.netrc
+            chmod 600 $HOME/.netrc
+          ''
+        else
+          ""
+      }
+    ''
+    + (
+      if sourceOnly then
         ''
-          cp ${netrcFile} $HOME/.netrc
-          chmod 600 $HOME/.netrc
+          export GOMODCACHE=$TMPDIR/modcache
+          go mod download "${fetchPath}@${version}"
+          cp -r "$TMPDIR/modcache/${dirSuffix}" "$out"
         ''
       else
-        ""
-    }
-  ''
-  + (
-    if sourceOnly then
-      ''
-        export GOMODCACHE=$TMPDIR/modcache
-        go mod download "${fetchPath}@${version}"
-        cp -r "$TMPDIR/modcache/${dirSuffix}" "$out"
-      ''
-    else
-      ''
-        export GOMODCACHE=$out
-        go mod download "${fetchPath}@${version}"
-      ''
-  );
+        ''
+          export GOMODCACHE=$out
+          go mod download "${fetchPath}@${version}"
+        ''
+    );
 
   # Skip other phases.
   dontInstall = true;

--- a/tests/nix/fetch_go_module_test.nix
+++ b/tests/nix/fetch_go_module_test.nix
@@ -1,9 +1,10 @@
 # tests/nix/fetch_go_module_test.nix — unit tests for nix/dag/fetch-go-module.nix
 #
-# Run: nix eval -f tests/nix/fetch_go_module_test.nix --impure
-# Returns true on success, throws on failure.
+# Returns true on success, throws on failure. Exercised by the
+# `nix-unit-tests` flake check; run standalone with
+#   nix eval -f tests/nix/fetch_go_module_test.nix --arg pkgs 'import <nixpkgs> {}'
+{ pkgs }:
 let
-  pkgs = import <nixpkgs> { };
   fetcher = pkgs.callPackage ../../nix/dag/fetch-go-module.nix {
     inherit (pkgs) go;
     helpers = import ../../nix/helpers.nix;

--- a/tests/nix/fetch_go_module_test.nix
+++ b/tests/nix/fetch_go_module_test.nix
@@ -14,6 +14,12 @@ let
     fetchPath = "example.com/test/module";
     version = "v1.0.0";
   };
+  drvWithProxy = fetcher {
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    fetchPath = "example.com/test/module";
+    version = "v1.0.0";
+    goProxy = "https://proxy.example/go";
+  };
 
   assertElem =
     name: x: xs:
@@ -25,4 +31,14 @@ in
 assert assertElem "impureEnvVars has GOPROXY" "GOPROXY" drv.impureEnvVars;
 assert assertElem "impureEnvVars has NETRC" "NETRC" drv.impureEnvVars;
 assert assertElem "impureEnvVars has http_proxy" "http_proxy" drv.impureEnvVars;
+# Default (goProxy = null): buildPhase must not mention GOPROXY so the
+# .drv path is unchanged — the impure path is the only route.
+assert
+  builtins.match ".*GOPROXY.*" drv.buildPhase == null
+  || builtins.throw "default buildPhase should not export GOPROXY";
+# Explicit goProxy: buildPhase exports it so the FOD doesn't depend on the
+# daemon's environment under daemon nix / remote builders.
+assert
+  pkgs.lib.hasInfix "export GOPROXY=https://proxy.example/go" drvWithProxy.buildPhase
+  || builtins.throw "goProxy not exported in buildPhase";
 true


### PR DESCRIPTION
## Summary

`buildGoApplication { goProxy = "..."; }` reached the eval-time `go list` (via `resolveGoPackages`) but not the per-module fetch FODs — those only saw `GOPROXY` via `impureEnvVars`. Under daemon nix or remote builders the daemon's environment has no `GOPROXY`, so the FOD's `go mod download` fell back to Go's default `proxy.golang.org,direct` and private modules became unfetchable (no `git` in `nativeBuildInputs` either, so `direct` can't help).

`fetchGoModule` now accepts a per-call `goProxy` and exports it at the top of `buildPhase`. The export is prepended via `lib.optionalString` so when `goProxy` is null (the default) `buildPhase` is byte-identical and existing `.drv` paths don't change.

## Test plan

- [x] `tests/nix/fetch_go_module_test.nix`: default `buildPhase` has no `GOPROXY`; with `goProxy` set, `export GOPROXY=...` appears
- [x] `nix-instantiate tests/fixtures/testify-basic/dag.nix` produces the same `.drv` path as `origin/main` (hash-neutral when `goProxy=null`)
- [x] `nix flake check` (formatting)