### PR TITLE
tests,resolve: wire dynamic mode into CI; fix 3 regressions it surfaced

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,18 @@
             inherit flake system;
           };
 
+          test-package-dotool-dynamic = callPkgWith ./packages/test-package-dotool-dynamic/default.nix {
+            inherit flake system;
+          };
+          # test-package-nwg-drawer-dynamic kept under packages/ but not wired:
+          # the link drv still misses propagated lib dirs (fails on -lz), unlike
+          # the compile drvs which now get include dirs via CGO_CFLAGS.
+          test-package-yubikey-agent-dynamic =
+            callPkgWith ./packages/test-package-yubikey-agent-dynamic/default.nix
+              {
+                inherit flake system;
+              };
+
           test-fixture-testify-basic = callPkgWith ./packages/test-fixture-testify-basic/default.nix {
             inherit flake system;
           };

--- a/go/go2nix/pkg/nixdrv/daemon.go
+++ b/go/go2nix/pkg/nixdrv/daemon.go
@@ -118,7 +118,10 @@ func (s *DaemonStore) Build(installables ...string) ([]*storepath.StorePath, err
 
 		var sp *storepath.StorePath
 		for _, realised := range r.BuiltOutputs {
-			if sp, err = storepath.FromAbsolutePath(realised.OutPath); err != nil {
+			// Realisation JSON serialises outPath via Nix's StorePath
+			// to_string(), which is the bare HASH-NAME without the
+			// store dir prefix (libstore/include/nix/store/path.hh).
+			if sp, err = storepath.FromString(realised.OutPath); err != nil {
 				return nil, fmt.Errorf("parsing build output %q: %w", realised.OutPath, err)
 			}
 

--- a/go/go2nix/pkg/resolve/resolve.go
+++ b/go/go2nix/pkg/resolve/resolve.go
@@ -25,6 +25,7 @@ import (
 	"github.com/numtide/go2nix/pkg/lockfile"
 	"github.com/numtide/go2nix/pkg/nixdrv"
 	"golang.org/x/mod/module"
+	"golang.org/x/mod/sumdb/dirhash"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -163,7 +164,7 @@ func Resolve(cfg Config) error {
 
 	// Step 4: Set up GOMODCACHE
 	t = time.Now()
-	gomodcache, err := setupGOMODCACHE(fodPaths)
+	gomodcache, err := setupGOMODCACHE(fodPaths, lock)
 	if err != nil {
 		return fmt.Errorf("setting up GOMODCACHE: %w", err)
 	}
@@ -491,26 +492,70 @@ func registerDerivationsParallel(
 	return nil
 }
 
-// setupGOMODCACHE creates a temporary GOMODCACHE by merging all FOD outputs
-// into a single directory tree using symlinks.
+// setupGOMODCACHE assembles a GOMODCACHE from per-module FOD outputs.
 //
-// Each FOD output is a GOMODCACHE subtree (GOMODCACHE=$out). Multiple FODs
-// share directory prefixes (e.g., cache/download/golang.org/) but never share
-// leaf files since each FOD downloads a unique module@version. We walk each
-// FOD in parallel, create real directories for intermediate paths, and symlink
-// leaf files. MkdirAll is safe to call concurrently (idempotent), and leaf
-// files are unique per FOD so symlinks won't collide.
-func setupGOMODCACHE(fodPaths map[string]*storepath.StorePath) (string, error) {
+// Each FOD output is the extracted module source tree only (see fodScript —
+// $out is the contents of $GOMODCACHE/<epath>@<eversion>/). We mirror each
+// tree to its <epath>@<eversion>/ location and synthesise the minimum
+// cache/download/ metadata go list checks before using the extracted dir
+// (cmd/go/internal/modfetch/fetch.go: download → DownloadDir).
+func setupGOMODCACHE(fodPaths map[string]*storepath.StorePath, lock *lockfile.Lockfile) (string, error) {
 	gomodcache, err := os.MkdirTemp("", "gomodcache-")
 	if err != nil {
 		return "", err
 	}
 	g := new(errgroup.Group)
 	g.SetLimit(max(runtime.NumCPU(), 8))
-	for _, fodPath := range fodPaths {
+	for modKey, fodPath := range fodPaths {
 		src := fodPath.Absolute()
+		modPath, version, _ := strings.Cut(modKey, "@")
+		fetchPath := modPath
+		if r, ok := lock.Replace[modKey]; ok {
+			fetchPath = r
+		}
+		ep, err := module.EscapePath(fetchPath)
+		if err != nil {
+			return "", err
+		}
+		ev, err := module.EscapeVersion(version)
+		if err != nil {
+			return "", err
+		}
 		g.Go(func() error {
-			return symlinkTree(src, gomodcache)
+			extracted := filepath.Join(gomodcache, ep+"@"+ev)
+			if err := os.MkdirAll(extracted, 0o755); err != nil {
+				return err
+			}
+			if err := symlinkTree(src, extracted); err != nil {
+				return err
+			}
+			dlDir := filepath.Join(gomodcache, "cache", "download", ep, "@v")
+			if err := os.MkdirAll(dlDir, 0o755); err != nil {
+				return err
+			}
+			gomod, err := os.ReadFile(filepath.Join(src, "go.mod"))
+			if err != nil {
+				// Modules without a go.mod get the minimal one go mod download writes.
+				gomod = []byte("module " + fetchPath + "\n")
+			}
+			if err := os.WriteFile(filepath.Join(dlDir, ev+".mod"), gomod, 0o644); err != nil {
+				return err
+			}
+			if err := os.WriteFile(filepath.Join(dlDir, ev+".info"), []byte(`{"Version":"`+version+`"}`), 0o644); err != nil {
+				return err
+			}
+			// checkMod reads .ziphash; an empty file falls through to
+			// rehashing the (absent) .zip. dirhash.HashDir over the
+			// extracted tree yields the same h1 as the zip, which is
+			// what go.sum records.
+			h1, err := dirhash.HashDir(src, fetchPath+"@"+version, dirhash.Hash1)
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(filepath.Join(dlDir, ev+".ziphash"), []byte(h1), 0o644); err != nil {
+				return err
+			}
+			return os.WriteFile(filepath.Join(dlDir, ev+".lock"), nil, 0o644)
 		})
 	}
 	if err := g.Wait(); err != nil {
@@ -678,6 +723,15 @@ func setupPkgOverrides(
 	drv.SetEnv("PATH", strings.Join(pathParts, ":"))
 	if len(inputs.PkgConfigDirs) > 0 {
 		drv.SetEnv("PKG_CONFIG_PATH", strings.Join(inputs.PkgConfigDirs, ":"))
+	}
+	// Synthesised drvs don't run stdenv's setup hook, so cc-wrapper won't
+	// pick up include dirs from nativeBuildInputs the way default mode
+	// does. Pass them via CGO_CFLAGS, which compile-package's cgo step
+	// reads directly. -L paths come from pkg-config; adding every lib/ via
+	// CGO_LDFLAGS bloats the recorded _cgo_flags and overflows the link
+	// argument list for GTK-sized closures.
+	if len(inputs.IncludeDirs) > 0 {
+		drv.SetEnv("CGO_CFLAGS", "-I"+strings.Join(inputs.IncludeDirs, " -I"))
 	}
 	return inputs
 }
@@ -1127,6 +1181,7 @@ func storeDirOf(path string) string {
 type InputPaths struct {
 	BinDirs       []string // directories containing executables (e.g., /nix/store/xxx/bin)
 	PkgConfigDirs []string // directories containing .pc files (e.g., /nix/store/xxx/lib/pkgconfig)
+	IncludeDirs   []string // directories containing headers (for CGO_CFLAGS)
 	All           []string // all store paths (including transitive propagated-build-inputs)
 }
 
@@ -1146,6 +1201,9 @@ func discoverInputPaths(storePaths []string) InputPaths {
 
 		if isDir(p + "/bin") {
 			result.BinDirs = append(result.BinDirs, p+"/bin")
+		}
+		if isDir(p + "/include") {
+			result.IncludeDirs = append(result.IncludeDirs, p+"/include")
 		}
 		if isDir(p + "/lib/pkgconfig") {
 			result.PkgConfigDirs = append(result.PkgConfigDirs, p+"/lib/pkgconfig")

--- a/packages/go2nix/default.nix
+++ b/packages/go2nix/default.nix
@@ -14,7 +14,7 @@ buildGoModule {
 
   subPackages = [ "cmd/go2nix" ];
 
-  vendorHash = "sha256-rFvMITSISMcCABjeYYGagTYgUcDFQm89btao4p22LmQ=";
+  vendorHash = "sha256-BqHk1hgp7TbbLvzFvjLqaeA++gMo2Dn8VFb8wmZRIBM=";
 
   meta = {
     description = "Go Build — Nix-native Go package compiler";

--- a/packages/test-drv-canary/expected.txt
+++ b/packages/test-drv-canary/expected.txt
@@ -3,7 +3,7 @@
 # go/go2nix/, packages/go2nix-nix-plugin/, nix/dag/hooks/, or the nixpkgs
 # flake input. A change to nix/dag/*.nix alone should NOT require
 # updating this file.
-testify-basic /nix/store/clc3wsy19kvianrnvhw13fl037dyzsgq-testify-basic-0.0.1.drv
-xtest-local-dep /nix/store/5z2yjyjvcahcywiwk176sl820l2809vn-xtest-local-dep-0.0.1.drv
-cgo-internal-test /nix/store/2fcqq9ysndbk1bh6xcjrgr4bb720sb04-cgo-internal-test-0.0.1.drv
-torture-app-full /nix/store/0gkbcp1fbh35j17jd3jdl7bnglp3spm9-torture-app-full-0.0.1.drv
+testify-basic /nix/store/g7ah7gfcb5j26anb4izdl053v7pw7fqk-testify-basic-0.0.1.drv
+xtest-local-dep /nix/store/41z9mb39hzd5c6kvmycyyzxkrja8zq1q-xtest-local-dep-0.0.1.drv
+cgo-internal-test /nix/store/66x6kigzvj4vkh1sqbyvb8czwgw98j2x-cgo-internal-test-0.0.1.drv
+torture-app-full /nix/store/nvz4j27ki4q16af3iwssf614nr3659z9-torture-app-full-0.0.1.drv

--- a/packages/test-lib/run-dynamic-test.nix
+++ b/packages/test-lib/run-dynamic-test.nix
@@ -1,0 +1,39 @@
+# Shared test runner for buildGoApplicationExperimental (dynamic mode).
+#
+# Exercises pkg/resolve and the recursive-nix + ca-derivations +
+# dynamic-derivations chain. nix-build of dynamic.nix produces a text-mode
+# CA output that IS a .drv file; nix-store -r on that path realises the
+# final binary.
+{
+  pkgs,
+  testName,
+  dynamicFile,
+  checkCommand ? "$result/bin/${testName} --help",
+}:
+let
+  nix = pkgs.nixVersions.nix_2_34;
+  nixpkgsPath = pkgs.path;
+in
+pkgs.runCommand "test-dynamic-package-${testName}"
+  {
+    nativeBuildInputs = [ nix ];
+    requiredSystemFeatures = [
+      "recursive-nix"
+      "ca-derivations"
+    ];
+    meta.platforms = pkgs.lib.platforms.linux;
+  }
+  ''
+    export HOME=$(mktemp -d)
+    export NIX_CONFIG="extra-experimental-features = nix-command recursive-nix ca-derivations dynamic-derivations"
+
+    echo "=== Building ${testName} (dynamic mode) ==="
+    wrapper=$(nix-build ${dynamicFile} \
+      -I nixpkgs=${nixpkgsPath} \
+      --no-out-link)
+
+    result=$(nix-store -r "$wrapper")
+
+    ${checkCommand}
+    echo "PASS: ${testName} (dynamic mode)" > $out
+  ''

--- a/packages/test-package-dotool-dynamic/default.nix
+++ b/packages/test-package-dotool-dynamic/default.nix
@@ -1,0 +1,11 @@
+# Build test: dotool via buildGoApplicationExperimental.
+{
+  flake,
+  pkgs,
+  ...
+}:
+import ../test-lib/run-dynamic-test.nix {
+  inherit pkgs;
+  testName = "dotool";
+  dynamicFile = "${flake}/tests/packages/dotool/dynamic.nix";
+}

--- a/packages/test-package-nwg-drawer-dynamic/default.nix
+++ b/packages/test-package-nwg-drawer-dynamic/default.nix
@@ -1,0 +1,11 @@
+# Build test: nwg-drawer via buildGoApplicationExperimental (heavy GTK cgo).
+{
+  flake,
+  pkgs,
+  ...
+}:
+import ../test-lib/run-dynamic-test.nix {
+  inherit pkgs;
+  testName = "nwg-drawer";
+  dynamicFile = "${flake}/tests/packages/nwg-drawer/dynamic.nix";
+}

--- a/packages/test-package-yubikey-agent-dynamic/default.nix
+++ b/packages/test-package-yubikey-agent-dynamic/default.nix
@@ -1,0 +1,11 @@
+# Build test: yubikey-agent via buildGoApplicationExperimental (cgo + pcsclite).
+{
+  flake,
+  pkgs,
+  ...
+}:
+import ../test-lib/run-dynamic-test.nix {
+  inherit pkgs;
+  testName = "yubikey-agent";
+  dynamicFile = "${flake}/tests/packages/yubikey-agent/dynamic.nix";
+}


### PR DESCRIPTION
## Summary

Wires `buildGoApplicationExperimental` (dynamic mode) into CI via `packages.test-package-{dotool,yubikey-agent}-dynamic`. `pkg/resolve/` (~1k LOC, changed in #60/#81/#85/#89) previously had only script-generation unit tests; the existing `tests/packages/*/dynamic.nix` were never built.

Wiring surfaced **three regressions on `origin/main`** that no test caught:

1. `nixdrv/daemon.go:121` — Nix's `Realisation` JSON serialises `outPath` as bare `HASH-NAME` (libstore `StorePath::to_string()`), but `Build()` called `FromAbsolutePath`. Broken since the daemon backend landed. Fixed: `FromString`.
2. `resolve.setupGOMODCACHE` — #81 changed `fetchGoModule` FOD output from a GOMODCACHE root to a source-tree-only layout, but dynamic mode still merged FODs at the root → `go list` fails `module lookup disabled by GOPROXY=off`. Fixed: mirror each tree to `<epath>@<eversion>/` and synthesise `cache/download/.../{.mod,.info,.ziphash,.lock}` (`.ziphash` carries the real h1 from `dirhash.HashDir`).
3. `resolve.setupPkgOverrides` — synthesised compile drvs don't run stdenv's setup-hook, so cc-wrapper never sees `nativeBuildInputs` include dirs. Fixed: `discoverInputPaths` collects `include/` and threads via `CGO_CFLAGS`.

`nwg-drawer-dynamic` wrapper exists but is **unwired**: the synthesised link drv has the same setup-hook gap (no `NIX_LDFLAGS` for propagated lib dirs → `-lz` not found). Separate fix in `resolve.buildLinkDrv`; flake comment documents.

`test-drv-canary` `expected.txt` regenerated (Go-source change).

## Test plan

- [x] `test-package-dotool-dynamic` — `dotool --help` runs
- [x] `test-package-yubikey-agent-dynamic` (cgo + pcsclite via packageOverrides) — `yubikey-agent --help` runs
- [x] Default-mode `test-package-{dotool,nwg-drawer}` still PASS
- [x] `go test ./...`, `go vet ./...`, golangci-lint, `nix flake check`