### PR TITLE
buildinfo: omit -ldflags under trimpath and match cmd/go's GOOS/GO<ARCH> order

### DIFF
--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -124,7 +124,6 @@ func linkBinary(manifestPath, output string) error {
 
 	settings := buildinfo.BuildSettings{
 		BuildMode:      buildMode,
-		LDFlags:        strings.Join(m.LDFlags, " "),
 		Tags:           strings.Join(m.Tags, ","),
 		DefaultGODEBUG: godebugDefault,
 		CGOEnabled:     compile.GoEnvVar("CGO_ENABLED"),

--- a/go/go2nix/pkg/buildinfo/buildinfo.go
+++ b/go/go2nix/pkg/buildinfo/buildinfo.go
@@ -36,9 +36,13 @@ type ModDep struct {
 // the binary's modinfo, matching the subset of cmd/go's setBuildInfo that
 // go2nix can determine. Empty string fields are omitted from the output
 // (except -compiler and -trimpath, which are always emitted).
+//
+// -ldflags / -gcflags / -asmflags / CGO_*FLAGS are deliberately absent:
+// go2nix always builds with trimpath semantics, and cmd/go omits these
+// settings under -trimpath because their values can leak system paths
+// (see go.dev/issue/52372 and cmd/go/internal/load/pkg.go setBuildInfo).
 type BuildSettings struct {
 	BuildMode      string // -buildmode (e.g., "exe", "pie")
-	LDFlags        string // -ldflags as a single space-joined string
 	Tags           string // -tags as a comma-separated list
 	DefaultGODEBUG string // from go.mod's go directive
 	CGOEnabled     string // "0" or "1"
@@ -72,9 +76,6 @@ func (s BuildSettings) toDebugSettings() []debug.BuildSetting {
 		add("-buildmode", s.BuildMode)
 	}
 	add("-compiler", "gc")
-	if s.LDFlags != "" {
-		add("-ldflags", s.LDFlags)
-	}
 	if s.Tags != "" {
 		add("-tags", s.Tags)
 	}
@@ -88,12 +89,12 @@ func (s BuildSettings) toDebugSettings() []debug.BuildSetting {
 	}
 	if s.GOARCH != "" {
 		add("GOARCH", s.GOARCH)
-		if key := archLevelVar[s.GOARCH]; key != "" && s.GOARCHLevel != "" {
-			add(key, s.GOARCHLevel)
-		}
 	}
 	if s.GOOS != "" {
 		add("GOOS", s.GOOS)
+	}
+	if key := archLevelVar[s.GOARCH]; key != "" && s.GOARCHLevel != "" {
+		add(key, s.GOARCHLevel)
 	}
 	return out
 }

--- a/go/go2nix/pkg/buildinfo/buildinfo_test.go
+++ b/go/go2nix/pkg/buildinfo/buildinfo_test.go
@@ -76,9 +76,44 @@ golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq
 			t.Errorf("missing build setting %q in modinfo:\n%s", want, line)
 		}
 	}
-	// LDFlags/DefaultGODEBUG were empty — must be omitted.
-	if strings.Contains(line, "-ldflags") || strings.Contains(line, "DefaultGODEBUG") {
+	// DefaultGODEBUG was empty — must be omitted.
+	if strings.Contains(line, "DefaultGODEBUG") {
 		t.Errorf("empty optional settings should be omitted:\n%s", line)
+	}
+}
+
+// TestBuildSettingsMatchCmdGo locks the exact key set and order against
+// cmd/go/internal/load/pkg.go setBuildInfo for a `go build -trimpath`
+// invocation. Any future drift (extra keys, reordering, or reintroducing
+// -ldflags) fails this golden.
+func TestBuildSettingsMatchCmdGo(t *testing.T) {
+	got := BuildSettings{
+		BuildMode:      "exe",
+		Tags:           "netgo",
+		DefaultGODEBUG: "panicnil=1",
+		CGOEnabled:     "0",
+		GOARCH:         "amd64",
+		GOARCHLevel:    "v1",
+		GOOS:           "linux",
+	}.toDebugSettings()
+
+	want := []string{
+		"-buildmode", "-compiler", "-tags", "-trimpath",
+		"DefaultGODEBUG", "CGO_ENABLED", "GOARCH", "GOOS", "GOAMD64",
+	}
+	var gotKeys []string
+	for _, s := range got {
+		gotKeys = append(gotKeys, s.Key)
+	}
+	if strings.Join(gotKeys, ",") != strings.Join(want, ",") {
+		t.Errorf("build setting keys diverge from cmd/go setBuildInfo (under -trimpath):\n  got:  %v\n  want: %v", gotKeys, want)
+	}
+	// Upstream omits -ldflags/-gcflags/-asmflags under -trimpath
+	// (go.dev/issue/52372); never reintroduce.
+	for _, k := range gotKeys {
+		if k == "-ldflags" || k == "-gcflags" || k == "-asmflags" {
+			t.Errorf("%s must not be emitted: cmd/go omits it under -trimpath", k)
+		}
 	}
 }
 

--- a/go/go2nix/pkg/resolve/resolve.go
+++ b/go/go2nix/pkg/resolve/resolve.go
@@ -1205,7 +1205,6 @@ func generateModinfo(cfg Config, sorted []*ResolvedPkg, mainPath, defaultGODEBUG
 	}
 	settings := buildinfo.BuildSettings{
 		BuildMode:      cfg.buildMode,
-		LDFlags:        cfg.LDFlags,
 		Tags:           cfg.Tags,
 		DefaultGODEBUG: defaultGODEBUG,
 		CGOEnabled:     cgoEnabled,


### PR DESCRIPTION
## Summary

Two cosmetic divergences in `go version -m` build settings:

- `cmd/go/internal/load/pkg.go:2424-2435` omits `-ldflags`/`-gcflags`/`-asmflags` from modinfo when `-trimpath` is set (go.dev/issue/52372 — flag values can leak absolute paths). go2nix always uses trimpath, so the `-ldflags` line is dropped; the `BuildSettings.LDFlags` field is removed so it can't be reintroduced.
- `pkg.go:2473-2482` emits `GOARCH, GOOS, GO<ARCH>`; go2nix emitted `GOARCH, GO<ARCH>, GOOS`. Reordered.

`-gcflags`/`-asmflags` were never emitted; now also documented as deliberately absent.

After this, `go version -m | grep '^\tbuild'` is **identical** between go2nix and vanilla `go build -trimpath` for `tests/fixtures/testify-basic`.

## Test plan

- [x] **New** `TestBuildSettingsMatchCmdGo` — golden on the exact key sequence + explicit `-ldflags`/`-gcflags`/`-asmflags` rejection; fails on `origin/main` (`got: [...GOAMD64 GOOS] want: [...GOOS GOAMD64]`)
- [x] Integration: `go version -m` build settings on `testify-basic` — IDENTICAL to vanilla `go build -trimpath`
- [x] `go test ./...`, `go vet ./...`, `nix flake check` (formatting)