### PR TITLE
dag: exclude nested-module subtrees from pkgSrc and mainSrc filters

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -155,6 +155,7 @@
           check-godebug-table = callPkg ./packages/check-godebug-table/default.nix;
           cross-platform-env = callPkgWith ./tests/nix/cross_platform_test.nix { inherit pkgs; };
           mainsrc-replace = callPkgWith ./tests/nix/mainsrc_replace_test.nix { inherit pkgs; };
+          nested-module = callPkgWith ./tests/nix/nested_module_test.nix { inherit pkgs; };
           # tests/nix/{helpers,fetch_go_module}_test.nix return `true` or
           # throw. seq forces them at eval time so a failure breaks the
           # check; the runCommand body is just the success marker.

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -510,6 +510,10 @@ let
       # for every local package. The filter only needs to drop nested
       # package directories — builtins.path skips a rejected directory's
       # children, so an O(1) set lookup on the directory itself suffices.
+      # Nested-module subtrees are also dropped: go list stopped at their
+      # go.mod, so they are never compiled and would only churn the store
+      # path. The package's own root is never passed to the filter, so a
+      # modRoot/replace-target package's go.mod doesn't self-exclude.
       srcStr = toString src;
       pkgSrc = builtins.path {
         path = if isRoot then src else src + "/${relDir}";
@@ -519,10 +523,7 @@ let
           let
             rel = lib.removePrefix (srcStr + "/") (toString path);
           in
-          # Exclude directories that are themselves other local packages
-          # (their sources are isolated in their own pkgSrc). The root
-          # itself is never passed to the filter, so relDir won't match.
-          !(type == "directory" && localPkgDirSet ? ${rel});
+          !(type == "directory" && (localPkgDirSet ? ${rel} || builtins.pathExists (path + "/go.mod")));
       };
 
       srcDir = "${pkgSrc}";
@@ -834,21 +835,31 @@ let
       # Include modRoot for go.mod access plus sibling-replace module roots
       # so the testrunner can walk them.
       allowedDirs = [ cleanModRoot ] ++ subPkgDirs ++ replaceDirs;
+      allowedDirSet = lib.genAttrs allowedDirs (_: true);
       # When modRoot is "." or any subPackage resolves to ".", the entire
-      # source tree is needed — no filtering required.
+      # source tree is needed — no prefix filtering required.
       includeAll = builtins.elem "." allowedDirs;
     in
     builtins.path {
       path = src;
       name = "${pname}-main-src";
       filter =
-        path: _type:
-        if includeAll then
+        path: type:
+        let
+          rel = lib.removePrefix (toString src + "/") (toString path);
+          # A go.mod-bearing directory that isn't an allowed module root
+          # (modRoot, a subPackage dir, or a local-replace target) is a
+          # nested-module boundary; go list stopped there, so its files are
+          # never compiled or tested. Checked unconditionally so it also
+          # applies in the includeAll case.
+          isNestedModule =
+            type == "directory" && !(allowedDirSet ? ${rel}) && builtins.pathExists (path + "/go.mod");
+        in
+        if isNestedModule then
+          false
+        else if includeAll then
           true
         else
-          let
-            rel = lib.removePrefix (toString src + "/") (toString path);
-          in
           path == toString src
           || builtins.any (prefix: rel == prefix || lib.hasPrefix (prefix + "/") rel) allowedDirs
           || builtins.any (prefix: lib.hasPrefix (rel + "/") prefix) allowedDirs;

--- a/tests/fixtures/modroot-nested/app/nested-module/dummy.go
+++ b/tests/fixtures/modroot-nested/app/nested-module/dummy.go
@@ -1,0 +1,6 @@
+// Package ignored is a nested module that go list stops at. Regression
+// fixture for the pkgSrc/mainSrc filters: this file must not enter either
+// store path.
+package ignored
+
+const DoesNotCompile = nonexistent

--- a/tests/fixtures/modroot-nested/app/nested-module/go.mod
+++ b/tests/fixtures/modroot-nested/app/nested-module/go.mod
@@ -1,0 +1,3 @@
+module example.com/ignored
+
+go 1.25

--- a/tests/nix/nested_module_test.nix
+++ b/tests/nix/nested_module_test.nix
@@ -1,0 +1,58 @@
+# tests/nix/nested_module_test.nix — regression for pkgSrc/mainSrc leaking
+# nested-module subtrees.
+#
+# tests/fixtures/modroot-nested/app/nested-module/ has its own go.mod, so
+# go list stops there and its files are never compiled. The mainSrc and
+# per-package pkgSrc filters must drop the whole subtree; otherwise touching
+# a nested-module file would invalidate the parent package's compile drv.
+#
+# Eval-only: mainSrc is computed from go.mod parsing alone and does not
+# force goPackagesResult, so this check does not need the plugin.
+{
+  lib,
+  pkgs,
+  runCommand,
+}:
+let
+  go2nix = import ../../packages/go2nix { inherit pkgs; };
+  scope = import ../../nix/mk-go-env.nix {
+    inherit (pkgs) go callPackage;
+    inherit go2nix;
+  };
+  app = scope.buildGoApplication {
+    pname = "nested-module-test";
+    version = "0.0.1";
+    src = ../fixtures/modroot-nested;
+    goLock = ../fixtures/modroot-nested/app/go2nix.toml;
+    modRoot = "app";
+  };
+  ms = app.passthru.mainSrc;
+
+  assertions = [
+    {
+      msg = "modRoot's own go.mod must be present";
+      ok = builtins.pathExists "${ms}/app/go.mod";
+    }
+    {
+      msg = "main.go must be present";
+      ok = builtins.pathExists "${ms}/app/main.go";
+    }
+    {
+      msg = "internal/util (a real local package) must be present";
+      ok = builtins.pathExists "${ms}/app/internal/util/util.go";
+    }
+    {
+      msg = "nested-module subtree must NOT be in mainSrc";
+      ok = !(builtins.pathExists "${ms}/app/nested-module");
+    }
+  ];
+
+  failures = lib.filter (a: !a.ok) assertions;
+in
+if failures != [ ] then
+  throw "nested-module-test: ${lib.concatMapStringsSep "; " (a: a.msg) failures}"
+else
+  runCommand "nested-module-test" { } ''
+    echo "nested-module-test: ${toString (lib.length assertions)} assertions passed"
+    touch $out
+  ''


### PR DESCRIPTION
## Summary

`pkgSrc` and `mainSrc` filters excluded directories that are *other local packages* (`localPkgDirSet`) but not directories that are *nested module roots*. A nested module isn't a local package — `go list` correctly stops at its boundary — so its files leaked into the parent module's source closure: wrong incrementality (touching nested-module files invalidates the parent's compile drv) and store bloat.

Both filters now also reject `type == "directory" && pathExists (path + "/go.mod")`, exempting only `modRoot` (pkgSrc) or any path in `allowedDirSet` (mainSrc — i.e. modRoot, subPackage dirs, and `replace => ./sibling` targets).

`builtins.path` hashes the resulting file set, not the filter function, so projects without nested modules get identical store paths.

## Test plan

- [x] **New** `checks.nested-module` (`tests/nix/nested_module_test.nix`) — extends `modroot-nested` with `app/nested-module/{go.mod,dummy.go}`, asserts mainSrc/pkgSrc exclude it (fails on `origin/main`)
- [x] Drv-hash neutral: `testify-basic` `db55qr6...` and `xtest-local-dep` `d4fvcxc...` identical to `origin/main`
- [x] `checks.mainsrc-replace` 6/6 — `replace`-target dirs containing `go.mod` still included (allowedDirSet exemption)
- [x] `modroot-nested` e2e build passes; binary outputs `1.0.0`
- [x] `nix flake check` (formatting, nix-unit-tests)