### PR TITLE
testrunner: only test packages present in the build's localArchives

### DIFF
--- a/go/go2nix/cmd/go2nix/testpkgs.go
+++ b/go/go2nix/cmd/go2nix/testpkgs.go
@@ -103,6 +103,7 @@ func runTestPackagesCmd(args []string) {
 		Tags:             strings.Join(m.Tags, ","),
 		GCFlagsList:      m.GCFlags,
 		CheckFlagsList:   m.CheckFlags,
+		LocalArchives:    m.LocalArchives,
 	}
 
 	if err := testrunner.Run(opts); err != nil {

--- a/go/go2nix/pkg/testrunner/testrunner.go
+++ b/go/go2nix/pkg/testrunner/testrunner.go
@@ -32,6 +32,15 @@ type Options struct {
 	Tags             string   // comma-separated build tags
 	GCFlagsList      []string // extra compiler flags
 	CheckFlagsList   []string // flags to pass to test binaries
+	// LocalArchives bounds the test scope: only packages with an entry
+	// here are tested. ListLocalPackages walks the whole module tree
+	// (and after #75, sibling-replace targets too), but the eval-time
+	// resolver only computed importcfg entries for packages reachable
+	// from the subPackages closure (build + test-only locals). Packages
+	// outside that closure can't link their tests anyway, so testing
+	// them just produces a confusing "could not import" failure.
+	// Nil means no filter (test everything ListLocalPackages finds).
+	LocalArchives map[string]string
 }
 
 func (o Options) checkFlagsArgs() []string {
@@ -58,19 +67,29 @@ func Run(opts Options) error {
 		pkgMap[p.ImportPath] = p
 	}
 
-	// Filter to packages with test files
+	// Filter to packages with test files that are inside the build's
+	// resolved scope (see Options.LocalArchives).
 	var testable []*localpkgs.LocalPkg
+	skipped := 0
 	for _, p := range pkgs {
-		if len(p.TestGoFiles) > 0 || len(p.XTestGoFiles) > 0 {
-			testable = append(testable, p)
+		if len(p.TestGoFiles) == 0 && len(p.XTestGoFiles) == 0 {
+			continue
 		}
+		if opts.LocalArchives != nil {
+			if _, ok := opts.LocalArchives[p.ImportPath]; !ok {
+				slog.Debug("skipping testable package outside subPackages closure", "pkg", p.ImportPath)
+				skipped++
+				continue
+			}
+		}
+		testable = append(testable, p)
 	}
 
 	if len(testable) == 0 {
-		slog.Info("no testable packages found")
+		slog.Info("no testable packages found", "skipped", skipped)
 		return nil
 	}
-	slog.Info("testable packages", "count", len(testable))
+	slog.Info("testable packages", "count", len(testable), "skipped", skipped)
 
 	for _, p := range testable {
 		if err := runPackageTests(opts, p, pkgMap); err != nil {

--- a/tests/fixtures/test-helper-pkg/cmd/unbuilt/main.go
+++ b/tests/fixtures/test-helper-pkg/cmd/unbuilt/main.go
@@ -1,0 +1,11 @@
+// Binary unbuilt is intentionally NOT in dag.nix's subPackages, so neither
+// it nor its dependency unbuiltdep have a compile derivation.
+package main
+
+import (
+	"fmt"
+
+	"example.com/test-helper-pkg/internal/unbuiltdep"
+)
+
+func main() { fmt.Println(unbuiltdep.Answer()) }

--- a/tests/fixtures/test-helper-pkg/cmd/unbuilt/main_test.go
+++ b/tests/fixtures/test-helper-pkg/cmd/unbuilt/main_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	"example.com/test-helper-pkg/internal/unbuiltdep"
+)
+
+func TestAnswer(t *testing.T) {
+	if got := unbuiltdep.Answer(); got != 42 {
+		t.Fatalf("Answer() = %d, want 42", got)
+	}
+}

--- a/tests/fixtures/test-helper-pkg/dag.nix
+++ b/tests/fixtures/test-helper-pkg/dag.nix
@@ -2,6 +2,11 @@
 # is only imported from internal/app/app_test.go). doCheck exercises the
 # plugin's testLocalPackages output and the dag builder's union of those
 # into localPackages so the testrunner has an .a archive for the helper.
+#
+# Also: cmd/unbuilt + internal/unbuiltdep are deliberately NOT in the
+# subPackages closure (default = ["."], and the root main.go does not
+# import them). The testrunner must skip cmd/unbuilt's test rather than
+# fail trying to compile it against an importcfg that lacks unbuiltdep.
 let
   pkgs = import <nixpkgs> { };
   inherit (pkgs) go;

--- a/tests/fixtures/test-helper-pkg/internal/unbuiltdep/dep.go
+++ b/tests/fixtures/test-helper-pkg/internal/unbuiltdep/dep.go
@@ -1,0 +1,8 @@
+// Package unbuiltdep is only imported from cmd/unbuilt, which is NOT
+// in the build's subPackages closure. It exercises the testrunner's
+// scope filter: without it, the testrunner would try to compile
+// cmd/unbuilt's test against an importcfg that has no entry for this
+// package and fail with "could not import …".
+package unbuiltdep
+
+func Answer() int { return 42 }


### PR DESCRIPTION
## Summary

The testrunner walks the whole `moduleRoot` (and sibling-replace targets after #75) via `localpkgs.ListLocalPackages`, but the plugin's test pass only resolves test-deps for packages reachable from the `subPackages` build closure. Tests in packages outside that closure (a `cmd/tool` not in `subPackages`, or sibling-module subtrees) fail with `could not import … (open : no such file or directory)` because their deps' `.a` archives aren't in `localArchives`.

`testrunner.Run` now skips testable packages whose import path isn't a key in the test manifest's `localArchives` (which is exactly the set the build graph + #78's `testLocalPackages` reached). Skipped packages are debug-logged and counted in the summary.

This aligns testrunner scope with resolver scope (the conservative choice). If wider `go test ./...`-style scope is wanted later, both the plugin's test pass and the testrunner would need to use `./...`.

## Regression test

`tests/fixtures/test-helper-pkg/` gains `cmd/unbuilt/` (a `package main` with a test, importing `internal/unbuiltdep`, NOT in the `subPackages = ["."]` closure):

Without fix → `could not import …/internal/unbuiltdep (open : no such file or directory)`
With fix → `testable packages count=1 skipped=1`, `internal/app` test PASSes

`test-fixture-test-helper-pkg` building is the CI assertion.

## Test plan

- [x] `go test ./pkg/testrunner/... ./cmd/go2nix/...`, `go vet`
- [x] Fixture builds end-to-end with fix; fails without (output above)
- [x] `nix flake check` (formatting)