### PR TITLE
testrunner,localpkgs: defer //go:embed resolution until after LocalArchives filter

### DIFF
--- a/go/go2nix/pkg/localpkgs/localpkgs.go
+++ b/go/go2nix/pkg/localpkgs/localpkgs.go
@@ -19,19 +19,66 @@ import (
 )
 
 // LocalPkg describes a local package with its files and location.
+//
+// ListLocalPackages populates the *Patterns fields with the raw //go:embed
+// patterns from go/build but does NOT resolve them. Call ResolveEmbeds to
+// populate the *Cfg/*Files fields. This split lets the testrunner skip
+// out-of-scope packages whose embed targets are absent from the source
+// closure (e.g. supplied at build time via srcOverlay) without failing the
+// listing step.
 type LocalPkg struct {
-	ImportPath      string            `json:"import_path"`
-	SrcDir          string            `json:"src_dir"`
-	LocalDeps       []string          `json:"local_deps"` // local-to-local dependency import paths
-	TestGoFiles     []string          `json:"test_go_files"`
-	XTestGoFiles    []string          `json:"xtest_go_files"`
-	TestImports     []string          `json:"test_imports"`
-	XTestImports    []string          `json:"xtest_imports"`
-	TestEmbedFiles  []string          `json:"test_embed_files"`
-	XTestEmbedFiles []string          `json:"xtest_embed_files"`
-	TestEmbedCfg    *gofiles.EmbedCfg `json:"test_embed_cfg,omitempty"`
-	XTestEmbedCfg   *gofiles.EmbedCfg `json:"xtest_embed_cfg,omitempty"`
+	ImportPath         string            `json:"import_path"`
+	SrcDir             string            `json:"src_dir"`
+	LocalDeps          []string          `json:"local_deps"` // local-to-local dependency import paths
+	TestGoFiles        []string          `json:"test_go_files"`
+	XTestGoFiles       []string          `json:"xtest_go_files"`
+	TestImports        []string          `json:"test_imports"`
+	XTestImports       []string          `json:"xtest_imports"`
+	EmbedPatterns      []string          `json:"embed_patterns,omitempty"`
+	TestEmbedPatterns  []string          `json:"test_embed_patterns,omitempty"`
+	XTestEmbedPatterns []string          `json:"xtest_embed_patterns,omitempty"`
+	TestEmbedFiles     []string          `json:"test_embed_files"`
+	XTestEmbedFiles    []string          `json:"xtest_embed_files"`
+	TestEmbedCfg       *gofiles.EmbedCfg `json:"test_embed_cfg,omitempty"`
+	XTestEmbedCfg      *gofiles.EmbedCfg `json:"xtest_embed_cfg,omitempty"`
 	gofiles.PkgFiles
+}
+
+// ResolveEmbeds resolves the package's production, test, and xtest //go:embed
+// patterns against SrcDir, populating EmbedCfg/EmbedFiles, TestEmbedCfg/
+// TestEmbedFiles and XTestEmbedCfg/XTestEmbedFiles.
+func (p *LocalPkg) ResolveEmbeds() error {
+	resolve := func(patterns []string) (*gofiles.EmbedCfg, []string, error) {
+		if len(patterns) == 0 {
+			return nil, []string{}, nil
+		}
+		cfg, err := gofiles.ResolveEmbedCfg(p.SrcDir, patterns)
+		if err != nil {
+			return nil, nil, err
+		}
+		files := slices.Sorted(maps.Keys(cfg.Files))
+		return cfg, files, nil
+	}
+
+	cfg, files, err := resolve(p.EmbedPatterns)
+	if err != nil {
+		return fmt.Errorf("resolving embed patterns for %s: %w", p.ImportPath, err)
+	}
+	p.EmbedCfg, p.EmbedFiles = cfg, files
+
+	cfg, files, err = resolve(p.TestEmbedPatterns)
+	if err != nil {
+		return fmt.Errorf("resolving test embed patterns for %s: %w", p.ImportPath, err)
+	}
+	p.TestEmbedCfg, p.TestEmbedFiles = cfg, files
+
+	cfg, files, err = resolve(p.XTestEmbedPatterns)
+	if err != nil {
+		return fmt.Errorf("resolving xtest embed patterns for %s: %w", p.ImportPath, err)
+	}
+	p.XTestEmbedCfg, p.XTestEmbedFiles = cfg, files
+
+	return nil
 }
 
 // ListLocalPackages discovers all local packages under root (the directory
@@ -111,11 +158,6 @@ func ListLocalPackages(root string, tags string, goVersion string) ([]*LocalPkg,
 				importPath = importBase + "/" + rel
 			}
 
-			pf, err := gofiles.BuildPkgFiles(pkg, path)
-			if err != nil {
-				return fmt.Errorf("building pkg files for %s: %w", importPath, err)
-			}
-
 			var local []string
 			for _, imp := range pkg.Imports {
 				if isLocalImport(imp, localPrefixes) {
@@ -123,47 +165,34 @@ func ListLocalPackages(root string, tags string, goVersion string) ([]*LocalPkg,
 				}
 			}
 
-			// Resolve test-only embed patterns.
-			var testEmbedFiles []string
-			var testEmbedCfg *gofiles.EmbedCfg
-			if len(pkg.TestEmbedPatterns) > 0 {
-				cfg, err := gofiles.ResolveEmbedCfg(path, pkg.TestEmbedPatterns)
-				if err != nil {
-					return fmt.Errorf("resolving test embed patterns for %s: %w", importPath, err)
-				}
-				testEmbedCfg = cfg
-				for f := range cfg.Files {
-					testEmbedFiles = append(testEmbedFiles, f)
-				}
-				slices.Sort(testEmbedFiles)
-			}
-			var xtestEmbedFiles []string
-			var xtestEmbedCfg *gofiles.EmbedCfg
-			if len(pkg.XTestEmbedPatterns) > 0 {
-				cfg, err := gofiles.ResolveEmbedCfg(path, pkg.XTestEmbedPatterns)
-				if err != nil {
-					return fmt.Errorf("resolving xtest embed patterns for %s: %w", importPath, err)
-				}
-				xtestEmbedCfg = cfg
-				for f := range cfg.Files {
-					xtestEmbedFiles = append(xtestEmbedFiles, f)
-				}
-				slices.Sort(xtestEmbedFiles)
-			}
-
 			localPkg := &LocalPkg{
-				ImportPath:      importPath,
-				SrcDir:          path,
-				LocalDeps:       local,
-				TestGoFiles:     nonNil(pkg.TestGoFiles),
-				XTestGoFiles:    nonNil(pkg.XTestGoFiles),
-				TestImports:     nonNil(pkg.TestImports),
-				XTestImports:    nonNil(pkg.XTestImports),
-				TestEmbedFiles:  nonNil(testEmbedFiles),
-				XTestEmbedFiles: nonNil(xtestEmbedFiles),
-				TestEmbedCfg:    testEmbedCfg,
-				XTestEmbedCfg:   xtestEmbedCfg,
-				PkgFiles:        pf,
+				ImportPath:         importPath,
+				SrcDir:             path,
+				LocalDeps:          local,
+				TestGoFiles:        nonNil(pkg.TestGoFiles),
+				XTestGoFiles:       nonNil(pkg.XTestGoFiles),
+				TestImports:        nonNil(pkg.TestImports),
+				XTestImports:       nonNil(pkg.XTestImports),
+				EmbedPatterns:      pkg.EmbedPatterns,
+				TestEmbedPatterns:  pkg.TestEmbedPatterns,
+				XTestEmbedPatterns: pkg.XTestEmbedPatterns,
+				TestEmbedFiles:     []string{},
+				XTestEmbedFiles:    []string{},
+				PkgFiles: gofiles.PkgFiles{
+					GoFiles:      nonNil(pkg.GoFiles),
+					CgoFiles:     nonNil(pkg.CgoFiles),
+					SFiles:       nonNil(pkg.SFiles),
+					CFiles:       nonNil(pkg.CFiles),
+					CXXFiles:     nonNil(pkg.CXXFiles),
+					MFiles:       nonNil(pkg.MFiles),
+					FFiles:       nonNil(pkg.FFiles),
+					HFiles:       nonNil(pkg.HFiles),
+					SysoFiles:    nonNil(pkg.SysoFiles),
+					SwigFiles:    nonNil(pkg.SwigFiles),
+					SwigCXXFiles: nonNil(pkg.SwigCXXFiles),
+					EmbedFiles:   []string{},
+					IsCommand:    pkg.IsCommand(),
+				},
 			}
 			pkgs[importPath] = localPkg
 			localDeps[importPath] = local

--- a/go/go2nix/pkg/localpkgs/localpkgs_test.go
+++ b/go/go2nix/pkg/localpkgs/localpkgs_test.go
@@ -377,11 +377,79 @@ func TestExtEmbed(t *testing.T) { _ = fs }
 	}
 	pkg := pkgs[0]
 
+	if !slices.Equal(pkg.TestEmbedPatterns, []string{"*.txt"}) {
+		t.Errorf("TestEmbedPatterns = %v, want [*.txt]", pkg.TestEmbedPatterns)
+	}
+	if len(pkg.TestEmbedFiles) != 0 || pkg.TestEmbedCfg != nil {
+		t.Errorf("TestEmbedFiles/Cfg populated before ResolveEmbeds: %v / %v", pkg.TestEmbedFiles, pkg.TestEmbedCfg)
+	}
+
+	if err := pkg.ResolveEmbeds(); err != nil {
+		t.Fatal(err)
+	}
+
 	want := []string{"a.txt", "b.txt", "c.txt", "d.txt", "e.txt"}
 	if !slices.Equal(pkg.TestEmbedFiles, want) {
 		t.Errorf("TestEmbedFiles = %v, want %v (sorted)", pkg.TestEmbedFiles, want)
 	}
 	if !slices.Equal(pkg.XTestEmbedFiles, want) {
 		t.Errorf("XTestEmbedFiles = %v, want %v (sorted)", pkg.XTestEmbedFiles, want)
+	}
+}
+
+func TestListLocalPackages_DefersBrokenEmbed(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/test\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(root, "main.go"), "package main\n\nfunc main() {}\n")
+	// ui's //go:embed pattern matches nothing on disk; xtest's pattern is
+	// likewise unsatisfied. Listing must succeed; ResolveEmbeds surfaces it.
+	writeFile(t, filepath.Join(root, "ui", "ui.go"), `package ui
+
+import "embed"
+
+//go:embed all:dist
+var Assets embed.FS
+`)
+	writeFile(t, filepath.Join(root, "ui", "ui_ext_test.go"), `package ui_test
+
+import (
+	_ "embed"
+	"testing"
+)
+
+//go:embed missing.jsonc
+var cfg string
+
+func TestX(t *testing.T) { _ = cfg }
+`)
+
+	pkgs, err := ListLocalPackages(root, "", "")
+	if err != nil {
+		t.Fatalf("ListLocalPackages should defer broken embed resolution; got: %v", err)
+	}
+
+	var ui *LocalPkg
+	for _, p := range pkgs {
+		if p.ImportPath == "example.com/test/ui" {
+			ui = p
+		}
+	}
+	if ui == nil {
+		t.Fatalf("ui package not listed: %v", importPaths(pkgs))
+	}
+	if !slices.Equal(ui.EmbedPatterns, []string{"all:dist"}) {
+		t.Errorf("EmbedPatterns = %v, want [all:dist]", ui.EmbedPatterns)
+	}
+	if !slices.Equal(ui.XTestEmbedPatterns, []string{"missing.jsonc"}) {
+		t.Errorf("XTestEmbedPatterns = %v, want [missing.jsonc]", ui.XTestEmbedPatterns)
+	}
+
+	err = ui.ResolveEmbeds()
+	if err == nil {
+		t.Fatal("ResolveEmbeds should surface the missing-match error")
+	}
+	if !strings.Contains(err.Error(), "no matching files found") {
+		t.Errorf("expected 'no matching files found' in: %v", err)
 	}
 }

--- a/go/go2nix/pkg/testrunner/testrunner.go
+++ b/go/go2nix/pkg/testrunner/testrunner.go
@@ -67,6 +67,14 @@ func Run(opts Options) error {
 		pkgMap[p.ImportPath] = p
 	}
 
+	inScope := func(ip string) bool {
+		if opts.LocalArchives == nil {
+			return true
+		}
+		_, ok := opts.LocalArchives[ip]
+		return ok
+	}
+
 	// Filter to packages with test files that are inside the build's
 	// resolved scope (see Options.LocalArchives).
 	var testable []*localpkgs.LocalPkg
@@ -75,12 +83,10 @@ func Run(opts Options) error {
 		if len(p.TestGoFiles) == 0 && len(p.XTestGoFiles) == 0 {
 			continue
 		}
-		if opts.LocalArchives != nil {
-			if _, ok := opts.LocalArchives[p.ImportPath]; !ok {
-				slog.Debug("skipping testable package outside subPackages closure", "pkg", p.ImportPath)
-				skipped++
-				continue
-			}
+		if !inScope(p.ImportPath) {
+			slog.Debug("skipping testable package outside subPackages closure", "pkg", p.ImportPath)
+			skipped++
+			continue
 		}
 		testable = append(testable, p)
 	}
@@ -90,6 +96,22 @@ func Run(opts Options) error {
 		return nil
 	}
 	slog.Info("testable packages", "count", len(testable), "skipped", skipped)
+
+	// Resolve //go:embed patterns now, only for packages in scope. Doing this
+	// after the LocalArchives filter means an out-of-scope package whose
+	// embed targets are absent from mainSrc (e.g. supplied at build time
+	// via srcOverlay, or filtered from the source closure) cannot fail the
+	// run. The recompileForTest set is the intersection of an in-scope
+	// package's reverse-dep closure and an xtest's forward-dep closure, so
+	// it is itself a subset of LocalArchives.
+	for _, p := range pkgs {
+		if !inScope(p.ImportPath) {
+			continue
+		}
+		if err := p.ResolveEmbeds(); err != nil {
+			return fmt.Errorf("listing local packages: %w", err)
+		}
+	}
 
 	for _, p := range testable {
 		if err := runPackageTests(opts, p, pkgMap); err != nil {

--- a/tests/fixtures/test-helper-pkg/dag.nix
+++ b/tests/fixtures/test-helper-pkg/dag.nix
@@ -7,6 +7,11 @@
 # subPackages closure (default = ["."], and the root main.go does not
 # import them). The testrunner must skip cmd/unbuilt's test rather than
 # fail trying to compile it against an importcfg that lacks unbuiltdep.
+#
+# internal/brokenembed is likewise out-of-closure and has a //go:embed
+# pattern with no match in the source closure. The testrunner must defer
+# embed-pattern resolution until after the LocalArchives filter so this
+# package is skipped, not fatal.
 let
   pkgs = import <nixpkgs> { };
   inherit (pkgs) go;

--- a/tests/fixtures/test-helper-pkg/internal/brokenembed/embed.go
+++ b/tests/fixtures/test-helper-pkg/internal/brokenembed/embed.go
@@ -1,0 +1,12 @@
+// Package brokenembed has a //go:embed pattern with no on-disk match.
+// It is not imported by any subPackage and has no tests, so the testrunner
+// must skip it (counted in skipped) without trying to resolve the pattern.
+// Regression: ListLocalPackages used to resolve patterns eagerly during
+// the walk, failing the whole listing before the LocalArchives filter could
+// drop this package.
+package brokenembed
+
+import "embed"
+
+//go:embed missing.txt
+var FS embed.FS


### PR DESCRIPTION
## Summary

`ListLocalPackages` eagerly resolved every package's `//go:embed` patterns during its directory walk, so a pattern miss in a package the testrunner would *skip* (outside the per-subPackage `LocalArchives` closure that #83 scopes execution to) still failed the whole checkPhase. This blocks any `srcOverlay`-injected embed content (placeholder dir not in `mainSrc`) and any test-only embed in an unbuilt subtree.

`ListLocalPackages` now stores the raw `EmbedPatterns`/`TestEmbedPatterns`/`XTestEmbedPatterns` from `go/build` and builds `PkgFiles` directly without resolving. New `(*LocalPkg).ResolveEmbeds()` does the resolution; `testrunner.Run` calls it only for packages that survive both the testable filter and the `LocalArchives` scope. The per-package compile path (`gofiles.BuildPkgFiles`) is untouched — it still fails fast on a real miss in a package being compiled.

`recompileForTest` recompiles packages in `(reverse-deps of in-scope target) ∩ (forward-closure of xtest imports)`; the forward closure ⊆ build closure ⊆ `LocalArchives`, so every recompiled package's embeds are resolved.

## Test plan

- [x] **Unit** `TestListLocalPackages_DefersBrokenEmbed`: module with `//go:embed all:dist` (no match) and an xtest `//go:embed missing.jsonc` — listing succeeds, `ResolveEmbeds()` returns the error
- [x] **Integration** `tests/fixtures/test-helper-pkg/internal/brokenembed/embed.go` (`//go:embed missing.txt`, no tests, outside subPackages closure) — `test-fixture-test-helper-pkg` is the CI regression check. Without the Go fix the fixture build fails at list time (`pattern "missing.txt": no matching files found`); with it, `count=1 skipped=1`, PASS
- [x] `go test ./...`, `go vet ./...`, `nix flake check` (formatting)