### PR TITLE
dag: Tier-2 eval-perf — precompute allowedDir sets for path filters

### DIFF
--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -527,6 +527,12 @@ let
     }) allLocalPkgInfo
   );
 
+  # Hoisted once for the per-entry rel-path computation in both the pkgSrc
+  # and mainSrc builtins.path filters (instead of toString src + "/" per
+  # filter callback per local package).
+  srcStr = toString src;
+  srcPrefix = srcStr + "/";
+
   # Main module's go directive (major.minor). Threaded explicitly to every
   # local-package compile because non-root pkgSrc filters exclude go.mod,
   # so the build-time go.mod walk would otherwise miss it and compile
@@ -575,16 +581,18 @@ let
       # go.mod, so they are never compiled and would only churn the store
       # path. The package's own root is never passed to the filter, so a
       # modRoot/replace-target package's go.mod doesn't self-exclude.
-      srcStr = toString src;
       pkgSrc = builtins.path {
         path = if isRoot then src else src + "/${relDir}";
         name = "golocal-${helpers.sanitizeName importPath}-src";
         filter =
           path: type:
-          let
-            rel = removePrefix (srcStr + "/") (toString path);
-          in
-          !(type == "directory" && (localPkgDirSet ? ${rel} || builtins.pathExists (path + "/go.mod")));
+          type != "directory"
+          || (
+            let
+              rel = removePrefix srcPrefix (toString path);
+            in
+            !(localPkgDirSet ? ${rel} || builtins.pathExists (path + "/go.mod"))
+          );
       };
 
       srcDir = "${pkgSrc}";
@@ -848,6 +856,37 @@ let
       # so the testrunner can walk them.
       allowedDirs = [ cleanModRoot ] ++ subPkgDirs ++ replaceDirs;
       allowedDirSet = genAttrs allowedDirs (_: true);
+      # Every allowedDir together with all of its strict ancestors. Lets the
+      # filter answer "is rel an allowedDir or an ancestor of one?" with a
+      # single attrset lookup instead of an O(|allowedDirs|) hasPrefix scan.
+      allowedAncestorSet = builtins.listToAttrs (
+        builtins.concatMap (
+          d:
+          let
+            walk =
+              r:
+              [
+                {
+                  name = r;
+                  value = true;
+                }
+              ]
+              ++ optionals (r != "." && r != "") (walk (builtins.dirOf r));
+          in
+          walk d
+        ) allowedDirs
+      );
+      # rel is at-or-under an allowedDir? O(depth) attrset lookups via dirOf
+      # instead of O(|allowedDirs|) hasPrefix string scans.
+      isUnderAllowed =
+        r:
+        allowedDirSet ? ${r}
+        || (
+          let
+            d = builtins.dirOf r;
+          in
+          d != "." && isUnderAllowed d
+        );
       # When modRoot is "." or any subPackage resolves to ".", the entire
       # source tree is needed — no prefix filtering required.
       includeAll = builtins.elem "." allowedDirs;
@@ -858,23 +897,16 @@ let
       filter =
         path: type:
         let
-          rel = removePrefix (toString src + "/") (toString path);
-          # A go.mod-bearing directory that isn't an allowed module root
-          # (modRoot, a subPackage dir, or a local-replace target) is a
-          # nested-module boundary; go list stopped there, so its files are
-          # never compiled or tested. Checked unconditionally so it also
-          # applies in the includeAll case.
-          isNestedModule =
-            type == "directory" && !(allowedDirSet ? ${rel}) && builtins.pathExists (path + "/go.mod");
+          rel = removePrefix srcPrefix (toString path);
         in
-        if isNestedModule then
-          false
-        else if includeAll then
-          true
-        else
-          path == toString src
-          || builtins.any (prefix: rel == prefix || hasPrefix (prefix + "/") rel) allowedDirs
-          || builtins.any (prefix: hasPrefix (rel + "/") prefix) allowedDirs;
+        # rel must be on the path to, at, or under an allowedDir. Checked
+        # before the nested-module pathExists so siblings the filter would
+        # reject anyway skip the syscall.
+        (includeAll || path == srcStr || allowedAncestorSet ? ${rel} || isUnderAllowed rel)
+        # A go.mod-bearing directory that isn't an allowed module root
+        # (modRoot, a subPackage dir, or a local-replace target) is a
+        # nested-module boundary; go list stopped there.
+        && !(type == "directory" && !(allowedDirSet ? ${rel}) && builtins.pathExists (path + "/go.mod"));
     };
 
   moduleRoot = if modRoot == "." then "${mainSrc}" else "${mainSrc}/${modRoot}";

--- a/packages/test-drv-canary/expected.txt
+++ b/packages/test-drv-canary/expected.txt
@@ -3,7 +3,7 @@
 # go/go2nix/, packages/go2nix-nix-plugin/, nix/dag/hooks/, or the nixpkgs
 # flake input. A change to nix/dag/*.nix alone should NOT require
 # updating this file.
-testify-basic /nix/store/g7ah7gfcb5j26anb4izdl053v7pw7fqk-testify-basic-0.0.1.drv
-xtest-local-dep /nix/store/41z9mb39hzd5c6kvmycyyzxkrja8zq1q-xtest-local-dep-0.0.1.drv
-cgo-internal-test /nix/store/66x6kigzvj4vkh1sqbyvb8czwgw98j2x-cgo-internal-test-0.0.1.drv
-torture-app-full /nix/store/nvz4j27ki4q16af3iwssf614nr3659z9-torture-app-full-0.0.1.drv
+testify-basic /nix/store/dwd0891b52gmyfgvvxszc8ndq9w7f7q1-testify-basic-0.0.1.drv
+xtest-local-dep /nix/store/wadfi2yz1bwhr2yxcd0zdx19v88g57yq-xtest-local-dep-0.0.1.drv
+cgo-internal-test /nix/store/hyjn415bqmga8zjr1xzkwrwifxksrjh2-cgo-internal-test-0.0.1.drv
+torture-app-full /nix/store/wz95zjwgd4knlacxm2jmlhgvvx2bq528-torture-app-full-0.0.1.drv


### PR DESCRIPTION
## Summary

`mainSrc` filter rewrite: replaces O(files × allowedDirs) `builtins.any`/`hasPrefix` linear scans with O(depth) attrset lookups via precomputed `allowedDirSet` + `allowedAncestorSet`. Per-entry `pathExists "/go.mod"` (#86's nested-module check) is reordered after the allowedDirs check so siblings the filter would reject anyway skip the syscall. `pkgSrc` micro-optimisation: short-circuit `type != "directory"` before computing `rel`; hoist `srcPrefix`.

The directive's "precompute nested-module roots via one `readDir` walk" was prototyped and dropped: a Nix-side `readDir` per directory adds more primops than it saves, since `builtins.path`'s C++ traversal already enumerates them — and the walk must descend past allowedDirs' own go.mod to remain correct for nested-under-allowedDir cases. The right fix is Tier-3 (plugin emits boundaries — `go list` already knows them).

| eval-stats (torture, 58 files / 16 allowedDirs) | before (Tier-1) | after | Δ |
|---|---|---|---|
| nrFunctionCalls | 552,465 | 548,874 | −0.65% |
| nrPrimOpCalls | 281,488 | 279,447 | −0.73% |
| nrThunks | 908,259 | 905,042 | −0.35% |

Torture under-weights this — the win scales with `entries × |allowedDirs|`. For larger trees (~thousands of entries × ~20 allowedDirs) the per-entry cost drops from ~40 string scans to ~5 attrset lookups.

**Second commit** regenerates `expected.txt`: it was stale on `origin/main` (#106 generated it pre-#103; #103's `*_test.go` additions to `go/go2nix/` changed the CLI drv via `cleanSource`). The Tier-2 change itself is hash-neutral — verified by direct `nix-instantiate` of `testify-basic` with/without (`dwd0891b52...` both ways).

## Test plan

- [x] `test-drv-canary` PASS (after regen for #103 drift); Tier-2 change itself proven hash-neutral via direct instantiate
- [x] `test-eval-stats` PASS, counts down
- [x] `mainsrc-replace` (6), `nested-module` (4), `nix-unit-tests`, `test-golden-vs-gobuild` (9/9), `test-fixture-modroot-nested` PASS
- [x] `nix flake check` (formatting)