### PR TITLE
tests: add drv-hash canary and eval-stats threshold guards

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -127,6 +127,12 @@
           test-golden-vs-gobuild = callPkgWith ./packages/test-golden-vs-gobuild/default.nix {
             inherit flake system;
           };
+          test-drv-canary = callPkgWith ./packages/test-drv-canary/default.nix {
+            inherit flake system;
+          };
+          test-eval-stats = callPkgWith ./packages/test-eval-stats/default.nix {
+            inherit flake system;
+          };
 
           go2nix-testgen = callPkgWith ./packages/go2nix-testgen/default.nix {
             inherit flake system;

--- a/packages/test-drv-canary/default.nix
+++ b/packages/test-drv-canary/default.nix
@@ -1,0 +1,118 @@
+# Semantic-stability canary for nix/dag/*.nix.
+#
+# A pure refactor of the Nix-side derivation builders must produce
+# identical .drv paths (same derivationStrict input). Any change means
+# the refactor altered an env key, attr value, or input — i.e., semantic
+# drift, even if the build result happens to be the same.
+#
+# Regenerate expected.txt with ./scripts/update-drv-canary.sh after any
+# change to go/go2nix/, packages/go2nix-nix-plugin/, nix/dag/hooks/, or
+# the nixpkgs flake input. A change to nix/dag/*.nix alone should NOT
+# require updating this file — that's the point of the canary.
+{
+  flake,
+  pkgs,
+  system,
+  ...
+}:
+if !(flake.packages.${system} ? go2nix-nix-plugin) then
+  pkgs.runCommand "test-drv-canary-unsupported" { meta.platforms = pkgs.lib.platforms.linux; } ''
+    echo "test-drv-canary requires go2nix-nix-plugin (Linux only)" >&2
+    exit 1
+  ''
+else
+  let
+    plugin = flake.packages.${system}.go2nix-nix-plugin;
+    nix = pkgs.nixVersions.nix_2_34;
+    go = pkgs.go_1_26;
+
+    nixpkgsPath = pkgs.path;
+    go2nixSrc = flake;
+
+    mkGoModCache =
+      {
+        name,
+        modDir,
+        outputHash,
+      }:
+      pkgs.stdenvNoCC.mkDerivation {
+        inherit name outputHash;
+        outputHashMode = "recursive";
+        outputHashAlgo = "sha256";
+        nativeBuildInputs = [
+          go
+          pkgs.cacert
+        ];
+        dontUnpack = true;
+        buildPhase = ''
+          export HOME=$TMPDIR
+          export GOMODCACHE=$out
+          cd ${go2nixSrc}/${modDir}
+          go mod download
+        '';
+        installPhase = "true";
+      };
+
+    testifyModules = mkGoModCache {
+      name = "testify-basic-gomodcache";
+      modDir = "tests/fixtures/testify-basic";
+      outputHash = "sha256-jfyOzY3bhiTD5GZKF9aIGAYL2Bequp76/LGLc0LFFGQ=";
+    };
+    tortureModules = mkGoModCache {
+      name = "torture-app-full-gomodcache";
+      modDir = "tests/fixtures/torture-project/app-full";
+      outputHash = "sha256-uQKbuVSzWJhqbvPwi1KL5OKlYpPjHoA437m7zgQlrbA=";
+    };
+
+    # Produces the actual <name> <drvPath> lines. Exposed via passthru so
+    # update-drv-canary.sh can build it directly even when the diff fails.
+    actual =
+      pkgs.runCommand "test-drv-canary-actual"
+        {
+          nativeBuildInputs = [ nix ];
+          requiredSystemFeatures = [ "recursive-nix" ];
+        }
+        ''
+          export HOME=$(mktemp -d)
+          export NIX_CONFIG="extra-experimental-features = nix-command recursive-nix"
+          PLUGIN="${plugin}/lib/nix/plugins/libgo2nix_plugin.so"
+
+          inst() {
+            local name="$1" gomodcache="$2" file="$3"
+            drv=$(GOMODCACHE="$gomodcache" nix-instantiate \
+              -I nixpkgs=${nixpkgsPath} \
+              --option plugin-files "$PLUGIN" \
+              "${go2nixSrc}/$file" 2>/dev/null)
+            echo "$name $drv"
+          }
+
+          {
+            inst testify-basic    "${testifyModules}" tests/fixtures/testify-basic/dag.nix
+            inst xtest-local-dep  "$TMPDIR/empty-gmc" tests/fixtures/xtest-local-dep/dag.nix
+            inst cgo-internal-test "$TMPDIR/empty-gmc" tests/fixtures/cgo-internal-test/dag.nix
+            inst torture-app-full "${tortureModules}" tests/fixtures/torture-project/dag-app-full.nix
+          } > $out
+        '';
+  in
+  pkgs.runCommand "test-drv-canary"
+    {
+      passthru = { inherit actual; };
+    }
+    ''
+      grep -v '^#' ${./expected.txt} > expected.txt
+      if ! diff -u expected.txt ${actual}; then
+        cat >&2 <<'EOF'
+
+      FAIL: .drv hashes changed.
+
+      If you changed go/go2nix/, packages/go2nix-nix-plugin/, nix/dag/hooks/,
+      or the nixpkgs flake input, regenerate with:
+        ./scripts/update-drv-canary.sh
+
+      If you ONLY changed nix/dag/*.nix or nix/helpers.nix, this is a
+      regression: pure refactors must produce identical .drv paths.
+      EOF
+        exit 1
+      fi
+      echo "PASS: .drv hashes match canary" > $out
+    ''

--- a/packages/test-drv-canary/expected.txt
+++ b/packages/test-drv-canary/expected.txt
@@ -1,0 +1,9 @@
+# Expected .drv hashes for the nix/dag semantic-stability canary.
+# Regenerate with ./scripts/update-drv-canary.sh after any change to
+# go/go2nix/, packages/go2nix-nix-plugin/, nix/dag/hooks/, or the nixpkgs
+# flake input. A change to nix/dag/*.nix alone should NOT require
+# updating this file.
+testify-basic /nix/store/clc3wsy19kvianrnvhw13fl037dyzsgq-testify-basic-0.0.1.drv
+xtest-local-dep /nix/store/5z2yjyjvcahcywiwk176sl820l2809vn-xtest-local-dep-0.0.1.drv
+cgo-internal-test /nix/store/2fcqq9ysndbk1bh6xcjrgr4bb720sb04-cgo-internal-test-0.0.1.drv
+torture-app-full /nix/store/0gkbcp1fbh35j17jd3jdl7bnglp3spm9-torture-app-full-0.0.1.drv

--- a/packages/test-eval-stats/default.nix
+++ b/packages/test-eval-stats/default.nix
@@ -1,0 +1,97 @@
+# Eval-time regression guard for nix/dag/*.nix.
+#
+# Asserts deterministic NIX_SHOW_STATS counts (not cpuTime — counts are
+# machine-independent) for instantiating torture-project/dag-app-full.nix
+# stay below thresholds. Catches refactors that accidentally allocate
+# more thunks/calls (e.g., a let-hoist that creates a thunk-per-iteration
+# instead of sharing).
+{
+  flake,
+  pkgs,
+  system,
+  ...
+}:
+if !(flake.packages.${system} ? go2nix-nix-plugin) then
+  pkgs.runCommand "test-eval-stats-unsupported" { meta.platforms = pkgs.lib.platforms.linux; } ''
+    echo "test-eval-stats requires go2nix-nix-plugin (Linux only)" >&2
+    exit 1
+  ''
+else
+  let
+    plugin = flake.packages.${system}.go2nix-nix-plugin;
+    nix = pkgs.nixVersions.nix_2_34;
+    go = pkgs.go_1_26;
+
+    nixpkgsPath = pkgs.path;
+    go2nixSrc = flake;
+
+    tortureModules = pkgs.stdenvNoCC.mkDerivation {
+      name = "torture-app-full-gomodcache";
+      outputHashMode = "recursive";
+      outputHashAlgo = "sha256";
+      outputHash = "sha256-uQKbuVSzWJhqbvPwi1KL5OKlYpPjHoA437m7zgQlrbA=";
+      nativeBuildInputs = [
+        go
+        pkgs.cacert
+      ];
+      dontUnpack = true;
+      buildPhase = ''
+        export HOME=$TMPDIR
+        export GOMODCACHE=$out
+        cd ${go2nixSrc}/tests/fixtures/torture-project/app-full
+        go mod download
+      '';
+      installPhase = "true";
+    };
+  in
+  pkgs.runCommand "test-eval-stats"
+    {
+      nativeBuildInputs = [
+        nix
+        pkgs.jq
+      ];
+      requiredSystemFeatures = [ "recursive-nix" ];
+    }
+    ''
+      export HOME=$(mktemp -d)
+      export NIX_CONFIG="extra-experimental-features = nix-command recursive-nix"
+
+      GOMODCACHE=${tortureModules} \
+      NIX_SHOW_STATS=1 NIX_SHOW_STATS_PATH=$TMPDIR/stats.json \
+        nix-instantiate \
+          -I nixpkgs=${nixpkgsPath} \
+          --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
+          ${go2nixSrc}/tests/fixtures/torture-project/dag-app-full.nix \
+        > /dev/null
+
+      echo "=== NIX_SHOW_STATS (torture-project/dag-app-full.nix) ==="
+      jq '{nrFunctionCalls, nrPrimOpCalls, nrThunks, nrLookups, nrOpUpdates, cpuTime}' $TMPDIR/stats.json
+
+      fail=0
+      check() {
+        local key="$1" max="$2"
+        val=$(jq -r ".$key" $TMPDIR/stats.json)
+        if [ "$val" -ge "$max" ]; then
+          echo "FAIL: $key = $val >= threshold $max"
+          fail=1
+        else
+          echo "  OK: $key = $val < threshold $max"
+        fi
+      }
+
+      # Baseline @ 13b4e98: 611,001 / 327,242 / 957,299. ~15% headroom.
+      check nrFunctionCalls 700000
+      check nrPrimOpCalls   380000
+      check nrThunks        1100000
+
+      if [ "$fail" -ne 0 ]; then
+        cat >&2 <<'EOF'
+
+      Eval-stats threshold(s) exceeded for torture-project/dag-app-full.nix.
+      If this is an intentional cost increase, bump the thresholds in
+      packages/test-eval-stats/default.nix with justification.
+      EOF
+        exit 1
+      fi
+      echo "PASS: eval stats within thresholds" > $out
+    ''

--- a/scripts/update-drv-canary.sh
+++ b/scripts/update-drv-canary.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Regenerate packages/test-drv-canary/expected.txt from the current tree.
+#
+# Run after any change to go/go2nix/, packages/go2nix-nix-plugin/,
+# nix/dag/hooks/, or the nixpkgs flake input. A change to nix/dag/*.nix
+# alone should NOT require running this — that's the point of the canary.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+actual=$(nix build --no-link --print-out-paths .#test-drv-canary.actual)
+
+{
+  echo "# Expected .drv hashes for the nix/dag semantic-stability canary."
+  echo "# Regenerate with ./scripts/update-drv-canary.sh after any change to"
+  echo "# go/go2nix/, packages/go2nix-nix-plugin/, nix/dag/hooks/, or the nixpkgs"
+  echo "# flake input. A change to nix/dag/*.nix alone should NOT require"
+  echo "# updating this file."
+  cat "$actual"
+} >packages/test-drv-canary/expected.txt
+
+echo "Updated packages/test-drv-canary/expected.txt"
+cat "$actual"


### PR DESCRIPTION
## Summary

Two regression guards so Nix-side refactors of `nix/dag/default.nix` can land with confidence.

**`test-drv-canary`** — `nix-instantiate` 4 fixtures (`testify-basic`, `xtest-local-dep`, `cgo-internal-test`, `torture-app-full`) and diff `.drv` paths against committed `expected.txt`. A pure `nix/dag/*.nix` refactor must not change this file — `derivationStrict` output should be identical. Regenerate via `scripts/update-drv-canary.sh` after intentional changes to `go/go2nix/`, the plugin, hooks, or the nixpkgs input. `passthru.actual` is a separate derivation so the script works even when the diff fails.

**`test-eval-stats`** — `NIX_SHOW_STATS=1` on `torture-project/dag-app-full`, asserts deterministic counts (machine-independent, not cpuTime): `nrFunctionCalls < 700000`, `nrPrimOpCalls < 380000`, `nrThunks < 1100000` (~15% above measured 611,001 / 327,242 / 957,299). Logs actuals; failure message says how to bump with justification.

## Test plan

- [x] Both build → PASS
- [x] Canary perturbation: added `__debugCanaryPerturbation = 1;` to a drv env in `nix/dag/default.nix` → `FAIL: .drv hashes changed` with diff; reverted → PASS
- [x] Canary stable across unrelated repo additions (fixture sources are content-addressed via `src = ./.`)
- [x] `nix flake check` (formatting)