### PR TITLE
compile/cgo: deterministic cgo compile output (strip cgowork from -trimpath)

### DIFF
--- a/go/go2nix/pkg/compile/cgo.go
+++ b/go/go2nix/pkg/compile/cgo.go
@@ -24,6 +24,13 @@ func compileCgo(opts Options, files gofiles.PkgFiles, embedFlag string) error {
 	}
 	defer os.RemoveAll(cgowork) //nolint:errcheck
 
+	// cgowork carries a random MkdirTemp suffix; prepend it to the
+	// -trimpath rewrite (first-match wins, cmd/internal/objabi/line.go:72)
+	// so it's stripped from go tool compile output before the broader
+	// TrimPath rule can leave the suffix behind. Mirrors cmd/go's
+	// `rewrite += objdir + "=>"` (cmd/go/internal/work/gc.go:323).
+	opts.trimRewrite = cgowork + "=>;" + opts.trimRewrite
+
 	cc := envOrDefault("CC", "gcc")
 	cxx := envOrDefault("CXX", "g++")
 
@@ -55,8 +62,18 @@ func compileCgo(opts Options, files gofiles.PkgFiles, embedFlag string) error {
 		}
 	}
 
-	// Ensure absolute build paths don't leak into debug info for reproducibility.
-	cgoCflags = append([]string{"-fdebug-prefix-map=" + opts.SrcDir + "=."}, cgoCflags...)
+	// Keep absolute build paths out of gcc/g++ object files. Mirrors
+	// cmd/go's compilerCmd (cmd/go/internal/work/exec.go:2484-2500): map
+	// the work dir to /tmp/go-build, and -gno-record-gcc-switches so the
+	// flag itself (which contains cgowork's random suffix) isn't recorded.
+	// Also map SrcDir so source-file debug info is store-path-free.
+	ccReproFlags := []string{
+		"-ffile-prefix-map=" + cgowork + "=/tmp/go-build",
+		"-ffile-prefix-map=" + opts.SrcDir + "=.",
+		"-gno-record-gcc-switches",
+	}
+	cgoCflags = append(slices.Clone(ccReproFlags), cgoCflags...)
+	cgoCxxflags = append(slices.Clone(ccReproFlags), cgoCxxflags...)
 
 	// Copy headers.
 	for _, h := range files.HFiles {
@@ -365,13 +382,15 @@ func cgoTestLinkAndDynimport(cc, linker, cgowork string, opts Options, uid strin
 		return fail, nil
 	}
 
+	// cmd/go passes -dynlinker only for runtime/cgo
+	// (cmd/go/internal/work/exec.go:3294-3296); user packages don't need
+	// the //go:cgo_dynamic_linker directive it emits.
 	pkgName := extractPackageName(filepath.Join(cgowork, "_cgo_gotypes.go"))
 	dynOut := filepath.Join(cgowork, "_cgo_import_"+uid+".go")
 	if err := runIn(opts.SrcDir, "go", "tool", "cgo",
 		"-dynimport", testLinkO,
 		"-dynout", dynOut,
-		"-dynpackage", pkgName,
-		"-dynlinker"); err != nil {
+		"-dynpackage", pkgName); err != nil {
 		return "", fmt.Errorf("cgo dynimport: %w", err)
 	}
 	return "", nil

--- a/packages/test-fixture-cgo-internal-test/default.nix
+++ b/packages/test-fixture-cgo-internal-test/default.nix
@@ -67,5 +67,16 @@ else
         | grep -qE '^[[:space:]]*path[[:space:]]+example.com/cgo-internal-test$' \
         || { echo "FAIL: root binary BuildInfo.Path should be the module path"; exit 1; }
 
+      echo "=== Asserting cgowork temp dir does not leak into compiled archives ==="
+      drv=$(nix-instantiate ${go2nixSrc}/tests/fixtures/cgo-internal-test/dag.nix \
+        -I nixpkgs=${nixpkgsPath} \
+        --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" 2>/dev/null)
+      for d in $(nix-store -q --references "$drv" | grep -- -golocal-); do
+        a=$(find "$(nix-store -q --outputs "$d")" -name '*.a')
+        if grep -aq cgo_work_ "$a"; then
+          echo "FAIL: $a embeds cgowork temp dir (non-reproducible)"; exit 1
+        fi
+      done
+
       echo "PASS: cgo-internal-test" > $out
     ''

--- a/packages/test-fixture-cxx-pkgconfig/default.nix
+++ b/packages/test-fixture-cxx-pkgconfig/default.nix
@@ -63,5 +63,20 @@ else
       patchelf --print-needed $result/bin/cxx-pkgconfig | tee /dev/stderr | grep -q "^libsnappy" \
         || { echo "FAIL: cxx-pkgconfig should NEEDED libsnappy.so"; exit 1; }
 
+      # cgowork's MkdirTemp suffix used to leak into go tool compile output
+      # (the broader TrimPath rewrite left cgo_work_<uid>_<random>/ behind in
+      # __.PKGDEF and _go_.o). The cgowork-specific rewrite rule strips it to
+      # bare filenames, so the dir name must not appear in any compiled .a.
+      echo "=== Asserting cgowork temp dir does not leak into compiled archives ==="
+      drv=$(nix-instantiate ${go2nixSrc}/tests/fixtures/cxx-pkgconfig/dag.nix \
+        -I nixpkgs=${nixpkgsPath} \
+        --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" 2>/dev/null)
+      for d in $(nix-store -q --references "$drv" | grep -- -golocal-); do
+        a=$(find "$(nix-store -q --outputs "$d")" -name '*.a')
+        if grep -aq cgo_work_ "$a"; then
+          echo "FAIL: $a embeds cgowork temp dir (non-reproducible)"; exit 1
+        fi
+      done
+
       echo "PASS: cxx-pkgconfig" > $out
     ''


### PR DESCRIPTION
## Summary

`nix-build --check` on cgo `golocal-*` drvs reported non-determinism. Only `__.PKGDEF` and `_go_.o` differed; gcc/g++ `.o` members were already byte-identical (no `-g`, no `.debug_*`). The leak was the `os.MkdirTemp` random suffix surviving the existing `-trimpath` rewrite — `cgo_work_<pkg>_<random>/_cgo_gotypes.go` etc. ended up in the Go compiler output.

Fix mirrors `cmd/go/internal/work/gc.go:323` (`rewrite += a.Objdir + "=>"`): prepend `cgowork + "=>;"` to `opts.trimRewrite` (first-match wins per `cmd/internal/objabi/line.go:72`). Also hardened gcc-side flags to match `compilerCmd` (exec.go:2484-2500): `-ffile-prefix-map` for cgowork+SrcDir and `-gno-record-gcc-switches`, now applied to CXXFLAGS too. Dropped the unconditional `-dynlinker` from `go tool cgo -dynimport` — upstream (exec.go:3294-3296) only passes it for `runtime/cgo`, which go2nix never compiles via this path.

## Test plan

- [x] `nix-build --check` on `golocal-...-snap.drv` → exit 0 (was: `may not be deterministic: output ... differs`)
- [x] **Regression** in both cgo fixture wrappers: `! grep -aq cgo_work_` on every `golocal-*.a` (`--check` is unsupported via the recursive-nix daemon). With the cgo.go fix stashed: `FAIL: ...snap.a embeds cgowork temp dir`. With fix: PASS.
- [x] `test-golden-vs-gobuild` 10/10 IDENTICAL; `cgo-internal-test` / `cxx-cgo` / `cxx-pkgconfig` all build and run unchanged
- [x] `go test ./...`, `go vet ./...`, `nix flake check` (formatting)