### PR TITLE
gofiles: follow symlinked leaf files in ResolveEmbedCfg (golang/go#59924)

### DIFF
--- a/go/go2nix/pkg/gofiles/gofiles.go
+++ b/go/go2nix/pkg/gofiles/gofiles.go
@@ -152,8 +152,11 @@ func ListFiles(dir string, tags string, goVersion string) (PkgFiles, error) {
 // producing the JSON structure expected by go tool compile -embedcfg.
 //
 // Ported from cmd/go/internal/load.resolveEmbed, using os/filepath instead
-// of the internal fsys/str packages. We omit the GODEBUG embedfollowsymlinks
-// knob since it's a niche opt-in that doesn't affect Nix sandbox builds.
+// of the internal fsys/str packages. Upstream gates leaf-file symlink support
+// behind GODEBUG=embedfollowsymlinks=1 (golang/go#59924), added so build
+// systems that stage source via symlinks (rules_go) can embed; go2nix's own
+// testrunner does the same, so we follow leaf-file symlinks unconditionally.
+// Directory symlinks remain rejected, matching upstream.
 func ResolveEmbedCfg(dir string, patterns []string) (*EmbedCfg, error) {
 	cfg := &EmbedCfg{
 		Patterns: make(map[string][]string),
@@ -214,6 +217,19 @@ func ResolveEmbedCfg(dir string, patterns []string) (*EmbedCfg, error) {
 
 			switch {
 			case info.Mode().IsRegular():
+				if have[rel] != pid {
+					have[rel] = pid
+					list = append(list, rel)
+				}
+
+			case info.Mode()&fs.ModeType == fs.ModeSymlink:
+				info, err := os.Stat(file)
+				if err != nil {
+					return nil, fmt.Errorf("pattern %q: %w", pattern, err)
+				}
+				if !info.Mode().IsRegular() {
+					return nil, fmt.Errorf("cannot embed irregular file %s", rel)
+				}
 				if have[rel] != pid {
 					have[rel] = pid
 					list = append(list, rel)

--- a/go/go2nix/pkg/gofiles/gofiles_test.go
+++ b/go/go2nix/pkg/gofiles/gofiles_test.go
@@ -320,23 +320,6 @@ func TestResolveEmbedCfg_InvalidPattern(t *testing.T) {
 	}
 }
 
-func TestResolveEmbedCfg_IrregularFileRejected(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "real.txt"), "real")
-	// Create a symlink — should be rejected as irregular.
-	if err := os.Symlink("real.txt", filepath.Join(dir, "link.txt")); err != nil {
-		t.Fatal(err)
-	}
-
-	_, err := ResolveEmbedCfg(dir, []string{"link.txt"})
-	if err == nil {
-		t.Fatal("expected error for symlink, got nil")
-	}
-	if !strings.Contains(err.Error(), "irregular file") {
-		t.Errorf("expected 'irregular file' in error, got: %v", err)
-	}
-}
-
 func TestResolveEmbedCfg_ModuleBoundary(t *testing.T) {
 	dir := t.TempDir()
 	// Create a subdirectory that contains its own go.mod — a module boundary.
@@ -427,5 +410,52 @@ func TestResolveEmbedCfg_Deduplication(t *testing.T) {
 	}
 	if len(cfg.Patterns["readme.txt"]) != 1 {
 		t.Errorf("Patterns[readme.txt] = %v, want 1 entry", cfg.Patterns["readme.txt"])
+	}
+}
+
+func TestResolveEmbedCfg_SymlinkLeafFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "real.txt"), "content")
+	if err := os.Symlink("real.txt", filepath.Join(dir, "link.txt")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	cfg, err := ResolveEmbedCfg(dir, []string{"link.txt"})
+	if err != nil {
+		t.Fatalf("ResolveEmbedCfg(link.txt) errored: %v; symlinked leaf files must be embeddable (golang/go#59924)", err)
+	}
+	if got := cfg.Patterns["link.txt"]; len(got) != 1 || got[0] != "link.txt" {
+		t.Errorf("Patterns[link.txt] = %v, want [link.txt]", got)
+	}
+	if cfg.Files["link.txt"] != filepath.Join(dir, "link.txt") {
+		t.Errorf("Files[link.txt] = %q, want %q", cfg.Files["link.txt"], filepath.Join(dir, "link.txt"))
+	}
+}
+
+func TestResolveEmbedCfg_SymlinkToDirectoryRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "realdir", "f.txt"), "x")
+	if err := os.Symlink("realdir", filepath.Join(dir, "linkdir")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err := ResolveEmbedCfg(dir, []string{"linkdir"})
+	if err == nil {
+		t.Fatal("ResolveEmbedCfg(linkdir) succeeded; want error: symlink-to-directory must be rejected (only leaf files are followed)")
+	}
+	if !strings.Contains(err.Error(), "cannot embed irregular file") {
+		t.Errorf("got %q, want error containing %q", err, "cannot embed irregular file")
+	}
+}
+
+func TestResolveEmbedCfg_DanglingSymlinkRejected(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Symlink("nonexistent", filepath.Join(dir, "dangling.txt")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err := ResolveEmbedCfg(dir, []string{"dangling.txt"})
+	if err == nil {
+		t.Fatal("ResolveEmbedCfg(dangling.txt) succeeded; want error: dangling symlinks must be rejected")
 	}
 }


### PR DESCRIPTION
## Summary

`ResolveEmbedCfg` rejected symlinked files, with a comment stating the upstream `embedfollowsymlinks` GODEBUG "doesn't affect Nix sandbox builds." That's incorrect: build systems that stage source via symlinks need it — golang/go#59924 was filed for rules_go's Bazel sandbox, and go2nix's own testrunner symlinks embed files into staging directories.

Now matches `cmd/go/internal/load/pkg.go:2202-2213` (`embedfollowsymlinks=1` branch) unconditionally: if a matched leaf is `ModeSymlink`, `os.Stat` through it; accept iff the target is a regular file. Directory symlinks remain rejected; parent-dir symlink checks unchanged.

## Test plan

- [x] **New** `TestResolveEmbedCfg_Symlinks`: leaf-file symlink → accepted; directory symlink → rejected; dangling symlink → error
- [x] Without fix (stash): leaf-symlink case fails; with fix: PASS
- [x] `go test ./pkg/gofiles/...`, `go vet ./...`, `nix flake check` (formatting)