### PR TITLE
linkbinary,dag: pass module list via link manifest so lockfile-free builds emit dep lines

### DIFF
--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/numtide/go2nix/pkg/buildinfo"
 	"github.com/numtide/go2nix/pkg/compile"
-	"github.com/numtide/go2nix/pkg/lockfile"
 	"github.com/numtide/go2nix/pkg/mvscheck"
 )
 
@@ -121,24 +120,13 @@ func linkBinary(manifestPath, output string) error {
 		return fmt.Errorf("getting Go version: %w", err)
 	}
 
-	var deps []buildinfo.ModDep
-	if m.Lockfile != nil && *m.Lockfile != "" {
-		lock, err := lockfile.Read(*m.Lockfile)
-		if err != nil {
-			return fmt.Errorf("reading lockfile: %w", err)
+	deps := make([]buildinfo.ModDep, 0, len(m.Modules))
+	for _, mm := range m.Modules {
+		dep := buildinfo.ModDep{Path: mm.Path, Version: mm.Version}
+		if mm.ReplacePath != "" {
+			dep.Replace = &buildinfo.ModDep{Path: mm.ReplacePath, Version: mm.ReplaceVersion}
 		}
-
-		for modKey := range lock.Mod {
-			modPath, version, ok := strings.Cut(modKey, "@")
-			if !ok {
-				continue
-			}
-			dep := buildinfo.ModDep{Path: modPath, Version: version}
-			if replacePath, ok := lock.Replace[modKey]; ok {
-				dep.Replace = &buildinfo.ModDep{Path: replacePath, Version: version}
-			}
-			deps = append(deps, dep)
-		}
+		deps = append(deps, dep)
 	}
 
 	godebugDefault := buildinfo.DefaultGODEBUG(m.ModuleRoot)

--- a/go/go2nix/pkg/compile/manifest.go
+++ b/go/go2nix/pkg/compile/manifest.go
@@ -128,13 +128,26 @@ type LinkManifest struct {
 	SubPackages           []LinkSubPackage  `json:"subPackages"`
 	ModuleRoot            string            `json:"moduleRoot"`
 	Lockfile              *string           `json:"lockfile"`
-	Pname                 string            `json:"pname"`
-	GOOS                  *string           `json:"goos"`
-	GOARCH                *string           `json:"goarch"`
-	LDFlags               []string          `json:"ldflags"`
-	GCFlags               []string          `json:"gcflags"`
-	Tags                  []string          `json:"tags"`
-	PGOProfile            *string           `json:"pgoProfile"`
+	// Modules is the resolved third-party module set, threaded straight
+	// from the Nix build graph so debug.BuildInfo.Deps is populated
+	// regardless of whether a lockfile is in use.
+	Modules    []ManifestModule `json:"modules,omitempty"`
+	Pname      string           `json:"pname"`
+	GOOS       *string          `json:"goos"`
+	GOARCH     *string          `json:"goarch"`
+	LDFlags    []string         `json:"ldflags"`
+	GCFlags    []string         `json:"gcflags"`
+	Tags       []string         `json:"tags"`
+	PGOProfile *string          `json:"pgoProfile"`
+}
+
+// ManifestModule is one third-party module in a LinkManifest, used to
+// populate debug.BuildInfo.Deps.
+type ManifestModule struct {
+	Path           string `json:"path"`
+	Version        string `json:"version"`
+	ReplacePath    string `json:"replacePath,omitempty"`
+	ReplaceVersion string `json:"replaceVersion,omitempty"`
 }
 
 // LinkSubPackage is one main-package entry in a LinkManifest.

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -913,6 +913,34 @@ let
           }}"
         else
           null;
+      # Resolved third-party module set, threaded straight to link-binary
+      # so debug.BuildInfo.Deps is populated in lockfile-free mode too
+      # (link-binary previously read it from the lockfile only).
+      # allModules contains replacement targets as separate keys (so
+      # fetchGoModule can find their hash); filter those out so modinfo
+      # records `dep <orig> => <repl>` rather than a spurious second dep.
+      modules =
+        let
+          replTargets = lib.mapAttrs' (_: r: {
+            name = "${r.path}@${if r.version != "" then r.version else ""}";
+            value = true;
+          }) goPackagesResult.replacements;
+          isReplTarget =
+            _modKey: m: replTargets."${m.path}@${m.version}" or false || replTargets."${m.path}@" or false;
+        in
+        lib.mapAttrsToList (
+          modKey: m:
+          let
+            repl = goPackagesResult.replacements.${modKey} or null;
+          in
+          {
+            inherit (m) path version;
+          }
+          // lib.optionalAttrs (repl != null) {
+            replacePath = repl.path;
+            replaceVersion = if repl.version != "" then repl.version else m.version;
+          }
+        ) (lib.filterAttrs (k: v: !(isReplTarget k v)) allModules);
       inherit pname;
       goos = targetGoos;
       goarch = targetGoarch;

--- a/packages/test-fixture-testify-basic/default.nix
+++ b/packages/test-fixture-testify-basic/default.nix
@@ -73,5 +73,11 @@ else
           || { echo "FAIL: missing 'build $key' in go version -m output"; exit 1; }
       done
 
+      echo "=== Asserting modinfo contains dep lines (lockfile mode) ==="
+      ndeps=$(grep -cE '^[[:space:]]+dep[[:space:]]' buildinfo.txt || true)
+      [ "$ndeps" -ge 1 ] || { echo "FAIL: expected >= 1 dep lines, got $ndeps"; exit 1; }
+      grep -E '^[[:space:]]+dep[[:space:]]+github\.com/stretchr/testify[[:space:]]' buildinfo.txt \
+        || { echo "FAIL: expected dep github.com/stretchr/testify"; exit 1; }
+
       echo "PASS: testify-basic" > $out
     ''

--- a/packages/test-fixture-torture-app-replace/default.nix
+++ b/packages/test-fixture-torture-app-replace/default.nix
@@ -46,7 +46,10 @@ else
   in
   pkgs.runCommand "test-dag-fixture-torture-app-replace"
     {
-      nativeBuildInputs = [ nix ];
+      nativeBuildInputs = [
+        nix
+        go
+      ];
       requiredSystemFeatures = [ "recursive-nix" ];
     }
     ''
@@ -62,5 +65,15 @@ else
 
       out_val=$($result/bin/app-replace)
       [ "$out_val" = "42" ] || { echo "FAIL: expected 42, got $out_val"; exit 1; }
+
+      echo "=== Asserting modinfo contains dep lines (lockfile-free mode) ==="
+      go version -m "$result/bin/app-replace" | tee buildinfo.txt
+      ndeps=$(grep -cE '^[[:space:]]+dep[[:space:]]' buildinfo.txt || true)
+      [ "$ndeps" -ge 1 ] || { echo "FAIL: expected >= 1 dep lines, got $ndeps"; exit 1; }
+      grep -E '^[[:space:]]+dep[[:space:]]+go\.uber\.org/atomic[[:space:]]+v1\.11\.0' buildinfo.txt \
+        || { echo "FAIL: expected dep go.uber.org/atomic v1.11.0"; exit 1; }
+      grep -E '^[[:space:]]+=>[[:space:]]+github\.com/uber-go/atomic[[:space:]]+v1\.11\.0' buildinfo.txt \
+        || { echo "FAIL: expected replace => github.com/uber-go/atomic v1.11.0"; exit 1; }
+
       echo "PASS: torture-app-replace" > $out
     ''


### PR DESCRIPTION
## Summary

`go version -m` showed zero `dep` lines for lockfile-free builds (`goLock = null`): `link-binary` only populated `deps` from `lockfile.Read(*m.Lockfile)`, so `debug.BuildInfo.Deps` was empty and govulncheck/SBOM tooling saw nothing.

`linkManifestJSON` now carries a `modules` list (built from the same `allModules` + `replacements` that `nix/dag` already has from the plugin, regardless of lockfile), and `link-binary` consumes it directly. The lockfile-read path is removed — the manifest is the actual build set, and the lockfile is still used for `mvscheck.CheckLockfile`.

Replacement-target keys are filtered so a fork replace records one `dep` + `=>` line rather than two `dep` lines.

## Regression checks

- `test-fixture-torture-app-replace` (lockfile-free, fork replace): asserts `dep go.uber.org/atomic v1.11.0` + `=> github.com/uber-go/atomic`
- `test-fixture-testify-basic` (lockfile): asserts ≥1 `dep` line + `dep github.com/stretchr/testify`

## Test plan

- [x] `go test ./...` (14 pkgs), `go vet`
- [x] Both fixture wrappers' new assertions pass against built binaries (output above)
- [x] `nix flake check` (formatting)