### PR TITLE
tests: add unit coverage for ModulePath, ResolveEmbeds, applySrcOverlay, Fips140Enabled

### DIFF
--- a/go/go2nix/pkg/buildinfo/buildinfo_test.go
+++ b/go/go2nix/pkg/buildinfo/buildinfo_test.go
@@ -135,6 +135,23 @@ func TestBuildSettingsMatchCmdGo(t *testing.T) {
 	}
 }
 
+func TestFips140Enabled(t *testing.T) {
+	for _, tt := range []struct {
+		v    string
+		want bool
+	}{
+		{"", false},
+		{"off", false},
+		{"latest", true},
+		{"v1.0.0", true},
+		{"inprocess", true},
+	} {
+		if got := Fips140Enabled(tt.v); got != tt.want {
+			t.Errorf("Fips140Enabled(%q) = %v, want %v", tt.v, got, tt.want)
+		}
+	}
+}
+
 func TestGenerateModinfoNoGoSum(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(`module example.com/myapp

--- a/go/go2nix/pkg/localpkgs/localpkgs_test.go
+++ b/go/go2nix/pkg/localpkgs/localpkgs_test.go
@@ -397,6 +397,91 @@ func TestExtEmbed(t *testing.T) { _ = fs }
 	}
 }
 
+func TestModulePath(t *testing.T) {
+	t.Run("module directive", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "go.mod"), "module example.com/myapp\n\ngo 1.21\n")
+		got, err := ModulePath(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "example.com/myapp" {
+			t.Errorf("ModulePath = %q, want example.com/myapp", got)
+		}
+	})
+	t.Run("no go.mod", func(t *testing.T) {
+		_, err := ModulePath(t.TempDir())
+		if err == nil {
+			t.Fatal("expected error for missing go.mod, got nil")
+		}
+	})
+	t.Run("no module directive", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "go.mod"), "go 1.21\n")
+		got, err := ModulePath(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "" {
+			t.Errorf("ModulePath = %q, want empty (modfile.ModulePath returns \"\" when no module line)", got)
+		}
+	})
+}
+
+func TestResolveEmbeds(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"a.txt", "b.txt", "test.json", "x.yaml"} {
+		writeFile(t, filepath.Join(dir, name), "x")
+	}
+
+	p := &LocalPkg{
+		ImportPath:         "example.com/test",
+		SrcDir:             dir,
+		EmbedPatterns:      []string{"*.txt"},
+		TestEmbedPatterns:  []string{"test.json"},
+		XTestEmbedPatterns: []string{"x.yaml"},
+	}
+	if err := p.ResolveEmbeds(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Equal(p.EmbedFiles, []string{"a.txt", "b.txt"}) {
+		t.Errorf("EmbedFiles = %v, want [a.txt b.txt]", p.EmbedFiles)
+	}
+	if p.EmbedCfg == nil {
+		t.Fatal("EmbedCfg = nil")
+	}
+	if got := p.EmbedCfg.Patterns["*.txt"]; !slices.Equal(got, []string{"a.txt", "b.txt"}) {
+		t.Errorf("EmbedCfg.Patterns[*.txt] = %v, want [a.txt b.txt]", got)
+	}
+	if p.EmbedCfg.Files["a.txt"] != filepath.Join(dir, "a.txt") {
+		t.Errorf("EmbedCfg.Files[a.txt] = %q, want absolute path under SrcDir", p.EmbedCfg.Files["a.txt"])
+	}
+
+	if !slices.Equal(p.TestEmbedFiles, []string{"test.json"}) {
+		t.Errorf("TestEmbedFiles = %v, want [test.json]", p.TestEmbedFiles)
+	}
+	if p.TestEmbedCfg == nil || p.TestEmbedCfg.Files["test.json"] != filepath.Join(dir, "test.json") {
+		t.Errorf("TestEmbedCfg.Files[test.json] = %v", p.TestEmbedCfg)
+	}
+
+	if !slices.Equal(p.XTestEmbedFiles, []string{"x.yaml"}) {
+		t.Errorf("XTestEmbedFiles = %v, want [x.yaml]", p.XTestEmbedFiles)
+	}
+	if p.XTestEmbedCfg == nil || p.XTestEmbedCfg.Files["x.yaml"] != filepath.Join(dir, "x.yaml") {
+		t.Errorf("XTestEmbedCfg.Files[x.yaml] = %v", p.XTestEmbedCfg)
+	}
+
+	// Empty patterns yield nil cfg and an empty (not nil) file slice.
+	empty := &LocalPkg{SrcDir: dir}
+	if err := empty.ResolveEmbeds(); err != nil {
+		t.Fatal(err)
+	}
+	if empty.EmbedCfg != nil || empty.EmbedFiles == nil || len(empty.EmbedFiles) != 0 {
+		t.Errorf("empty patterns: EmbedCfg=%v EmbedFiles=%v, want nil / []", empty.EmbedCfg, empty.EmbedFiles)
+	}
+}
+
 func TestListLocalPackages_DefersBrokenEmbed(t *testing.T) {
 	root := t.TempDir()
 

--- a/go/go2nix/pkg/testrunner/testrunner_test.go
+++ b/go/go2nix/pkg/testrunner/testrunner_test.go
@@ -114,6 +114,61 @@ func TestInternalTestPkgFiles(t *testing.T) {
 	}
 }
 
+func TestApplySrcOverlay(t *testing.T) {
+	srcDir := t.TempDir()
+	overlay := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(srcDir, "a.txt"), []byte("from-src"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "shared.txt"), []byte("from-src"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(overlay, "dist"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(overlay, "dist", "b.txt"), []byte("from-overlay"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(overlay, "shared.txt"), []byte("from-overlay"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &localpkgs.LocalPkg{ImportPath: "example.com/test", SrcDir: srcDir}
+	if err := applySrcOverlay(p, overlay); err != nil {
+		t.Fatal(err)
+	}
+
+	if p.SrcDir == srcDir {
+		t.Fatal("SrcDir not repointed")
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(p.SrcDir) })
+
+	mustRead := func(rel string) string {
+		t.Helper()
+		b, err := os.ReadFile(filepath.Join(p.SrcDir, rel))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b)
+	}
+	if got := mustRead("a.txt"); got != "from-src" {
+		t.Errorf("a.txt = %q, want from-src (srcDir content preserved)", got)
+	}
+	if got := mustRead("dist/b.txt"); got != "from-overlay" {
+		t.Errorf("dist/b.txt = %q, want from-overlay (overlay content layered in)", got)
+	}
+	if got := mustRead("shared.txt"); got != "from-overlay" {
+		t.Errorf("shared.txt = %q, want from-overlay (overlay wins on conflict)", got)
+	}
+
+	// Result must be writable so the testrunner can drop generated files
+	// (xtest internal-test recompile writes alongside the source).
+	if err := os.WriteFile(filepath.Join(p.SrcDir, "a.txt"), []byte("mutated"), 0o644); err != nil {
+		t.Errorf("overlaid SrcDir not writable: %v", err)
+	}
+}
+
 func TestSanitize(t *testing.T) {
 	tests := []struct {
 		input, want string


### PR DESCRIPTION
## Summary

Direct unit tests for logic-bearing functions that previously had only integration or negative-case coverage. Test-only — zero production-code changes.

- `localpkgs.ModulePath` (#93) — 3 cases: valid `module` directive; missing go.mod → error; go.mod without `module` line → `""`.
- `(*LocalPkg).ResolveEmbeds` (#87) — positive case on a hand-built `LocalPkg`: asserts `EmbedFiles`/`EmbedCfg` (incl. `Patterns` and absolute-path `Files` mapping), `TestEmbedFiles`/`TestEmbedCfg`, `XTestEmbedFiles`/`XTestEmbedCfg` all populated; plus the empty-patterns → nil/`[]` branch.
- `testrunner.applySrcOverlay` (#96) — srcDir + overlay (with nested subdir) → repointed `SrcDir` contains both; overlay wins on conflict; result writable.
- `buildinfo.Fips140Enabled` (#100) — table: `""`/`"off"` → false; `"latest"`/`"v1.0.0"`/`"inprocess"` → true.

`compile.CompileGoPackage` routing and `linkbinary.runLinkBinary`/`resolve.Resolve` scoped out — the dispatch is inline after subprocess calls (no separate routing func), and the latter two are integration-only by nature (covered by the golden test and dynamic-mode wrappers).

## Test plan

- [x] `go test ./...` 14/14 ok; all four new tests pass
- [x] `go vet ./...`, `nix flake check` (formatting)