### PR TITLE
compile/cgo: use CXX for dynimport test-link when package has C++ files

### DIFF
--- a/go/go2nix/pkg/compile/cgo.go
+++ b/go/go2nix/pkg/compile/cgo.go
@@ -127,9 +127,19 @@ func compileCgo(opts Options, files gofiles.PkgFiles, embedFlag string) error {
 		return err
 	}
 
-	// Step 3: test link + dynimport.
-	if err := cgoTestLinkAndDynimport(cc, cgowork, opts, uid, compiledOFiles, cgoFlagsLDFLAGS, cgoLdflags, cgoCflags); err != nil {
+	// Step 3: test link + dynimport. The test link uses CXX when the
+	// package has C++ sources, matching cmd/go's gccld
+	// (cmd/go/internal/work/exec.go:2383).
+	linker := cc
+	if len(files.CXXFiles) > 0 || len(files.SwigCXXFiles) > 0 {
+		linker = cxx
+	}
+	dynFailObj, err := cgoTestLinkAndDynimport(cc, linker, cgowork, opts, uid, compiledOFiles, cgoFlagsLDFLAGS, cgoLdflags, cgoCflags)
+	if err != nil {
 		return err
+	}
+	if dynFailObj != "" {
+		compiledOFiles = append(compiledOFiles, dynFailObj)
 	}
 
 	// Generate //go:cgo_ldflag directives so the linker picks up LDFLAGS.
@@ -315,11 +325,21 @@ func compileCFiles(cc, cxx, cgowork, srcDir, uid string, files gofiles.PkgFiles,
 	return compiledOFiles, nil
 }
 
-// cgoTestLinkAndDynimport performs the cgo test link and extracts dynamic imports.
-func cgoTestLinkAndDynimport(cc, cgowork string, opts Options, uid string, compiledOFiles, cgoFlagsLDFLAGS, cgoLdflags, cgoCflags []string) error {
+// cgoTestLinkAndDynimport performs the cgo test link and extracts dynamic
+// imports. _cgo_main.c is always compiled with cc; the link itself uses
+// linker (cxx when the package has C++ sources, cc otherwise) — see
+// cmd/go's gccld (cmd/go/internal/work/exec.go:2383).
+//
+// Failure of the test link is an expected outcome (e.g. .syso files with
+// unexpected dependencies) and is handled by writing an empty
+// "dynimportfail" marker that gets packed into the archive; cmd/link
+// recognises that member name and forces external linking (golang/go#52863;
+// cmd/go/internal/work/exec.go:3284, cmd/link/internal/ld/lib.go:1139).
+// The link's stderr is suppressed accordingly, matching cmd/go.
+func cgoTestLinkAndDynimport(cc, linker, cgowork string, opts Options, uid string, compiledOFiles, cgoFlagsLDFLAGS, cgoLdflags, cgoCflags []string) (string, error) {
 	cgoMainC := filepath.Join(cgowork, "_cgo_main.c")
 	if _, err := os.Stat(cgoMainC); err != nil {
-		return nil //nolint:nilerr // missing _cgo_main.c is expected, not an error
+		return "", nil //nolint:nilerr // missing _cgo_main.c is expected, not an error
 	}
 
 	mainO := filepath.Join(cgowork, "_cgo_main_"+uid+".o")
@@ -327,7 +347,7 @@ func cgoTestLinkAndDynimport(cc, cgowork string, opts Options, uid string, compi
 	mainArgs = append(mainArgs, cgoCflags...)
 	mainArgs = append(mainArgs, cgoMainC, "-o", mainO)
 	if err := runIn("", cc, mainArgs...); err != nil {
-		return fmt.Errorf("cc _cgo_main.c: %w", err)
+		return "", fmt.Errorf("cc _cgo_main.c: %w", err)
 	}
 
 	testLinkO := filepath.Join(cgowork, "_cgo__"+uid+".o")
@@ -335,34 +355,26 @@ func cgoTestLinkAndDynimport(cc, cgowork string, opts Options, uid string, compi
 	linkArgs = append(linkArgs, "-lpthread")
 	linkArgs = append(linkArgs, cgoFlagsLDFLAGS...)
 	linkArgs = append(linkArgs, cgoLdflags...)
-	if err := runIn("", cc, linkArgs...); err != nil {
-		// Test link may fail due to unresolved external symbols.
-		// Retry allowing unresolved symbols since this binary is
-		// only used to extract dynamic imports.
-		var flag string
-		switch opts.goos {
-		case "darwin":
-			flag = "-Wl,-undefined,dynamic_lookup"
-		default:
-			flag = "-Wl,--unresolved-symbols=ignore-all"
+	cmd := exec.Command(linker, linkArgs...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		slog.Debug("cgo test link failed; emitting dynimportfail marker", "err", err, "out", string(out))
+		fail := filepath.Join(cgowork, "dynimportfail")
+		if werr := os.WriteFile(fail, nil, 0o644); werr != nil {
+			return "", werr
 		}
-		if err2 := runIn("", cc, append(linkArgs, flag)...); err2 != nil {
-			slog.Debug("cgo test link failed (no dynamic imports)", "err", err)
-			return nil //nolint:nilerr // test link failure is non-fatal, just means no dynamic imports
-		}
+		return fail, nil
 	}
-	if _, err := os.Stat(testLinkO); err == nil {
-		pkgName := extractPackageName(filepath.Join(cgowork, "_cgo_gotypes.go"))
-		dynOut := filepath.Join(cgowork, "_cgo_import_"+uid+".go")
-		if err := runIn(opts.SrcDir, "go", "tool", "cgo",
-			"-dynimport", testLinkO,
-			"-dynout", dynOut,
-			"-dynpackage", pkgName,
-			"-dynlinker"); err != nil {
-			return fmt.Errorf("cgo dynimport: %w", err)
-		}
+
+	pkgName := extractPackageName(filepath.Join(cgowork, "_cgo_gotypes.go"))
+	dynOut := filepath.Join(cgowork, "_cgo_import_"+uid+".go")
+	if err := runIn(opts.SrcDir, "go", "tool", "cgo",
+		"-dynimport", testLinkO,
+		"-dynout", dynOut,
+		"-dynpackage", pkgName,
+		"-dynlinker"); err != nil {
+		return "", fmt.Errorf("cgo dynimport: %w", err)
 	}
-	return nil
+	return "", nil
 }
 
 // filterCppFlags removes -lc++ and -lstdc++ from flags when no C++ sources

--- a/packages/test-fixture-cxx-pkgconfig/default.nix
+++ b/packages/test-fixture-cxx-pkgconfig/default.nix
@@ -45,7 +45,14 @@ else
       result=$(nix-build ${go2nixSrc}/tests/fixtures/cxx-pkgconfig/dag.nix \
         -I nixpkgs=${nixpkgsPath} \
         --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
-        --no-out-link)
+        --no-out-link 2>build.log)
+      cat build.log >&2
+
+      # The dynimport test-link uses CXX when the package has C++ sources
+      # (cmd/go's gccld); a CC-driven attempt would emit
+      # "undefined reference to symbol '_ZdlPvm'" before the build recovers.
+      ! grep -qE 'undefined reference|_ZdlPvm' build.log \
+        || { echo "FAIL: dynimport test-link used CC for a CXXFiles package"; exit 1; }
 
       got=$($result/bin/cxx-pkgconfig)
       [ "$got" = "hello-snappy" ] || { echo "FAIL: got '$got', want hello-snappy"; exit 1; }


### PR DESCRIPTION
## Summary

Two divergences in `cgoTestLinkAndDynimport` from `cmd/go/internal/work/exec.go`:

- `gccld` (exec.go:2383) uses CXX when `len(p.CXXFiles) > 0 || len(p.SwigCXXFiles) > 0`; go2nix always used CC. With C++ object files this failed on `_ZdlPvm` (operator delete) and retried with `--unresolved-symbols=ignore-all` — worked but emitted stderr noise.
- `dynimport` (exec.go:3284, golang/go#52863) on link failure writes an empty `dynimportfail` archive member that `cmd/link` checks by name (lib.go:1139 `arhdr.name == "dynimportfail"`) to force external linking; go2nix retried with ignore-all instead.

The caller now picks `linker = cxx` when `CXXFiles`/`SwigCXXFiles` are present (the `_cgo_main.c` compile stays CC). The link uses `CombinedOutput()` so stderr is captured, not streamed. On failure, `cgowork/dynimportfail` is written and packed into the `.a` via the existing `pack r` step; the retry-with-ignore-all path is removed.

## Test plan

- [x] **Regression** `test-fixture-cxx-pkgconfig` — captures inner build stderr, asserts `! grep -qE 'undefined reference|_ZdlPvm'`. Before: `_ZdlPvm@@CXXABI_1.3.9` undefined + `DSO missing from command line`. After: clean; `ar t snap.a` shows no `dynimportfail` member (CXX link succeeded)
- [x] `cgo-internal-test` (C-only cgo) unchanged — root dynamic, `purebin` static; `cxx-cgo` (#95) unchanged
- [x] `go test ./...`, `go vet ./...`, `nix flake check` (formatting)