### PR TITLE
testmain: error on bad-signature/generic test funcs and set testdeps.ModulePath

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -105,6 +105,9 @@
           test-fixture-lang-loopvar = callPkgWith ./packages/test-fixture-lang-loopvar/default.nix {
             inherit flake system;
           };
+          test-fixture-testmain-badsig = callPkgWith ./tests/nix/testmain_badsig_test.nix {
+            inherit flake system;
+          };
           test-fixture-torture-app-full = callPkgWith ./packages/test-fixture-torture-app-full/default.nix {
             inherit flake system;
           };

--- a/go/go2nix/cmd/go2nix/gentestmain.go
+++ b/go/go2nix/cmd/go2nix/gentestmain.go
@@ -12,6 +12,7 @@ import (
 func runGenTestMainCmd(args []string) {
 	fs := flag.NewFlagSet("generate-test-main", flag.ExitOnError)
 	importPath := fs.String("import-path", "", "import path of the package under test")
+	modulePath := fs.String("module-path", "", "module path of the main module (for testdeps.ModulePath)")
 	testFiles := fs.String("test-files", "", "comma-separated absolute paths to internal _test.go files")
 	xtestFiles := fs.String("xtest-files", "", "comma-separated absolute paths to external _test.go files")
 	output := fs.String("output", "", "output file path (default: stdout)")
@@ -24,6 +25,7 @@ func runGenTestMainCmd(args []string) {
 
 	opts := testmain.Options{
 		ImportPath: *importPath,
+		ModulePath: *modulePath,
 	}
 	if *testFiles != "" {
 		opts.TestGoFiles = strings.Split(*testFiles, ",")

--- a/go/go2nix/pkg/localpkgs/localpkgs.go
+++ b/go/go2nix/pkg/localpkgs/localpkgs.go
@@ -81,6 +81,15 @@ func (p *LocalPkg) ResolveEmbeds() error {
 	return nil
 }
 
+// ModulePath returns the module path declared in root/go.mod.
+func ModulePath(root string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(root, "go.mod"))
+	if err != nil {
+		return "", fmt.Errorf("reading go.mod: %w", err)
+	}
+	return modfile.ModulePath(data), nil
+}
+
 // ListLocalPackages discovers all local packages under root (the directory
 // containing go.mod) and returns them in topological dependency order.
 //

--- a/go/go2nix/pkg/testmain/testmain.go
+++ b/go/go2nix/pkg/testmain/testmain.go
@@ -12,6 +12,7 @@ package testmain
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"go/ast"
 	"go/doc"
 	"go/parser"
@@ -27,6 +28,7 @@ import (
 // Options configures test main generation.
 type Options struct {
 	ImportPath   string   // import path of the package under test
+	ModulePath   string   // module path of the main module (for testdeps.ModulePath)
 	TestGoFiles  []string // absolute paths to internal _test.go files
 	XTestGoFiles []string // absolute paths to external _test.go files
 }
@@ -52,12 +54,14 @@ type testFuncs struct {
 	NeedXtest   bool
 
 	ImportPath string // package under test
+	ModulePath string // main module path
 }
 
 // Generate produces test main source code for the given options.
 func Generate(opts Options) ([]byte, error) {
 	t := &testFuncs{
 		ImportPath: opts.ImportPath,
+		ModulePath: opts.ModulePath,
 	}
 
 	fset := token.NewFileSet()
@@ -106,28 +110,32 @@ func (t *testFuncs) load(fset *token.FileSet, filename, pkg string, doImport, se
 				*doImport, *seen = true, true
 				continue
 			}
-			if isTestFunc(n, "M") {
-				if t.TestMain != nil {
-					return errors.New("multiple definitions of TestMain")
-				}
-				t.TestMain = &testFunc{pkg, name, "", false}
-				*doImport, *seen = true, true
+			if err := checkTestFunc(fset, n, "M"); err != nil {
+				return err
 			}
+			if t.TestMain != nil {
+				return errors.New("multiple definitions of TestMain")
+			}
+			t.TestMain = &testFunc{pkg, name, "", false}
+			*doImport, *seen = true, true
 		case isTest(name, "Test"):
-			if isTestFunc(n, "T") {
-				t.Tests = append(t.Tests, testFunc{pkg, name, "", false})
-				*doImport, *seen = true, true
+			if err := checkTestFunc(fset, n, "T"); err != nil {
+				return err
 			}
+			t.Tests = append(t.Tests, testFunc{pkg, name, "", false})
+			*doImport, *seen = true, true
 		case isTest(name, "Benchmark"):
-			if isTestFunc(n, "B") {
-				t.Benchmarks = append(t.Benchmarks, testFunc{pkg, name, "", false})
-				*doImport, *seen = true, true
+			if err := checkTestFunc(fset, n, "B"); err != nil {
+				return err
 			}
+			t.Benchmarks = append(t.Benchmarks, testFunc{pkg, name, "", false})
+			*doImport, *seen = true, true
 		case isTest(name, "Fuzz"):
-			if isTestFunc(n, "F") {
-				t.FuzzTargets = append(t.FuzzTargets, testFunc{pkg, name, "", false})
-				*doImport, *seen = true, true
+			if err := checkTestFunc(fset, n, "F"); err != nil {
+				return err
 			}
+			t.FuzzTargets = append(t.FuzzTargets, testFunc{pkg, name, "", false})
+			*doImport, *seen = true, true
 		}
 	}
 	ex := doc.Examples(f)
@@ -163,6 +171,24 @@ func isTestFunc(fn *ast.FuncDecl, arg string) bool {
 		return true
 	}
 	return false
+}
+
+// checkTestFunc reports an error if fn is named like a test function but
+// has the wrong signature or has type parameters.
+// Ported from cmd/go/internal/load/test.go (checkTestFunc).
+func checkTestFunc(fset *token.FileSet, fn *ast.FuncDecl, arg string) error {
+	var why string
+	if !isTestFunc(fn, arg) {
+		why = fmt.Sprintf("must be: func %s(%s *testing.%s)", fn.Name.String(), strings.ToLower(arg), arg)
+	}
+	if fn.Type.TypeParams.NumFields() > 0 {
+		why = "test functions cannot have type parameters"
+	}
+	if why != "" {
+		pos := fset.Position(fn.Pos())
+		return fmt.Errorf("%s: wrong signature for %s, %s", pos, fn.Name.String(), why)
+	}
+	return nil
 }
 
 // isTest checks Go test naming convention: prefix + optional uppercase letter.
@@ -225,6 +251,7 @@ var examples = []testing.InternalExample{
 }
 
 func init() {
+	testdeps.ModulePath = {{printf "%q" .ModulePath}}
 	testdeps.ImportPath = {{printf "%q" .ImportPath}}
 }
 

--- a/go/go2nix/pkg/testmain/testmain_test.go
+++ b/go/go2nix/pkg/testmain/testmain_test.go
@@ -47,6 +47,73 @@ func FuzzAdd(f *testing.F) {}
 	}
 }
 
+func writeTestFile(t *testing.T, body string) string {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "x_test.go")
+	if err := os.WriteFile(f, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func TestGenerateBadSignature(t *testing.T) {
+	cases := []struct {
+		name, src, wantArg string
+	}{
+		{"Test", "func TestBad(x int) {}\n", "t *testing.T"},
+		{"Benchmark", "func BenchmarkBad() {}\n", "b *testing.B"},
+		{"Fuzz", "func FuzzBad(f *testing.T) {}\n", "f *testing.F"},
+		{"TestMain", "func TestMain() {}\n", "m *testing.M"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := writeTestFile(t, "package foo\nimport \"testing\"\nvar _ = testing.Short\n"+tc.src)
+			_, err := Generate(Options{ImportPath: "example.com/foo", TestGoFiles: []string{f}})
+			if err == nil {
+				t.Fatalf("expected error for bad %s signature, got nil", tc.name)
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, "wrong signature for") || !strings.Contains(msg, tc.wantArg) {
+				t.Errorf("error %q does not match upstream format (want %q)", msg, tc.wantArg)
+			}
+			if !strings.Contains(msg, "x_test.go:") {
+				t.Errorf("error %q missing file:line position", msg)
+			}
+		})
+	}
+}
+
+func TestGenerateGenericTestFunc(t *testing.T) {
+	f := writeTestFile(t, "package foo\nimport \"testing\"\nfunc TestGeneric[T any](t *testing.T) { _ = t }\n")
+	_, err := Generate(Options{ImportPath: "example.com/foo", TestGoFiles: []string{f}})
+	if err == nil {
+		t.Fatal("expected error for generic test func, got nil")
+	}
+	if !strings.Contains(err.Error(), "test functions cannot have type parameters") {
+		t.Errorf("error %q does not mention type parameters", err.Error())
+	}
+}
+
+func TestGenerateModulePath(t *testing.T) {
+	got, err := Generate(Options{
+		ImportPath: "example.com/foo/bar",
+		ModulePath: "example.com/foo",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(got)
+	if !strings.Contains(src, `testdeps.ModulePath = "example.com/foo"`) {
+		t.Error("missing testdeps.ModulePath assignment")
+	}
+	if !strings.Contains(src, `testdeps.ImportPath = "example.com/foo/bar"`) {
+		t.Error("missing testdeps.ImportPath assignment")
+	}
+	if strings.Index(src, "testdeps.ModulePath") > strings.Index(src, "testdeps.ImportPath") {
+		t.Error("ModulePath should be set before ImportPath (matches upstream template)")
+	}
+}
+
 func TestGenerateExternal(t *testing.T) {
 	dir := t.TempDir()
 	testFile := filepath.Join(dir, "foo_ext_test.go")

--- a/go/go2nix/pkg/testrunner/testrunner.go
+++ b/go/go2nix/pkg/testrunner/testrunner.go
@@ -63,6 +63,11 @@ func (o Options) tagsList() []string {
 
 // Run discovers testable packages and runs their tests.
 func Run(opts Options) error {
+	modulePath, err := localpkgs.ModulePath(opts.ModuleRoot)
+	if err != nil {
+		return err
+	}
+
 	pkgs, err := localpkgs.ListLocalPackages(opts.ModuleRoot, opts.Tags, compile.ToolchainVersion())
 	if err != nil {
 		return fmt.Errorf("listing local packages: %w", err)
@@ -126,7 +131,7 @@ func Run(opts Options) error {
 	}
 
 	for _, p := range testable {
-		if err := runPackageTests(opts, p, pkgMap); err != nil {
+		if err := runPackageTests(opts, modulePath, p, pkgMap); err != nil {
 			return fmt.Errorf("testing %s: %w", p.ImportPath, err)
 		}
 	}
@@ -232,7 +237,7 @@ func affectedLocalDeps(targetPkg string, xtestLocalImports []string, pkgMap map[
 	})
 }
 
-func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*localpkgs.LocalPkg) error {
+func runPackageTests(opts Options, modulePath string, pkg *localpkgs.LocalPkg, pkgMap map[string]*localpkgs.LocalPkg) error {
 	slog.Info("testing", "pkg", pkg.ImportPath)
 
 	testDir := filepath.Join(opts.TrimPath, "test-"+sanitize(pkg.ImportPath))
@@ -450,6 +455,7 @@ func runPackageTests(opts Options, pkg *localpkgs.LocalPkg, pkgMap map[string]*l
 	}
 	src, err := testmain.Generate(testmain.Options{
 		ImportPath:   pkg.ImportPath,
+		ModulePath:   modulePath,
 		TestGoFiles:  testFiles,
 		XTestGoFiles: xtestFiles,
 	})

--- a/tests/nix/testmain_badsig_test.nix
+++ b/tests/nix/testmain_badsig_test.nix
@@ -1,0 +1,82 @@
+# Negative integration check: a bad-signature test function must surface as
+# a build failure through the testrunner, not be silently dropped.
+#
+# Copies the test-helper-pkg fixture, appends `func TestBadSig(x int) {}` to
+# the in-scope internal/app package, and asserts the inner build fails with
+# the upstream `wrong signature for TestBadSig` error from checkTestFunc.
+{
+  flake,
+  pkgs,
+  system,
+  ...
+}:
+if !(flake.packages.${system} ? go2nix-nix-plugin) then
+  pkgs.runCommand "testmain-badsig-test-unsupported" { meta.platforms = pkgs.lib.platforms.linux; } ''
+    echo "testmain-badsig requires go2nix-nix-plugin (Linux only)" >&2
+    exit 1
+  ''
+else
+  let
+    plugin = flake.packages.${system}.go2nix-nix-plugin;
+    nix = pkgs.nixVersions.nix_2_34;
+    nixpkgsPath = pkgs.path;
+    go2nixSrc = flake;
+
+    dag = pkgs.writeText "dag.nix" ''
+      let
+        pkgs = import <nixpkgs> { };
+        inherit (pkgs) go;
+        go2nix = import ${go2nixSrc}/packages/go2nix { inherit pkgs; };
+        goEnv = import ${go2nixSrc}/nix/mk-go-env.nix {
+          inherit go go2nix;
+          inherit (pkgs) callPackage;
+        };
+      in
+      goEnv.buildGoApplication {
+        pname = "test-helper-pkg-badsig";
+        version = "0.0.1";
+        src = ./.;
+        goLock = ./go2nix.toml;
+        doCheck = true;
+      }
+    '';
+  in
+  pkgs.runCommand "testmain-badsig-test"
+    {
+      nativeBuildInputs = [ nix ];
+      requiredSystemFeatures = [ "recursive-nix" ];
+    }
+    ''
+      export HOME=$(mktemp -d)
+      export NIX_CONFIG="extra-experimental-features = nix-command recursive-nix"
+
+      cp -r ${go2nixSrc}/tests/fixtures/test-helper-pkg $TMPDIR/fixture
+      chmod -R u+w $TMPDIR/fixture
+      cp ${dag} $TMPDIR/fixture/dag.nix
+
+      cat >> $TMPDIR/fixture/internal/app/app_test.go <<'EOF'
+
+      func TestBadSig(x int) {}
+      EOF
+
+      set +e
+      nix-build $TMPDIR/fixture/dag.nix \
+        -I nixpkgs=${nixpkgsPath} \
+        --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
+        --no-out-link 2> $TMPDIR/stderr
+      rc=$?
+      set -e
+
+      cat $TMPDIR/stderr
+
+      if [ "$rc" -eq 0 ]; then
+        echo "FAIL: build unexpectedly succeeded; bad-signature test function was silently skipped" >&2
+        exit 1
+      fi
+      if ! grep -q "wrong signature for TestBadSig" $TMPDIR/stderr; then
+        echo "FAIL: build failed but stderr lacks 'wrong signature for TestBadSig'" >&2
+        exit 1
+      fi
+
+      echo "PASS: build failed with expected checkTestFunc error" > $out
+    ''


### PR DESCRIPTION
## Summary

Three `_testmain.go` divergences from `cmd/go/internal/load/test.go`:

- A `func TestFoo(x int)` (wrong signature) was silently skipped; upstream `test.go:741-749` `checkTestFunc` errors. Now matches — errors with file:line for `Test*`/`Benchmark*`/`Fuzz*`/`TestMain`.
- Generic test funcs (`func TestFoo[T any](t *testing.T)`) — upstream `test.go:780` rejects via `fn.Type.TypeParams != nil`; go2nix had no check.
- Generated `_testmain.go` set `testdeps.ImportPath` but not `testdeps.ModulePath` (affects `-fuzz` corpus location). Threaded from `localpkgs.ModulePath(root)` → `testrunner` → `testmain.Options`.

## Test plan

- [x] **Unit** `TestGenerateBadSignature` (Test/Benchmark/Fuzz/TestMain), `TestGenerateGenericTestFunc`, `TestGenerateModulePath` — all FAIL on `origin/main`, PASS with fix
- [x] **Negative integration** `tests/nix/testmain_badsig_test.nix` (wired as `checks.testmain-badsig`): copies `test-helper-pkg`, injects `func TestBadSig(x int) {}`, asserts the build fails with `wrong signature for TestBadSig` in stderr
- [x] `tests/fixtures/testify-basic/dag.nix` (doCheck=true) builds end-to-end, checkPhase passes
- [x] `go test ./...`, `go vet ./...`, `nix flake check` (formatting)