### PR TITLE
dag,testrunner: thread srcOverlay into testManifest so checkPhase sees overlay content

### DIFF
--- a/docs/src/package-overrides.md
+++ b/docs/src/package-overrides.md
@@ -147,8 +147,6 @@ Keep a placeholder file in the source tree (e.g. `ui/dist/.gitkeep`) so
 the eval-time `go list` doesn't error on a `//go:embed` pattern with zero
 matches; the overlay then replaces or augments it at build time.
 
-`srcOverlay` only reaches the per-package compile derivation. The
-`doCheck` testrunner recompiles from the link derivation's `mainSrc`,
-which is the unmodified source tree — so tests see the placeholder, not
-the overlay. This is usually what you want (tests don't need the bundled
-SPA), but if a test asserts on overlaid content it will fail.
+The `doCheck` testrunner applies the same overlay before resolving
+`//go:embed` patterns and recompiling for tests, so tests see the
+overlaid content too.

--- a/go/go2nix/cmd/go2nix/testpkgs.go
+++ b/go/go2nix/cmd/go2nix/testpkgs.go
@@ -104,6 +104,7 @@ func runTestPackagesCmd(args []string) {
 		GCFlagsList:      m.GCFlags,
 		CheckFlagsList:   m.CheckFlags,
 		LocalArchives:    m.LocalArchives,
+		SrcOverlays:      m.SrcOverlays,
 	}
 
 	if err := testrunner.Run(opts); err != nil {

--- a/go/go2nix/pkg/compile/manifest.go
+++ b/go/go2nix/pkg/compile/manifest.go
@@ -195,10 +195,14 @@ type TestManifest struct {
 	// step still uses ImportcfgParts/LocalArchives (.a link objects).
 	CompileImportcfgParts []string          `json:"compileImportcfgParts,omitempty"`
 	LocalIfaces           map[string]string `json:"localIfaces,omitempty"`
-	ModuleRoot            string            `json:"moduleRoot"`
-	Tags                  []string          `json:"tags"`
-	GCFlags               []string          `json:"gcflags"`
-	CheckFlags            []string          `json:"checkFlags"`
+	// SrcOverlays maps importPath → packageOverrides.<pkg>.srcOverlay store
+	// path so the testrunner can layer the same overlay before
+	// ResolveEmbeds/compile, mirroring compile-go-pkg.sh.
+	SrcOverlays map[string]string `json:"srcOverlays,omitempty"`
+	ModuleRoot  string            `json:"moduleRoot"`
+	Tags        []string          `json:"tags"`
+	GCFlags     []string          `json:"gcflags"`
+	CheckFlags  []string          `json:"checkFlags"`
 }
 
 // LoadTestManifest reads and validates a test manifest from path.

--- a/go/go2nix/pkg/testrunner/testrunner.go
+++ b/go/go2nix/pkg/testrunner/testrunner.go
@@ -41,6 +41,13 @@ type Options struct {
 	// them just produces a confusing "could not import" failure.
 	// Nil means no filter (test everything ListLocalPackages finds).
 	LocalArchives map[string]string
+	// SrcOverlays maps importPath → packageOverrides.<pkg>.srcOverlay
+	// store path. The per-package compile drv layered this onto its
+	// pkgSrc before ResolveEmbedCfg (compile-go-pkg.sh:24-28); the
+	// testrunner walks mainSrc instead, so without re-applying the
+	// overlay any in-closure srcOverlay package fails embed resolution
+	// (or, with placeholders present, observes source-tree content).
+	SrcOverlays map[string]string
 }
 
 func (o Options) checkFlagsArgs() []string {
@@ -108,6 +115,11 @@ func Run(opts Options) error {
 		if !inScope(p.ImportPath) {
 			continue
 		}
+		if overlay, ok := opts.SrcOverlays[p.ImportPath]; ok {
+			if err := applySrcOverlay(p, overlay); err != nil {
+				return fmt.Errorf("applying srcOverlay for %s: %w", p.ImportPath, err)
+			}
+		}
 		if err := p.ResolveEmbeds(); err != nil {
 			return fmt.Errorf("listing local packages: %w", err)
 		}
@@ -118,6 +130,26 @@ func Run(opts Options) error {
 			return fmt.Errorf("testing %s: %w", p.ImportPath, err)
 		}
 	}
+	return nil
+}
+
+// applySrcOverlay layers the packageOverrides.<pkg>.srcOverlay derivation
+// onto a writable copy of the package's source dir and repoints p.SrcDir
+// at it, mirroring compile-go-pkg.sh's overlay step. Subsequent
+// ResolveEmbeds and any internal/xtest recompile then see overlay content.
+func applySrcOverlay(p *localpkgs.LocalPkg, overlay string) error {
+	dst, err := os.MkdirTemp("", "srcoverlay-*")
+	if err != nil {
+		return err
+	}
+	for _, src := range []string{p.SrcDir, overlay} {
+		cmd := exec.Command("cp", "-rL", "--no-preserve=mode", src+"/.", dst+"/")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("cp -rL %s: %w: %s", src, err, out)
+		}
+	}
+	slog.Debug("applied srcOverlay", "pkg", p.ImportPath, "overlay", overlay)
+	p.SrcDir = dst
 	return nil
 }
 

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -493,6 +493,23 @@ let
   # without -lang (silently flipping loopvar semantics for pre-1.22 modules).
   localGoVersion = goPackagesResult.goVersion or "";
 
+  # importPath → srcOverlay store path for local packages with one set.
+  # Mirrors the per-package override lookup below so the testrunner sees
+  # the same overlay the compile drv applied. Threaded into
+  # testManifestJSON.srcOverlays so checkPhase can layer overlay content
+  # before ResolveEmbeds — without this an in-closure srcOverlay package
+  # (e.g. an embedded UI dist imported by the main binary) fails the
+  # testrunner's embed resolution with "no matching files found".
+  localSrcOverlays = lib.filterAttrs (_: v: v != null) (
+    builtins.mapAttrs (
+      importPath: _:
+      let
+        override = packageOverrides.${importPath} or packageOverrides.${goPackagesResult.modulePath} or { };
+      in
+      if override ? srcOverlay then "${override.srcOverlay}" else null
+    ) allLocalPkgInfo
+  );
+
   localPackages = builtins.mapAttrs (
     importPath: pkg:
     let
@@ -1033,6 +1050,7 @@ let
           if hasTestDeps then [ "${testDepsImportcfg}/importcfg" ] else [ "${depsImportcfg}/importcfg" ];
         localIfaces = builtins.mapAttrs (importPath: pkg: "${pkg.iface}/${importPath}.x") localPackages;
       }
+      // lib.optionalAttrs (localSrcOverlays != { }) { srcOverlays = localSrcOverlays; }
       // {
         inherit moduleRoot;
         inherit tags;

--- a/packages/test-fixture-cgo-internal-test/default.nix
+++ b/packages/test-fixture-cgo-internal-test/default.nix
@@ -42,11 +42,11 @@ else
         --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
         --no-out-link)
 
-      out=$($result/bin/cgo-internal-test); echo "$out"
+      output=$($result/bin/cgo-internal-test); echo "$output"
 
       echo "=== Asserting srcOverlay won over source-tree embeds (cgo + raw paths) ==="
-      banner=$(echo "$out" | sed -n 2p)
-      version=$(echo "$out" | sed -n 3p)
+      banner=$(echo "$output" | sed -n 2p)
+      version=$(echo "$output" | sed -n 3p)
       [ "$banner" = "hello-from-overlay" ] \
         || { echo "FAIL: adder.Banner() = '$banner', want hello-from-overlay (cgo srcOverlay path)"; exit 1; }
       [ "$version" = "v1.2.3-overlay" ] \

--- a/tests/fixtures/cgo-internal-test/internal/adder/adder_test.go
+++ b/tests/fixtures/cgo-internal-test/internal/adder/adder_test.go
@@ -20,11 +20,13 @@ func TestAdd(t *testing.T) {
 	}
 }
 
-// TestBanner asserts the source-tree data.txt, not the srcOverlay value:
-// the testrunner recompiles from mainSrc (link-derivation source), which
-// srcOverlay does not touch. This pins that divergence so it's deliberate.
-func TestBanner(t *testing.T) {
-	if got := Banner(); got != "hello-from-embed" {
-		t.Fatalf("Banner() = %q, want %q", got, "hello-from-embed")
+// TestBannerFromOverlay is the testrunner srcOverlay regression: data.txt in
+// the source tree says "hello-from-embed", but dag.nix's
+// packageOverrides.<adder>.srcOverlay supplies "hello-from-overlay". The
+// testrunner now layers the same overlay (via testManifest.srcOverlays)
+// before ResolveEmbeds/compile, so checkPhase sees what the build saw.
+func TestBannerFromOverlay(t *testing.T) {
+	if got := Banner(); got != "hello-from-overlay" {
+		t.Fatalf("Banner() = %q, want %q (testrunner must apply srcOverlay)", got, "hello-from-overlay")
 	}
 }


### PR DESCRIPTION
## Summary

Closes the gap left by #87: deferred embed resolution only protected packages *outside* `localArchives`, but a `srcOverlay` target that's a build dependency of a subPackage (the common case — a UI package imported by the server binary) is in-scope, so the testrunner still ran `ResolveEmbeds()` against `mainSrc` where the overlay content doesn't exist.

`nix/dag` now emits `testManifestJSON.srcOverlays` (importPath → store path, same `packageOverrides` lookup the compile path uses; omitted when empty so non-overlay projects are manifest-neutral). `testrunner.Run` applies each overlay to a writable copy of the package's source dir before `ResolveEmbeds()` and compile, mirroring `compile-go-pkg.sh:24-28`. Tests now see the same content the binary embeds.

Also: `packages/test-fixture-cgo-internal-test/default.nix` had `out=$(...)` shadowing Nix's `$out` — renamed to `output`.

## Test plan

- [x] **Regression** `cgo-internal-test/internal/adder/adder_test.go` `TestBannerFromOverlay`: asserts `Banner() == "hello-from-overlay"` (overlay content), not the source-tree placeholder. Without the Go-side fix: `FAIL — got "hello-from-embed"`. With fix: PASS.
- [x] `testManifestJSON.srcOverlays` populated for `cgo-internal-test`; absent for `testify-basic` (no `srcOverlays` key)
- [x] `nix build .#test-fixture-cgo-internal-test` (recursive-nix wrapper) passes with the `$out`-shadowing fix
- [x] `go test ./...`, `go vet ./...`, `nix flake check` (formatting)