### PR TITLE
dag,linkbinary: per-subPackage module closure for modinfo deps

### DIFF
--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -120,15 +120,6 @@ func linkBinary(manifestPath, output string) error {
 		return fmt.Errorf("getting Go version: %w", err)
 	}
 
-	deps := make([]buildinfo.ModDep, 0, len(m.Modules))
-	for _, mm := range m.Modules {
-		dep := buildinfo.ModDep{Path: mm.Path, Version: mm.Version}
-		if mm.ReplacePath != "" {
-			dep.Replace = &buildinfo.ModDep{Path: mm.ReplacePath, Version: mm.ReplaceVersion}
-		}
-		deps = append(deps, dep)
-	}
-
 	godebugDefault := buildinfo.DefaultGODEBUG(m.ModuleRoot)
 
 	settings := buildinfo.BuildSettings{
@@ -193,6 +184,15 @@ func linkBinary(manifestPath, output string) error {
 		// after a cgo one doesn't inherit -extld / -linkmode external.
 		_ = os.Remove(filepath.Join(tmpDir, ".has_cgo"))
 		_ = os.Remove(filepath.Join(tmpDir, ".has_cxx"))
+
+		deps := make([]buildinfo.ModDep, 0, len(sp.Modules))
+		for _, mm := range sp.Modules {
+			dep := buildinfo.ModDep{Path: mm.Path, Version: mm.Version}
+			if mm.ReplacePath != "" {
+				dep.Replace = &buildinfo.ModDep{Path: mm.ReplacePath, Version: mm.ReplaceVersion}
+			}
+			deps = append(deps, dep)
+		}
 
 		var importpath, srcdir, binname string
 

--- a/go/go2nix/pkg/compile/manifest.go
+++ b/go/go2nix/pkg/compile/manifest.go
@@ -128,17 +128,13 @@ type LinkManifest struct {
 	SubPackages           []LinkSubPackage  `json:"subPackages"`
 	ModuleRoot            string            `json:"moduleRoot"`
 	Lockfile              *string           `json:"lockfile"`
-	// Modules is the resolved third-party module set, threaded straight
-	// from the Nix build graph so debug.BuildInfo.Deps is populated
-	// regardless of whether a lockfile is in use.
-	Modules    []ManifestModule `json:"modules,omitempty"`
-	Pname      string           `json:"pname"`
-	GOOS       *string          `json:"goos"`
-	GOARCH     *string          `json:"goarch"`
-	LDFlags    []string         `json:"ldflags"`
-	GCFlags    []string         `json:"gcflags"`
-	Tags       []string         `json:"tags"`
-	PGOProfile *string          `json:"pgoProfile"`
+	Pname                 string            `json:"pname"`
+	GOOS                  *string           `json:"goos"`
+	GOARCH                *string           `json:"goarch"`
+	LDFlags               []string          `json:"ldflags"`
+	GCFlags               []string          `json:"gcflags"`
+	Tags                  []string          `json:"tags"`
+	PGOProfile            *string           `json:"pgoProfile"`
 }
 
 // ManifestModule is one third-party module in a LinkManifest, used to
@@ -154,6 +150,10 @@ type ManifestModule struct {
 type LinkSubPackage struct {
 	Path  string         `json:"path"`
 	Files *ManifestFiles `json:"files,omitempty"`
+	// Modules is this binary's transitive third-party module closure,
+	// threaded from the Nix build graph so debug.BuildInfo.Deps records
+	// only modules actually linked into this binary (matching `go build`).
+	Modules []ManifestModule `json:"modules,omitempty"`
 }
 
 // LoadLinkManifest reads and validates a link manifest from path.

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -909,10 +909,59 @@ let
               clean = lib.removePrefix "./" sp;
             in
             if sp == "." || clean == "" then modulePath else "${modulePath}/${clean}";
+
+          # Per-subPackage transitive module closure for modinfo deps.
+          # `go build` records only modules whose packages are actually
+          # linked into the binary; recording allModules over-reports
+          # test-only deps and modules used by other subPackages.
+          # genericClosure dedupes by key, so cycles terminate.
+          importsOf =
+            ip:
+            let
+              lp = goPackagesResult.localPackages.${ip} or null;
+              tp = goPackagesResult.packages.${ip} or null;
+            in
+            if lp != null then
+              (lp.localImports or [ ]) ++ (lp.thirdPartyImports or [ ])
+            else if tp != null then
+              tp.imports or [ ]
+            else
+              [ ];
+          closureOf =
+            ip:
+            builtins.genericClosure {
+              startSet = [ { key = ip; } ];
+              operator = item: map (i: { key = i; }) (importsOf item.key);
+            };
+          modKeysOf =
+            ip:
+            lib.unique (
+              builtins.concatMap (
+                item:
+                let
+                  p = goPackagesResult.packages.${item.key} or null;
+                in
+                lib.optional (p != null) p.modKey
+              ) (closureOf ip)
+            );
+          toModule =
+            modKey:
+            let
+              m = allModules.${modKey};
+              repl = goPackagesResult.replacements.${modKey} or null;
+            in
+            {
+              inherit (m) path version;
+            }
+            // lib.optionalAttrs (repl != null) {
+              replacePath = repl.path;
+              replaceVersion = if repl.version != "" then repl.version else m.version;
+            };
         in
         map (sp: {
           path = sp;
           files = goPackagesResult.localPackages.${spImportPath sp}.files or null;
+          modules = map toModule (modKeysOf (spImportPath sp));
         }) normalizedSubPackages;
       inherit moduleRoot;
       lockfile =
@@ -923,34 +972,6 @@ let
           }}"
         else
           null;
-      # Resolved third-party module set, threaded straight to link-binary
-      # so debug.BuildInfo.Deps is populated in lockfile-free mode too
-      # (link-binary previously read it from the lockfile only).
-      # allModules contains replacement targets as separate keys (so
-      # fetchGoModule can find their hash); filter those out so modinfo
-      # records `dep <orig> => <repl>` rather than a spurious second dep.
-      modules =
-        let
-          replTargets = lib.mapAttrs' (_: r: {
-            name = "${r.path}@${if r.version != "" then r.version else ""}";
-            value = true;
-          }) goPackagesResult.replacements;
-          isReplTarget =
-            _modKey: m: replTargets."${m.path}@${m.version}" or false || replTargets."${m.path}@" or false;
-        in
-        lib.mapAttrsToList (
-          modKey: m:
-          let
-            repl = goPackagesResult.replacements.${modKey} or null;
-          in
-          {
-            inherit (m) path version;
-          }
-          // lib.optionalAttrs (repl != null) {
-            replacePath = repl.path;
-            replaceVersion = if repl.version != "" then repl.version else m.version;
-          }
-        ) (lib.filterAttrs (k: v: !(isReplTarget k v)) allModules);
       inherit pname;
       goos = targetGoos;
       goarch = targetGoarch;

--- a/packages/test-fixture-testify-basic/default.nix
+++ b/packages/test-fixture-testify-basic/default.nix
@@ -73,11 +73,11 @@ else
           || { echo "FAIL: missing 'build $key' in go version -m output"; exit 1; }
       done
 
-      echo "=== Asserting modinfo contains dep lines (lockfile mode) ==="
+      echo "=== Asserting modinfo records only modules linked into THIS binary ==="
+      # main.go → internal/greeter; testify is imported only from
+      # greeter_test.go. `go build` would record zero deps here.
       ndeps=$(grep -cE '^[[:space:]]+dep[[:space:]]' buildinfo.txt || true)
-      [ "$ndeps" -ge 1 ] || { echo "FAIL: expected >= 1 dep lines, got $ndeps"; exit 1; }
-      grep -E '^[[:space:]]+dep[[:space:]]+github\.com/stretchr/testify[[:space:]]' buildinfo.txt \
-        || { echo "FAIL: expected dep github.com/stretchr/testify"; exit 1; }
+      [ "$ndeps" -eq 0 ] || { echo "FAIL: expected 0 dep lines (testify is test-only), got $ndeps"; exit 1; }
 
       echo "PASS: testify-basic" > $out
     ''

--- a/packages/test-fixture-torture-app-replace/default.nix
+++ b/packages/test-fixture-torture-app-replace/default.nix
@@ -66,10 +66,12 @@ else
       out_val=$($result/bin/app-replace)
       [ "$out_val" = "42" ] || { echo "FAIL: expected 42, got $out_val"; exit 1; }
 
-      echo "=== Asserting modinfo contains dep lines (lockfile-free mode) ==="
+      echo "=== Asserting modinfo records only modules linked into THIS binary ==="
+      # main.go imports go.uber.org/atomic; testify/spew/difflib are
+      # transitive test deps of atomic listed in go.sum but never linked.
       go version -m "$result/bin/app-replace" | tee buildinfo.txt
       ndeps=$(grep -cE '^[[:space:]]+dep[[:space:]]' buildinfo.txt || true)
-      [ "$ndeps" -ge 1 ] || { echo "FAIL: expected >= 1 dep lines, got $ndeps"; exit 1; }
+      [ "$ndeps" -eq 1 ] || { echo "FAIL: expected exactly 1 dep line, got $ndeps"; exit 1; }
       grep -E '^[[:space:]]+dep[[:space:]]+go\.uber\.org/atomic[[:space:]]+v1\.11\.0' buildinfo.txt \
         || { echo "FAIL: expected dep go.uber.org/atomic v1.11.0"; exit 1; }
       grep -E '^[[:space:]]+=>[[:space:]]+github\.com/uber-go/atomic[[:space:]]+v1\.11\.0' buildinfo.txt \


### PR DESCRIPTION
## Summary

Follow-up to #80. `linkManifestJSON.modules` was built from `allModules` (the full lockfile/plugin module set) and shared across all subPackages, so every binary's `go version -m` listed every module — including test-only deps and modules other subPackages use. `go build` only records modules whose packages are actually linked into that binary. The over-reporting trips govulncheck/SBOM false positives.

`modules` is now per-subPackage: `genericClosure` walks the import graph from each subPackage's import path through `localPackages.{localImports,thirdPartyImports}` and `packages.imports`, collecting only the third-party `modKey`s actually reached. `Modules` moves from `LinkManifest` to `LinkSubPackage`; `link-binary` reads `sp.Modules` inside the loop.

The replacement-target filter from #80 is removed — the closure only reaches packages that are actually imported, so fork-replace targets (which aren't keyed by their original path in `goPackagesResult.packages`) never appear as a spurious second dep.

`genericClosure` dedupes by `key` so import cycles terminate; the walk is bounded by `|localPackages| + |packages|`.

## Regression checks

- `test-fixture-testify-basic`: now asserts **exactly 0** `dep` lines (its `main.go` imports no third-party; testify is test-only).
- `test-fixture-torture-app-replace`: asserts **exactly 1** `dep` line (`go.uber.org/atomic` + `=>`; not the test-transitive testify/spew/difflib).

## Test plan

- [x] `go test ./...` (14 pkgs), `go vet`
- [x] Both fixtures built end-to-end; `go version -m` output verified (0 deps / 1 dep respectively)
- [x] `nix flake check` (formatting, nix-unit-tests)