### PR TITLE
compile,linkbinary: pass -nolocalimports and dedupe -extld to match cmd/go

### DIFF
--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -178,6 +178,12 @@ func linkBinary(manifestPath, output string) error {
 		return err
 	}
 
+	ldflags, err := expandLDFlags(m.LDFlags)
+	if err != nil {
+		return fmt.Errorf("parsing ldflags: %w", err)
+	}
+	userExtld := hasExtld(ldflags)
+
 	for _, sp := range m.SubPackages {
 		deps := make([]buildinfo.ModDep, 0, len(sp.Modules))
 		for _, mm := range sp.Modules {
@@ -238,14 +244,17 @@ func linkBinary(manifestPath, output string) error {
 		// pick the link mode itself (cmd/link/internal/ld/lib.go:576 sets
 		// iscgo = LibraryByPkg["runtime/cgo"] != nil; config.go:208 picks
 		// external when iscgo && externalobj). Mirror that: pass -extld
-		// unconditionally, never force -linkmode.
+		// unconditionally, never force -linkmode. setextld (gc.go:538-550)
+		// skips this when user ldflags already contain -extld.
 		var linkFlags []string
-		extld := os.Getenv("CC")
-		if sp.CXX {
-			extld = os.Getenv("CXX")
-		}
-		if extld != "" {
-			linkFlags = append(linkFlags, "-extld", extld)
+		if !userExtld {
+			extld := os.Getenv("CC")
+			if sp.CXX {
+				extld = os.Getenv("CXX")
+			}
+			if extld != "" {
+				linkFlags = append(linkFlags, "-extld", extld)
+			}
 		}
 
 		// Propagate sanitizer flags from gcflags to linker.
@@ -278,10 +287,6 @@ func linkBinary(manifestPath, output string) error {
 			"-buildid=redacted",
 			"-buildmode=" + buildMode,
 			"-importcfg", linkCfg,
-		}
-		ldflags, err := expandLDFlags(m.LDFlags)
-		if err != nil {
-			return fmt.Errorf("parsing ldflags for %s: %w", importpath, err)
 		}
 		linkArgs = append(linkArgs, ldflags...)
 		linkArgs = append(linkArgs, linkFlags...)
@@ -320,6 +325,17 @@ func goToolchainVersion() (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// hasExtld reports whether ldflags already specify -extld, mirroring
+// cmd/go's setextld check (cmd/go/internal/work/gc.go:538-550).
+func hasExtld(ldflags []string) bool {
+	for _, f := range ldflags {
+		if f == "-extld" || strings.HasPrefix(f, "-extld=") {
+			return true
+		}
+	}
+	return false
 }
 
 // expandLDFlags splits each ldflag element into separate exec arguments using

--- a/go/go2nix/cmd/go2nix/linkbinary_test.go
+++ b/go/go2nix/cmd/go2nix/linkbinary_test.go
@@ -104,6 +104,28 @@ func TestExpandLDFlags(t *testing.T) {
 	}
 }
 
+func TestHasExtld(t *testing.T) {
+	tests := []struct {
+		name    string
+		ldflags []string
+		want    bool
+	}{
+		{"absent", []string{"-s", "-w"}, false},
+		{"separate form", []string{"-s", "-extld", "/custom/ld"}, true},
+		{"equals form", []string{"-extld=/custom/ld"}, true},
+		{"extldflags is not extld", []string{"-extldflags", "-static"}, false},
+		{"extldflags equals form is not extld", []string{"-extldflags=-static"}, false},
+		{"nil", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasExtld(tt.ldflags); got != tt.want {
+				t.Errorf("hasExtld(%v) = %v, want %v", tt.ldflags, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExtractModulePath(t *testing.T) {
 	dir := t.TempDir()
 	gomod := filepath.Join(dir, "go.mod")

--- a/go/go2nix/pkg/compile/asm.go
+++ b/go/go2nix/pkg/compile/asm.go
@@ -51,16 +51,10 @@ func compileWithAsm(opts Options, files gofiles.PkgFiles, embedFlag string) erro
 	}
 
 	// Pass 2: compile Go with symabis + asmhdr.
-	compileArgs := []string{
-		"tool", "compile",
-		"-importcfg", opts.ImportCfg,
-		"-p", opts.PFlag,
-		"-buildid", "", // deterministic empty buildID for Nix reproducibility
-		"-trimpath=" + opts.trimRewrite,
+	compileArgs := append(baseCompileArgs(opts),
 		"-symabis", symabis,
 		"-asmhdr", asmhdr,
-		"-pack",
-	}
+	)
 	compileArgs = append(compileArgs, opts.outputFlags()...)
 	if opts.GoVersion != "" {
 		compileArgs = append(compileArgs, "-lang=go"+opts.GoVersion)

--- a/go/go2nix/pkg/compile/cgo.go
+++ b/go/go2nix/pkg/compile/cgo.go
@@ -176,15 +176,7 @@ func compileCgo(opts Options, files gofiles.PkgFiles, embedFlag string) error {
 		cgoGoFiles = append(cgoGoFiles, ldflagFile)
 	}
 
-	compileArgs := []string{
-		"tool", "compile",
-		"-importcfg", opts.ImportCfg,
-		"-p", opts.PFlag,
-		"-buildid", "", // deterministic empty buildID for Nix reproducibility
-		"-trimpath=" + opts.trimRewrite,
-		"-pack",
-	}
-	compileArgs = append(compileArgs, opts.outputFlags()...)
+	compileArgs := append(baseCompileArgs(opts), opts.outputFlags()...)
 	if opts.GoVersion != "" {
 		compileArgs = append(compileArgs, "-lang=go"+opts.GoVersion)
 	}

--- a/go/go2nix/pkg/compile/compile.go
+++ b/go/go2nix/pkg/compile/compile.go
@@ -143,6 +143,22 @@ func CompileGoPackage(opts Options) error {
 	return compileGo(opts, files, embedFlag)
 }
 
+// baseCompileArgs returns the flags common to every `go tool compile`
+// invocation. -nolocalimports mirrors cmd/go (work/gc.go:137-141): the
+// alternative -D LocalPrefix branch only applies to legacy GOPATH-style
+// relative imports, and go2nix only ever compiles module-based packages.
+func baseCompileArgs(opts Options) []string {
+	return []string{
+		"tool", "compile",
+		"-importcfg", opts.ImportCfg,
+		"-p", opts.PFlag,
+		"-buildid", "", // deterministic empty buildID for Nix reproducibility
+		"-trimpath=" + opts.trimRewrite,
+		"-nolocalimports",
+		"-pack",
+	}
+}
+
 // outputFlags returns the -o / -linkobj arguments. When IfaceOutput is set,
 // -o gets the export-data-only archive (read by downstream compiles via
 // importcfg) and -linkobj gets the linker object (read by go tool link).

--- a/go/go2nix/pkg/compile/compile_test.go
+++ b/go/go2nix/pkg/compile/compile_test.go
@@ -8,6 +8,26 @@ import (
 	"github.com/numtide/go2nix/pkg/gofiles"
 )
 
+func TestBaseCompileArgs(t *testing.T) {
+	args := baseCompileArgs(Options{
+		ImportCfg:   "/tmp/importcfg",
+		PFlag:       "example.com/p",
+		trimRewrite: "/nix/store/abc=>",
+	})
+	want := []string{
+		"tool", "compile",
+		"-importcfg", "/tmp/importcfg",
+		"-p", "example.com/p",
+		"-buildid", "",
+		"-trimpath=/nix/store/abc=>",
+		"-nolocalimports",
+		"-pack",
+	}
+	if !reflect.DeepEqual(args, want) {
+		t.Errorf("baseCompileArgs() = %v, want %v", args, want)
+	}
+}
+
 func TestOptions_outputFlags(t *testing.T) {
 	tests := []struct {
 		name string

--- a/go/go2nix/pkg/compile/go.go
+++ b/go/go2nix/pkg/compile/go.go
@@ -10,15 +10,7 @@ import (
 )
 
 func compileGo(opts Options, files gofiles.PkgFiles, embedFlag string) error {
-	args := []string{
-		"tool", "compile",
-		"-importcfg", opts.ImportCfg,
-		"-p", opts.PFlag,
-		"-buildid", "", // deterministic empty buildID for Nix reproducibility
-		"-trimpath=" + opts.trimRewrite,
-		"-pack",
-	}
-	args = append(args, opts.outputFlags()...)
+	args := append(baseCompileArgs(opts), opts.outputFlags()...)
 	if opts.GoVersion != "" {
 		args = append(args, "-lang=go"+opts.GoVersion)
 	}


### PR DESCRIPTION
## Summary

Two minor flag-parity fixes:

- `cmd/go/internal/work/gc.go:137-141` always passes `-nolocalimports` to `go tool compile`; go2nix omitted it. Low practical impact (modules + importcfg already block relative imports) but this matches upstream. The base-args slice was duplicated across `go.go`/`asm.go`/`cgo.go` — factored into `baseCompileArgs()` so the flag is in one place.
- `gc.go:538-550` `setextld` skips its own `-extld` if user ldflags already contain one; go2nix appended unconditionally after user flags, so a user-supplied `-extld` was overridden (linker takes last). New `hasExtld()` mirrors the upstream check (`-extld` or `-extld=`, distinguished from `-extldflags`).

Dynamic mode (`resolve/builder.go:103-108`) already places user `$ldflags` after `${extld:+-extld "$extld"}`, so user-supplied `-extld` already wins there via ordering — left unchanged.

## Test plan

- [x] `TestBaseCompileArgs` — asserts the exact base flag list including `-nolocalimports`
- [x] `TestHasExtld` — 6 cases incl. `-extldflags` ≠ `-extld`
- [x] `cgo-internal-test` e2e (cgo + pure paths, doCheck=true): root binary dynamic / `purebin` static — unchanged behaviour
- [x] `go test ./...`, `go vet ./...`, `nix flake check` (formatting)