### PR TITLE
buildinfo,linkbinary: honour //go:debug directives in main-package source files

### DIFF
--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"go/build"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -120,19 +121,26 @@ func linkBinary(manifestPath, output string) error {
 		return fmt.Errorf("getting Go version: %w", err)
 	}
 
-	godebugDefault := buildinfo.DefaultGODEBUG(m.ModuleRoot)
-
+	// DefaultGODEBUG depends on per-main-package //go:debug source
+	// directives, so it (and the BuildSettings that carry it) is computed
+	// inside the SubPackages loop. Everything else is invariant.
 	settings := buildinfo.BuildSettings{
-		BuildMode:      buildMode,
-		Tags:           strings.Join(m.Tags, ","),
-		DefaultGODEBUG: godebugDefault,
-		CGOEnabled:     compile.GoEnvVar("CGO_ENABLED"),
-		GOARCH:         goarch,
-		GOOS:           goos,
+		BuildMode:  buildMode,
+		Tags:       strings.Join(m.Tags, ","),
+		CGOEnabled: compile.GoEnvVar("CGO_ENABLED"),
+		GOARCH:     goarch,
+		GOOS:       goos,
 	}
 	if key := buildinfo.ArchLevelVar(goarch); key != "" {
 		settings.GOARCHLevel = compile.GoEnvVar(key)
 	}
+
+	// build.Context for ParseSourceGodebugs — directive collection respects
+	// build constraints, so use the same GOOS/GOARCH/tags as the compile.
+	bctx := build.Default
+	bctx.GOOS = goos
+	bctx.GOARCH = goarch
+	bctx.BuildTags = m.Tags
 
 	// Step 6: Read merged importcfg once; the per-binary modinfo line (which
 	// carries BuildInfo.Path = main package import path) is appended inside
@@ -202,6 +210,10 @@ func linkBinary(manifestPath, output string) error {
 			srcdir = filepath.Join(m.ModuleRoot, clean)
 			binname = filepath.Base(clean)
 		}
+
+		srcDirectives := buildinfo.ParseSourceGodebugs(&bctx, srcdir)
+		godebugDefault := buildinfo.DefaultGODEBUG(m.ModuleRoot, srcDirectives)
+		settings.DefaultGODEBUG = godebugDefault
 
 		slog.Info("compiling main", "pkg", importpath)
 

--- a/go/go2nix/cmd/go2nix/modinfo.go
+++ b/go/go2nix/cmd/go2nix/modinfo.go
@@ -18,6 +18,7 @@ func runModinfoCmd(args []string) {
 	lockfilePath := fs.String("lockfile", "", "path to go2nix.toml lockfile")
 	goBin := fs.String("go", "", "path to go binary (default: from PATH)")
 	mainPath := fs.String("main-path", "", "import path of the main package (default: module path)")
+	mainDir := fs.String("main-dir", "", "directory of the main package, for //go:debug directives (default: MODULE_ROOT)")
 	_ = fs.Parse(args)
 
 	moduleRoot := fs.Arg(0)
@@ -64,11 +65,18 @@ func runModinfoCmd(args []string) {
 		deps = append(deps, dep)
 	}
 
+	srcDir := *mainDir
+	if srcDir == "" {
+		srcDir = moduleRoot
+	}
+	srcDirectives := buildinfo.ParseSourceGodebugs(nil, srcDir)
+	godebug := buildinfo.DefaultGODEBUG(moduleRoot, srcDirectives)
+
 	goos := compile.GoEnvVar("GOOS")
 	goarch := compile.GoEnvVar("GOARCH")
 	settings := buildinfo.BuildSettings{
 		BuildMode:      compile.DefaultBuildMode(goos, goarch),
-		DefaultGODEBUG: buildinfo.DefaultGODEBUG(moduleRoot),
+		DefaultGODEBUG: godebug,
 		CGOEnabled:     compile.GoEnvVar("CGO_ENABLED"),
 		GOARCH:         goarch,
 		GOOS:           goos,
@@ -87,7 +95,7 @@ func runModinfoCmd(args []string) {
 
 	// Output GODEBUG default as a separate line for the link hook to parse.
 	// The linker embeds this via -X=runtime.godebugDefault=<value>.
-	if godebug := buildinfo.DefaultGODEBUG(moduleRoot); godebug != "" {
+	if godebug != "" {
 		fmt.Printf("godebug %s\n", godebug)
 	}
 }

--- a/go/go2nix/pkg/buildinfo/godebug.go
+++ b/go/go2nix/pkg/buildinfo/godebug.go
@@ -1,7 +1,9 @@
 package buildinfo
 
 import (
+	"errors"
 	"fmt"
+	"go/build"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -11,6 +13,63 @@ import (
 
 	"golang.org/x/mod/modfile"
 )
+
+// A Godebug is a single key=value setting parsed from a //go:debug source
+// directive (or, equivalently, a go.mod godebug line).
+type Godebug struct {
+	Key, Value string
+}
+
+var errNotGoDebug = errors.New("not //go:debug line")
+
+// ParseGoDebug parses a //go:debug directive. It mirrors
+// cmd/go/internal/load.ParseGoDebug minus the godebugs-table membership
+// check (go2nix passes unknown keys through, like it does for go.mod
+// godebug lines).
+func ParseGoDebug(text string) (key, value string, err error) {
+	if !strings.HasPrefix(text, "//go:debug") {
+		return "", "", errNotGoDebug
+	}
+	i := strings.IndexAny(text, " \t")
+	if i < 0 {
+		if strings.TrimSpace(text) == "//go:debug" {
+			return "", "", fmt.Errorf("missing key=value")
+		}
+		return "", "", errNotGoDebug
+	}
+	k, v, ok := strings.Cut(strings.TrimSpace(text[i:]), "=")
+	if !ok {
+		return "", "", fmt.Errorf("missing key=value")
+	}
+	if strings.ContainsAny(k, " \t,") || strings.ContainsAny(v, " \t,") {
+		return "", "", fmt.Errorf("key or value contains space or comma")
+	}
+	return k, v, nil
+}
+
+// ParseSourceGodebugs collects //go:debug directives from the package at
+// srcDir using go/build's directive extraction, the same mechanism cmd/go
+// uses (Package.Directives). Directives that fail ParseGoDebug are skipped,
+// matching cmd/go/internal/load.defaultGODEBUG.
+func ParseSourceGodebugs(ctx *build.Context, srcDir string) []Godebug {
+	if ctx == nil {
+		c := build.Default
+		ctx = &c
+	}
+	pkg, err := ctx.ImportDir(srcDir, 0)
+	if err != nil && pkg == nil {
+		return nil
+	}
+	var out []Godebug
+	for _, d := range pkg.Directives {
+		k, v, perr := ParseGoDebug(d.Text)
+		if perr != nil {
+			continue
+		}
+		out = append(out, Godebug{Key: k, Value: v})
+	}
+	return out
+}
 
 // godebugEntry mirrors internal/godebugs.Info for the subset we need.
 // Only entries with Changed > 0 affect the default GODEBUG string.
@@ -65,33 +124,51 @@ var godebugTable = []godebugEntry{
 // DefaultGODEBUG computes the default GODEBUG string for a main package,
 // matching cmd/go/internal/load.defaultGODEBUG.
 //
-// moduleRoot is the path to the directory containing go.mod.
-// Returns "" if the go.mod cannot be read or has no go directive.
-func DefaultGODEBUG(moduleRoot string) string {
+// moduleRoot is the path to the directory containing go.mod. srcDirectives
+// are //go:debug directives parsed from the main package's source files
+// (see ParseSourceGodebugs); they are applied after go.mod's godebug lines
+// so a source-file directive overrides a go.mod one for the same key,
+// including default=.
+func DefaultGODEBUG(moduleRoot string, srcDirectives []Godebug) string {
 	goModPath := filepath.Join(moduleRoot, "go.mod")
 	data, err := os.ReadFile(goModPath)
 	if err != nil {
 		return ""
 	}
 	mf, err := modfile.Parse(goModPath, data, nil)
-	if err != nil || mf.Go == nil {
+	if err != nil {
 		return ""
 	}
 
-	goVersion := mf.Go.Version
+	// Mirrors gover.FromGoMod: a go.mod with no `go` directive is treated
+	// as DefaultGoModVersion ("1.16"), the same fallback cmd/go's
+	// MainModules.GoVersion uses. See cmd/go/internal/gover/version.go:64.
+	goVersion := "1.16"
+	if mf.Go != nil {
+		goVersion = mf.Go.Version
+	}
 
-	// Parse go version minor number.
 	minor := parseGoMinor(goVersion)
 	if minor < 0 {
 		return ""
 	}
 
-	// cmd/go resolves the base version first (go directive, optionally
-	// overridden by any `godebug default=goX.Y` directive), then layers
-	// every explicit `godebug key=value` directive on top regardless of
-	// its position relative to `default=`. Do the same: first scan for
-	// `default=` to fix the base minor, then apply non-default directives.
+	// Merge go.mod godebug lines then source-file //go:debug directives, in
+	// that order, so the last writer (source) wins on conflict — matching
+	// cmd/go/internal/load.defaultGODEBUG which applies p.Internal.Build.
+	// Directives after MainModules.Godebugs.
+	directives := make([]Godebug, 0, len(mf.Godebug)+len(srcDirectives))
 	for _, gd := range mf.Godebug {
+		directives = append(directives, Godebug{Key: gd.Key, Value: gd.Value})
+	}
+	directives = append(directives, srcDirectives...)
+
+	// cmd/go resolves the base version first (go directive, optionally
+	// overridden by any `default=goX.Y` from go.mod or source), then layers
+	// every explicit `key=value` directive on top regardless of its
+	// position relative to `default=`. Do the same: first scan for
+	// `default=` to fix the base minor, then apply non-default directives.
+	for _, gd := range directives {
 		if gd.Key != "default" {
 			continue
 		}
@@ -110,8 +187,8 @@ func DefaultGODEBUG(moduleRoot string) string {
 		}
 	}
 
-	// Apply explicit godebug directives from go.mod on top.
-	for _, gd := range mf.Godebug {
+	// Apply explicit non-default directives on top.
+	for _, gd := range directives {
 		if gd.Key == "default" {
 			continue
 		}

--- a/go/go2nix/pkg/buildinfo/godebug_test.go
+++ b/go/go2nix/pkg/buildinfo/godebug_test.go
@@ -13,7 +13,7 @@ func TestDefaultGODEBUG_Go121(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result := DefaultGODEBUG(dir)
+	result := DefaultGODEBUG(dir, nil)
 
 	// Go 1.21 is before many Changed versions, so we expect several entries.
 	if result == "" {
@@ -44,7 +44,7 @@ func TestDefaultGODEBUG_Go124(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result := DefaultGODEBUG(dir)
+	result := DefaultGODEBUG(dir, nil)
 
 	// Go 1.24 — entries with Changed > 24 should be present.
 	// asynctimerchan has Changed: 23, so 24 < 23 is false — should NOT be present.
@@ -66,7 +66,7 @@ func TestDefaultGODEBUG_LatestVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result := DefaultGODEBUG(dir)
+	result := DefaultGODEBUG(dir, nil)
 
 	// No entries should have minor < Changed, so result should be empty.
 	if result != "" {
@@ -76,7 +76,7 @@ func TestDefaultGODEBUG_LatestVersion(t *testing.T) {
 
 func TestDefaultGODEBUG_NoGoMod(t *testing.T) {
 	dir := t.TempDir()
-	result := DefaultGODEBUG(dir)
+	result := DefaultGODEBUG(dir, nil)
 	if result != "" {
 		t.Errorf("expected empty result when no go.mod, got %q", result)
 	}
@@ -89,7 +89,7 @@ func TestDefaultGODEBUG_GodebugDirective(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result := DefaultGODEBUG(dir)
+	result := DefaultGODEBUG(dir, nil)
 
 	// asynctimerchan should be overridden to 0 by the explicit godebug directive.
 	if !contains(result, "asynctimerchan=0") {
@@ -105,7 +105,7 @@ func TestDefaultGODEBUG_DefaultDirective(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result := DefaultGODEBUG(dir)
+	result := DefaultGODEBUG(dir, nil)
 
 	// With default go1.24, asynctimerchan (Changed: 23) should NOT be present
 	// because 24 < 23 is false.
@@ -161,7 +161,7 @@ func TestDefaultGODEBUG_ExplicitSurvivesLaterDefault(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(tt.gomod), 0o644); err != nil {
 				t.Fatal(err)
 			}
-			result := DefaultGODEBUG(dir)
+			result := DefaultGODEBUG(dir, nil)
 			for k, v := range tt.want {
 				if !contains(result, k+"="+v) {
 					t.Errorf("expected %s=%s in %q", k, v, result)
@@ -173,6 +173,135 @@ func TestDefaultGODEBUG_ExplicitSurvivesLaterDefault(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestDefaultGODEBUG_NoGoDirective(t *testing.T) {
+	dir := t.TempDir()
+	gomod := "module example.com/test\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(gomod), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := DefaultGODEBUG(dir, nil)
+
+	// gover.FromGoMod falls back to DefaultGoModVersion = "1.16", so every
+	// table entry with Changed > 16 applies. Spot-check a few across the
+	// Changed range.
+	for _, want := range []string{"netedns0=0", "panicnil=1", "httpmuxgo121=1", "asynctimerchan=1"} {
+		if !contains(result, want) {
+			t.Errorf("expected %s for go.mod with no go directive (1.16 baseline); got %q", want, result)
+		}
+	}
+}
+
+func TestDefaultGODEBUG_SourceDirectives(t *testing.T) {
+	dir := t.TempDir()
+	gomod := "module example.com/test\n\ngo 1.24\n\ngodebug panicnil=0\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(gomod), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	src := []Godebug{
+		{Key: "panicnil", Value: "1"},
+		{Key: "httpmuxgo121", Value: "1"},
+	}
+	result := DefaultGODEBUG(dir, src)
+
+	// Source directive overrides go.mod for the same key.
+	if !contains(result, "panicnil=1") {
+		t.Errorf("expected panicnil=1 (source overrides go.mod); got %q", result)
+	}
+	if !contains(result, "httpmuxgo121=1") {
+		t.Errorf("expected httpmuxgo121=1 from source directive; got %q", result)
+	}
+	// Table default for go1.24 (containermaxprocs Changed=25) still applies.
+	if !contains(result, "containermaxprocs=0") {
+		t.Errorf("expected containermaxprocs=0 from table; got %q", result)
+	}
+}
+
+func TestDefaultGODEBUG_SourceDefaultDirective(t *testing.T) {
+	dir := t.TempDir()
+	gomod := "module example.com/test\n\ngo 1.21\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(gomod), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// //go:debug default=go1.24 in source overrides go.mod's go 1.21.
+	result := DefaultGODEBUG(dir, []Godebug{{Key: "default", Value: "go1.24"}})
+
+	if contains(result, "asynctimerchan=") {
+		t.Errorf("asynctimerchan should not be present with source default=go1.24; got %q", result)
+	}
+	if !contains(result, "containermaxprocs=0") {
+		t.Errorf("expected containermaxprocs=0 with source default=go1.24; got %q", result)
+	}
+}
+
+func TestParseGoDebug(t *testing.T) {
+	tests := []struct {
+		text       string
+		key, value string
+		wantErr    bool
+	}{
+		{"//go:debug panicnil=1", "panicnil", "1", false},
+		{"//go:debug\tdefault=go1.24", "default", "go1.24", false},
+		{"//go:debug   httpmuxgo121=1  ", "httpmuxgo121", "1", false},
+		{"//go:debug", "", "", true},
+		{"//go:debug noequals", "", "", true},
+		{"//go:debug k=a,b", "", "", true},
+		{"//go:debugfoo=1", "", "", true},
+		{"// go:debug panicnil=1", "", "", true},
+		{"//go:embed all:dist", "", "", true},
+	}
+	for _, tt := range tests {
+		k, v, err := ParseGoDebug(tt.text)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ParseGoDebug(%q) err=%v, wantErr=%v", tt.text, err, tt.wantErr)
+			continue
+		}
+		if k != tt.key || v != tt.value {
+			t.Errorf("ParseGoDebug(%q) = %q,%q; want %q,%q", tt.text, k, v, tt.key, tt.value)
+		}
+	}
+}
+
+func TestParseSourceGodebugs(t *testing.T) {
+	dir := t.TempDir()
+	mainGo := `// Binary x demonstrates //go:debug.
+//
+//go:debug panicnil=1
+//go:debug httpmuxgo121=1
+package main
+
+//go:debug ignored=1
+func main() {}
+`
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(mainGo), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	otherGo := `//go:debug asynctimerchan=0
+package main
+`
+	if err := os.WriteFile(filepath.Join(dir, "other.go"), []byte(otherGo), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := ParseSourceGodebugs(nil, dir)
+
+	want := map[string]string{"panicnil": "1", "httpmuxgo121": "1", "asynctimerchan": "0"}
+	gotM := map[string]string{}
+	for _, g := range got {
+		gotM[g.Key] = g.Value
+	}
+	for k, v := range want {
+		if gotM[k] != v {
+			t.Errorf("ParseSourceGodebugs: missing or wrong %s=%s; got %v", k, v, got)
+		}
+	}
+	if _, ok := gotM["ignored"]; ok {
+		t.Errorf("ParseSourceGodebugs: directive after package clause should not be collected; got %v", got)
 	}
 }
 

--- a/packages/test-fixture-lang-loopvar/default.nix
+++ b/packages/test-fixture-lang-loopvar/default.nix
@@ -26,7 +26,10 @@ else
   in
   pkgs.runCommand "test-dag-fixture-lang-loopvar"
     {
-      nativeBuildInputs = [ nix ];
+      nativeBuildInputs = [
+        nix
+        pkgs.go
+      ];
       requiredSystemFeatures = [ "recursive-nix" ];
     }
     ''
@@ -40,5 +43,11 @@ else
         --no-out-link)
 
       $result/bin/lang-loopvar
+
+      echo "=== Verifying //go:debug source directive is honoured ==="
+      go version -m $result/bin/lang-loopvar | tee /tmp/modinfo
+      grep -q "DefaultGODEBUG=.*panicnil=1" /tmp/modinfo \
+        || { echo "FAIL: DefaultGODEBUG missing panicnil=1 from //go:debug"; exit 1; }
+
       echo "PASS: lang-loopvar" > $out
     ''

--- a/tests/fixtures/lang-loopvar/main.go
+++ b/tests/fixtures/lang-loopvar/main.go
@@ -1,3 +1,11 @@
+// Binary lang-loopvar is the regression fixture for -lang threading.
+//
+// The //go:debug directive below is the regression fixture for source-file
+// godebug parsing: with go 1.21 the table-derived DefaultGODEBUG would not
+// include panicnil (Changed=21), so its presence proves the directive was
+// honoured.
+//
+//go:debug panicnil=1
 package main
 
 import (


### PR DESCRIPTION
## Summary

`DefaultGODEBUG` was computed from go.mod `godebug` directives only; `//go:debug key=value` directives in `package main` source files were ignored. Upstream `cmd/go/internal/load/godebug.go:84-95` merges both via `go/build.Package.Directives`, with source directives overriding go.mod (including `default=goX.Y`).

`buildinfo.DefaultGODEBUG(moduleRoot, srcDirectives)` now takes the source-file directives. New `ParseSourceGodebugs(&bctx, dir)` collects them via `build.ImportDir` with the same `GOOS/GOARCH/Tags` as the compile (directive collection respects build constraints). `linkbinary` calls it per-subPackage, so each binary's `DefaultGODEBUG` reflects its own main package.

Also: when go.mod has no `go` directive, the godebug baseline now falls back to `"1.16"` (`gover.FromGoMod` semantics for the go.mod-rooted path go2nix models — the upstream `"1.20"` at godebug.go:60 is the `RootMode == NoRoot` `go install pkg@version` path).

Dynamic mode was already correct (uses `go list`'s `DefaultGODEBUG`).

## Test plan

- [x] **Unit** `TestParseGoDebug` (9 cases), `TestParseSourceGodebugs`, `TestDefaultGODEBUG_SourceDirectives` (source overrides go.mod), `TestDefaultGODEBUG_SourceDefaultDirective`, `TestDefaultGODEBUG_NoGoDirective` (1.16 baseline)
- [x] **Integration** `tests/fixtures/lang-loopvar/main.go` adds `//go:debug panicnil=1`; `test-fixture-lang-loopvar` asserts `go version -m | grep panicnil=1`
- [x] With fix: `DefaultGODEBUG` byte-identical to vanilla `go build` on the fixture; without fix (Go changes stashed): `panicnil` absent
- [x] `go test ./...`, `go vet ./...`, `nix flake check` (formatting)