### PR TITLE
tests: assert ldflags -X output, exercise checkFlags, wire contentAddressed into CI

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,11 @@
           test-fixture-xtest-local-dep = callPkgWith ./packages/test-fixture-xtest-local-dep/default.nix {
             inherit flake system;
           };
+          test-fixture-xtest-local-dep-ca =
+            callPkgWith ./packages/test-fixture-xtest-local-dep-ca/default.nix
+              {
+                inherit flake system;
+              };
           test-fixture-cgo-internal-test = callPkgWith ./packages/test-fixture-cgo-internal-test/default.nix {
             inherit flake system;
           };

--- a/packages/test-fixture-xtest-local-dep-ca/default.nix
+++ b/packages/test-fixture-xtest-local-dep-ca/default.nix
@@ -1,0 +1,62 @@
+# default mode fixture test: contentAddressed = true.
+#
+# Builds the dag-ca.nix variant of xtest-local-dep with ca-derivations
+# enabled. Asserts the per-package golocal-* drvs declare both `out` and
+# `iface` outputs (the CA early-cutoff iface split) and the binary runs.
+#
+# This relies on the inner recursive-nix store accepting CA derivations.
+{
+  flake,
+  pkgs,
+  system,
+  ...
+}:
+if !(flake.packages.${system} ? go2nix-nix-plugin) then
+  pkgs.runCommand "test-dag-fixture-xtest-local-dep-ca-unsupported"
+    { meta.platforms = pkgs.lib.platforms.linux; }
+    ''
+      echo "test-dag-fixture-xtest-local-dep-ca requires go2nix-nix-plugin (Linux only)" >&2
+      exit 1
+    ''
+else
+  let
+    plugin = flake.packages.${system}.go2nix-nix-plugin;
+    nix = pkgs.nixVersions.nix_2_34;
+
+    nixpkgsPath = pkgs.path;
+    go2nixSrc = flake;
+  in
+  pkgs.runCommand "test-dag-fixture-xtest-local-dep-ca"
+    {
+      nativeBuildInputs = [ nix ];
+      requiredSystemFeatures = [
+        "recursive-nix"
+        "ca-derivations"
+      ];
+    }
+    ''
+      export HOME=$(mktemp -d)
+      export NIX_CONFIG="extra-experimental-features = nix-command recursive-nix ca-derivations"
+
+      echo "=== Building xtest-local-dep (contentAddressed) ==="
+      result=$(nix-build ${go2nixSrc}/tests/fixtures/xtest-local-dep/dag-ca.nix \
+        -I nixpkgs=${nixpkgsPath} \
+        --option extra-experimental-features 'nix-command ca-derivations' \
+        --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
+        --no-out-link)
+
+      echo "=== Asserting per-package drvs declare iface output (CA split) ==="
+      top_drv=$(nix-instantiate ${go2nixSrc}/tests/fixtures/xtest-local-dep/dag-ca.nix \
+        -I nixpkgs=${nixpkgsPath} \
+        --option extra-experimental-features 'nix-command ca-derivations' \
+        --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so")
+      sample_local=$(nix-store -q --references "$top_drv" | grep "golocal-" | head -1)
+      [ -n "$sample_local" ] || { echo "FAIL: no golocal-* drv in closure"; exit 1; }
+      outputs=$(nix derivation show "$sample_local^*" \
+        | grep -oE '"(out|iface)"' | sort -u | tr -d '"' | tr '\n' ' ')
+      [ "$outputs" = "iface out " ] || { echo "FAIL: expected outputs 'iface out ', got '$outputs' on $sample_local"; exit 1; }
+
+      "$result/bin/xtest-local-dep"
+
+      echo "PASS: xtest-local-dep-ca (per-package outputs: $outputs)" > $out
+    ''

--- a/packages/test-package-dotool/default.nix
+++ b/packages/test-package-dotool/default.nix
@@ -15,5 +15,8 @@ import ../test-lib/run-dag-test.nix {
   };
   vendorHash = "sha256-cdW4DhPUubSvJ9edTYgum3ppEkEPuoYFrU+gonyCpOk=";
   dagFile = "${flake}/tests/packages/dotool/dag.nix";
-  checkCommand = "$result/bin/dotool --version";
+  checkCommand = ''
+    output=$($result/bin/dotool --version)
+    [ "$output" = "1.6" ] || { echo "FAIL: dotool --version = '$output', want '1.6' (ldflags -X main.Version not applied)"; exit 1; }
+  '';
 }

--- a/tests/fixtures/testify-basic/dag.nix
+++ b/tests/fixtures/testify-basic/dag.nix
@@ -14,4 +14,7 @@ goEnv.buildGoApplication {
   src = ./.;
   goLock = ./go2nix.toml;
   doCheck = true;
+  # greeter_test.go has a TestSkipMe that always fails; this proves
+  # checkFlags reach the test binary.
+  checkFlags = [ "-test.run=^TestGreet$" ];
 }

--- a/tests/fixtures/testify-basic/internal/greeter/greeter_test.go
+++ b/tests/fixtures/testify-basic/internal/greeter/greeter_test.go
@@ -9,3 +9,9 @@ import (
 func TestGreet(t *testing.T) {
 	assert.Equal(t, "hello world", Greet("world"))
 }
+
+// TestSkipMe must NOT run — dag.nix sets checkFlags=["-test.run=^TestGreet$"].
+// If checkFlags don't reach the testrunner this fails the build.
+func TestSkipMe(t *testing.T) {
+	t.Fatal("checkFlags -test.run did not reach the test binary")
+}


### PR DESCRIPTION
## Summary

Three coverage gaps from the audit, all test-only:

- **`ldflags -X` runtime value** — `test-package-dotool` set `-X main.Version=1.6` and ran `--version` but never asserted. Now `[ "$output" = "1.6" ]`.
- **`checkFlags` reach the test binary** — no fixture set `checkFlags`. `testify-basic` adds `func TestSkipMe(t *testing.T) { t.Fatal(...) }` and `checkFlags = ["-test.run=^TestGreet$"]`. If checkFlags don't reach the testrunner, `TestSkipMe` runs and fails the build. Self-checking.
- **`contentAddressed` in CI** — `dag-ca.nix` was only run via the manual `tests/test-ca.sh`. New `test-fixture-xtest-local-dep-ca` wraps it (`requiredSystemFeatures = ["recursive-nix" "ca-derivations"]` so builders without CA support skip), asserts `golocal-*` drvs declare both `out` and `iface` outputs, runs the binary.

## Test plan

- [x] dotool wrapper builds; `--version` = `"1.6"`
- [x] testify-basic with `checkFlags` → PASS (only `TestGreet` runs); without → `--- FAIL: TestSkipMe`
- [x] `test-fixture-xtest-local-dep-ca` builds, per-package outputs `iface out`, binary runs
- [x] `test-golden-vs-gobuild` still PASS; `nix flake check` (formatting)