### PR TITLE
linkbinary,dag: pass -extld unconditionally with transitive CXX detection; drop forced -linkmode

### DIFF
--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -179,12 +179,6 @@ func linkBinary(manifestPath, output string) error {
 	}
 
 	for _, sp := range m.SubPackages {
-		// compileCgo writes .has_cgo / .has_cxx into NIX_BUILD_TOP; clear any
-		// markers left by the previous subpackage so a pure-Go binary built
-		// after a cgo one doesn't inherit -extld / -linkmode external.
-		_ = os.Remove(filepath.Join(tmpDir, ".has_cgo"))
-		_ = os.Remove(filepath.Join(tmpDir, ".has_cxx"))
-
 		deps := make([]buildinfo.ModDep, 0, len(sp.Modules))
 		for _, mm := range sp.Modules {
 			dep := buildinfo.ModDep{Path: mm.Path, Version: mm.Version}
@@ -239,21 +233,19 @@ func linkBinary(manifestPath, output string) error {
 			return fmt.Errorf("compiling main %s: %w", importpath, err)
 		}
 
-		// Detect CGO from compilation.
-		hasCgo := fileExists(filepath.Join(tmpDir, ".has_cgo"))
-		hasCxx := fileExists(filepath.Join(tmpDir, ".has_cxx"))
-
-		// Compute link flags.
+		// Compute link flags. cmd/go always passes -extld (CXX if any
+		// transitive package has C++ sources, else CC) and lets cmd/link
+		// pick the link mode itself (cmd/link/internal/ld/lib.go:576 sets
+		// iscgo = LibraryByPkg["runtime/cgo"] != nil; config.go:208 picks
+		// external when iscgo && externalobj). Mirror that: pass -extld
+		// unconditionally, never force -linkmode.
 		var linkFlags []string
-		if hasCgo {
-			extld := os.Getenv("CC")
-			if hasCxx {
-				extld = os.Getenv("CXX")
-			}
-			if extld == "" {
-				return fmt.Errorf("cgo package requires CC (or CXX) but none is set")
-			}
-			linkFlags = append(linkFlags, "-extld", extld, "-linkmode", "external")
+		extld := os.Getenv("CC")
+		if sp.CXX {
+			extld = os.Getenv("CXX")
+		}
+		if extld != "" {
+			linkFlags = append(linkFlags, "-extld", extld)
 		}
 
 		// Propagate sanitizer flags from gcflags to linker.
@@ -328,11 +320,6 @@ func goToolchainVersion() (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
-}
-
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
 }
 
 // expandLDFlags splits each ldflag element into separate exec arguments using

--- a/go/go2nix/pkg/compile/cgo.go
+++ b/go/go2nix/pkg/compile/cgo.go
@@ -18,20 +18,6 @@ import (
 func compileCgo(opts Options, files gofiles.PkgFiles, embedFlag string) error {
 	uid := strings.ReplaceAll(opts.ImportPath, "/", "_")
 
-	// Signal that cgo was used (linker needs -extld).
-	if nixBuildTop := os.Getenv("NIX_BUILD_TOP"); nixBuildTop != "" {
-		if err := os.WriteFile(filepath.Join(nixBuildTop, ".has_cgo"), nil, 0o644); err != nil {
-			return fmt.Errorf("writing .has_cgo: %w", err)
-		}
-		// Signal C++ usage so the linker uses CXX instead of CC as the
-		// external linker, matching Go's setextld behavior (gc.go).
-		if len(files.CXXFiles) > 0 {
-			if err := os.WriteFile(filepath.Join(nixBuildTop, ".has_cxx"), nil, 0o644); err != nil {
-				return fmt.Errorf("writing .has_cxx: %w", err)
-			}
-		}
-	}
-
 	cgowork, err := os.MkdirTemp(opts.TrimPath, "cgo_work_"+uid+"_")
 	if err != nil {
 		return err

--- a/go/go2nix/pkg/compile/manifest.go
+++ b/go/go2nix/pkg/compile/manifest.go
@@ -154,6 +154,10 @@ type LinkSubPackage struct {
 	// threaded from the Nix build graph so debug.BuildInfo.Deps records
 	// only modules actually linked into this binary (matching `go build`).
 	Modules []ManifestModule `json:"modules,omitempty"`
+	// CXX reports whether any package in this binary's transitive closure
+	// has C++ sources (CXXFiles or SwigCXXFiles), so link-binary picks the
+	// C++ compiler for -extld (cmd/go/internal/work/gc.go:591-595).
+	CXX bool `json:"cxx,omitempty"`
 }
 
 // LoadLinkManifest reads and validates a link manifest from path.

--- a/go/go2nix/pkg/resolve/builder.go
+++ b/go/go2nix/pkg/resolve/builder.go
@@ -96,9 +96,11 @@ func linkScript(goStorePath, pname, buildMode string) string {
 	b.WriteString(" \\\n  -importcfg \"$NIX_BUILD_TOP/importcfg\"")
 	b.WriteString(" \\\n  -buildid=")
 	fmt.Fprintf(&b, " \\\n  -buildmode=%s", shellQuote(buildMode))
-	// External linker for cgo packages — uses CC or CXX depending on
-	// whether C++ files are present, matching Go's setextld (gc.go).
-	b.WriteString(" \\\n  ${extld:+-extld \"$extld\" -linkmode external}")
+	// External linker — CXX if any transitive package has C++ sources,
+	// else CC. Always passed (matching cmd/go's setextld); cmd/link picks
+	// the link mode itself via determineLinkMode (cmd/link/internal/ld/
+	// config.go:208), so we never force -linkmode.
+	b.WriteString(" \\\n  ${extld:+-extld \"$extld\"}")
 	// Sanitizer flags (-race, -msan, -asan) propagated from gcflags
 	b.WriteString(" \\\n  ${sanitizerLinkFlags:+$sanitizerLinkFlags}")
 	// GODEBUG default from go.mod's go directive (gc.go:624-626)

--- a/go/go2nix/pkg/resolve/builder_test.go
+++ b/go/go2nix/pkg/resolve/builder_test.go
@@ -128,8 +128,11 @@ func TestLinkScript(t *testing.T) {
 	if !strings.Contains(script, "-buildmode='exe'") {
 		t.Error("missing -buildmode=exe")
 	}
-	if !strings.Contains(script, `${extld:+-extld "$extld" -linkmode external}`) {
-		t.Error("missing extld conditional for cgo external linking")
+	if !strings.Contains(script, `${extld:+-extld "$extld"}`) {
+		t.Error("missing extld conditional")
+	}
+	if strings.Contains(script, "-linkmode") {
+		t.Error("script forces -linkmode; cmd/link should pick it via determineLinkMode")
 	}
 }
 

--- a/go/go2nix/pkg/resolve/resolve.go
+++ b/go/go2nix/pkg/resolve/resolve.go
@@ -977,18 +977,23 @@ func buildLinkDrv(
 
 	drv.SetEnv("out", nixdrv.StandardOutput("out").Render())
 
-	// PATH: coreutils + CC for external linking (cgo)
+	// PATH: coreutils + CC for external linking. -extld is passed
+	// unconditionally (matching cmd/go's setextld, gc.go:591-649); cmd/link
+	// picks the link mode itself (lib.go:576 / config.go:208), so it's a
+	// no-op when internal linking is chosen. ccDir is only added when a
+	// cgo package is in the closure, since otherwise the link drv has no
+	// reason to depend on the cc-wrapper store path.
 	pathParts := []string{cfg.coreutilsDir + "/bin"}
-	if hasCgo && cfg.ccPath != "" {
-		// Pass -extld explicitly so the linker uses the correct compiler,
-		// matching cmd/go's setextld behavior (see gc.go).
+	if cfg.ccPath != "" {
 		extld := cfg.ccPath
 		if hasCxx && cfg.cxxPath != "" {
 			extld = cfg.cxxPath
 		}
 		drv.SetEnv("extld", extld)
-		pathParts = append(pathParts, cfg.ccDir+"/bin")
-		drv.AddInputSrc(cfg.ccDir)
+		if hasCgo {
+			pathParts = append(pathParts, cfg.ccDir+"/bin")
+			drv.AddInputSrc(cfg.ccDir)
+		}
 	}
 	drv.SetEnv("PATH", strings.Join(pathParts, ":"))
 

--- a/go/go2nix/pkg/resolve/resolve_test.go
+++ b/go/go2nix/pkg/resolve/resolve_test.go
@@ -322,7 +322,8 @@ func TestBuildLinkDrvClosureOnly(t *testing.T) {
 		},
 		"m/lib/unrelated": {
 			ImportPath: "m/lib/unrelated", Imports: nil,
-			CgoFiles: []string{"c.go"}, // cgo in an unrelated pkg must not flip extld
+			CgoFiles: []string{"c.go"}, // cgo+cxx in an unrelated pkg must not
+			CXXFiles: []string{"x.cc"}, // add ccDir to PATH or flip extld to CXX
 			DrvPath:  mkDrv("yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"),
 		},
 	}
@@ -334,6 +335,7 @@ func TestBuildLinkDrvClosureOnly(t *testing.T) {
 		GoBin:        "/nix/store/00000000000000000000000000000000-go/bin/go",
 		StdlibPath:   "/nix/store/00000000000000000000000000000000-stdlib",
 		ccPath:       "/nix/store/00000000000000000000000000000000-cc/bin/cc",
+		cxxPath:      "/nix/store/00000000000000000000000000000000-cc/bin/c++",
 		ccDir:        "/nix/store/00000000000000000000000000000000-cc",
 	}
 	cfg.coreutilsDir = storeDirOf(cfg.CoreutilsBin)
@@ -350,8 +352,16 @@ func TestBuildLinkDrvClosureOnly(t *testing.T) {
 	if strings.Contains(entries, "m/lib/unrelated") {
 		t.Errorf("importcfg references unrelated package:\n%s", entries)
 	}
-	if drv.Env()["extld"] != "" {
-		t.Errorf("extld set despite no cgo in closure: %q", drv.Env()["extld"])
+	// extld is now passed unconditionally (matching cmd/go's setextld);
+	// cmd/link picks the link mode itself, so for a pure-Go closure it
+	// chooses internal and extld is unused. The test cfg has both ccPath
+	// and cxxPath; m/lib/unrelated has cgo+cxx but is outside this main's
+	// closure, so extld must be CC and ccDir must not enter PATH.
+	if got := drv.Env()["extld"]; got != cfg.ccPath {
+		t.Errorf("extld = %q, want CC %q (cxx outside closure must not flip it)", got, cfg.ccPath)
+	}
+	if strings.Contains(drv.Env()["PATH"], cfg.ccDir) {
+		t.Errorf("PATH contains ccDir despite no cgo in closure: %q", drv.Env()["PATH"])
 	}
 }
 

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -944,6 +944,22 @@ let
                 lib.optional (p != null) p.modKey
               ) (closureOf ip)
             );
+          # cmd/go's gcToolchain.ld picks CXX over CC for -extld when any
+          # package in root.Deps has CXXFiles || SwigCXXFiles
+          # (cmd/go/internal/work/gc.go:591-595). The closure already
+          # includes the main package (start node), so this also covers the
+          # main-package-itself-has-cxx case without a side-channel marker.
+          hasCxx =
+            ip:
+            builtins.any (
+              item:
+              let
+                f =
+                  (goPackagesResult.localPackages.${item.key} or goPackagesResult.packages.${item.key} or { }).files
+                    or { };
+              in
+              (f.cxxFiles or [ ]) != [ ] || (f.swigCxxFiles or [ ]) != [ ]
+            ) (closureOf ip);
           toModule =
             modKey:
             let
@@ -958,11 +974,18 @@ let
               replaceVersion = if repl.version != "" then repl.version else m.version;
             };
         in
-        map (sp: {
-          path = sp;
-          files = goPackagesResult.localPackages.${spImportPath sp}.files or null;
-          modules = map toModule (modKeysOf (spImportPath sp));
-        }) normalizedSubPackages;
+        map (
+          sp:
+          let
+            ip = spImportPath sp;
+          in
+          {
+            path = sp;
+            files = goPackagesResult.localPackages.${ip}.files or null;
+            modules = map toModule (modKeysOf ip);
+            cxx = hasCxx ip;
+          }
+        ) normalizedSubPackages;
       inherit moduleRoot;
       lockfile =
         if goLock != null then


### PR DESCRIPTION
## Summary

Default-mode `link-binary` decided `-extld`/`-linkmode` from `.has_cgo`/`.has_cxx` markers written by `compileCgo` — but those only fire for the **main package's own** `CgoFiles`/`CXXFiles`, not transitive deps. So a pure-Go `cmd/*` importing a cgo (or C++) library got the wrong `-extld` (CC instead of CXX) and no `-linkmode external`. Dynamic mode already walked the closure correctly.

Aligned with `go build` (verified in `cmd/go/internal/work/gc.go:591-595` and `cmd/link/internal/ld/lib.go:576`, `config.go:208`):
- `cxx` is true if **any** package in the transitive deps has `CXXFiles || SwigCXXFiles`
- `-extld` is **always** passed (CXX if `cxx`, else CC)
- `-linkmode` is **never** forced — `cmd/link` auto-detects from `runtime/cgo` presence in the importcfg (`iscgo = LibraryByPkg["runtime/cgo"] != nil`)

rules_go follows the same model (always passes `-extld` from cc_toolchain, lets cmd/link decide mode).

`nix/dag` reuses #82's per-subPackage `genericClosure` to compute `subPackages[i].cxx`. `LinkSubPackage` gains `CXX bool`. `linkbinary.go` always passes `-extld` from `sp.CXX ? CXX : CC`. The `.has_cgo`/`.has_cxx` marker writes (cgo.go) and reads + `os.Remove` (#67) are deleted — the closure is authoritative since it includes the main package as start node. Dynamic mode's `-linkmode external` is also dropped.

The link drv already uses `stdenv.mkDerivation` (not `stdenvNoCC`), so CC/CXX are set.

## Regression check

`test-fixture-cgo-internal-test` (root binary uses cgo, `purebin` doesn't): both `file` outputs unchanged from main — root dynamically linked, purebin statically linked. cmd/link's auto-detection picks the same modes the explicit flags did. `resolve_test.go` asserts cxx-outside-closure doesn't flip `extld` to CXX.

## Test plan

- [x] `go test ./...` (14 pkgs), `go vet`, `golangci-lint`
- [x] cgo-internal-test: root=dynamic, purebin=static (unchanged); checkPhase PASS
- [x] `nix flake check` (formatting, nix-unit-tests)