### PR TITLE
resolve: thread propagated lib dirs to dynamic-mode link drv via salted NIX_LDFLAGS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,9 +75,11 @@
           test-package-dotool-dynamic = callPkgWith ./packages/test-package-dotool-dynamic/default.nix {
             inherit flake system;
           };
-          # test-package-nwg-drawer-dynamic kept under packages/ but not wired:
-          # the link drv still misses propagated lib dirs (fails on -lz), unlike
-          # the compile drvs which now get include dirs via CGO_CFLAGS.
+          test-package-nwg-drawer-dynamic =
+            callPkgWith ./packages/test-package-nwg-drawer-dynamic/default.nix
+              {
+                inherit flake system;
+              };
           test-package-yubikey-agent-dynamic =
             callPkgWith ./packages/test-package-yubikey-agent-dynamic/default.nix
               {

--- a/go/go2nix/pkg/resolve/resolve.go
+++ b/go/go2nix/pkg/resolve/resolve.go
@@ -6,6 +6,7 @@ package resolve
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -13,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -63,8 +65,15 @@ type Config struct {
 	ccPath string
 	// cxxPath is the full path to the C++ compiler (e.g., /nix/store/xxx/bin/c++).
 	cxxPath string
+	// ccSuffixSalt is the cc-wrapper suffixSalt (e.g. "x86_64_unknown_linux_gnu"),
+	// extracted from ccDir/nix-support/setup-hook so the link drv can set the
+	// salted NIX_LDFLAGS_<salt> directly without running stdenv's setup hook.
+	ccSuffixSalt string
 	// allOverridePaths collects all nativeBuildInputs store paths for the link derivation.
 	allOverridePaths []string
+	// allOverrideLibDirs collects lib/ directories from the transitive override
+	// closure for the link derivation's NIX_LDFLAGS (cgo external linking).
+	allOverrideLibDirs []string
 	// buildMode is "pie" or "exe", determined at Resolve() time from GOOS/GOARCH.
 	buildMode string
 	// goEnv caches the output of `go env -json` for the resolve run.
@@ -87,6 +96,7 @@ func (cfg *Config) prepare() {
 	if ccPath, err := exec.LookPath("cc"); err == nil {
 		cfg.ccPath = ccPath
 		cfg.ccDir = storeDirOf(filepath.Dir(ccPath))
+		cfg.ccSuffixSalt = ccSuffixSalt(cfg.ccDir)
 	}
 	if cxxPath, err := exec.LookPath("c++"); err == nil {
 		cfg.cxxPath = cxxPath
@@ -128,7 +138,9 @@ func Resolve(cfg Config) error {
 	for _, ov := range overrides {
 		allOverrideInputs = append(allOverrideInputs, ov.NativeBuildInputs...)
 	}
-	cfg.allOverridePaths = discoverInputPaths(allOverrideInputs).All
+	allOverrideDiscovered := discoverInputPaths(allOverrideInputs)
+	cfg.allOverridePaths = allOverrideDiscovered.All
+	cfg.allOverrideLibDirs = allOverrideDiscovered.LibDirs
 
 	resolveStart := time.Now()
 
@@ -534,9 +546,11 @@ func setupGOMODCACHE(fodPaths map[string]*storepath.StorePath, lock *lockfile.Lo
 				return err
 			}
 			gomod, err := os.ReadFile(filepath.Join(src, "go.mod"))
-			if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
 				// Modules without a go.mod get the minimal one go mod download writes.
 				gomod = []byte("module " + fetchPath + "\n")
+			} else if err != nil {
+				return err
 			}
 			if err := os.WriteFile(filepath.Join(dlDir, ev+".mod"), gomod, 0o644); err != nil {
 				return err
@@ -1047,6 +1061,16 @@ func buildLinkDrv(
 		if hasCgo {
 			pathParts = append(pathParts, cfg.ccDir+"/bin")
 			drv.AddInputSrc(cfg.ccDir)
+			// Synthesised drvs don't run stdenv's setup hook, so cc-wrapper
+			// never sees the propagated lib/ dirs the way default mode's
+			// stdenv.mkDerivation + overrideNativeBuildInputs does. Set the
+			// salted NIX_LDFLAGS directly — cc-wrapper reads
+			// NIX_LDFLAGS_<suffixSalt> unconditionally and adds each -L to
+			// the external linker invocation.
+			if cfg.ccSuffixSalt != "" && len(cfg.allOverrideLibDirs) > 0 {
+				drv.SetEnv("NIX_LDFLAGS_"+cfg.ccSuffixSalt,
+					"-L"+strings.Join(cfg.allOverrideLibDirs, " -L"))
+			}
 		}
 	}
 	drv.SetEnv("PATH", strings.Join(pathParts, ":"))
@@ -1182,6 +1206,7 @@ type InputPaths struct {
 	BinDirs       []string // directories containing executables (e.g., /nix/store/xxx/bin)
 	PkgConfigDirs []string // directories containing .pc files (e.g., /nix/store/xxx/lib/pkgconfig)
 	IncludeDirs   []string // directories containing headers (for CGO_CFLAGS)
+	LibDirs       []string // directories containing shared libraries (for NIX_LDFLAGS at link time)
 	All           []string // all store paths (including transitive propagated-build-inputs)
 }
 
@@ -1205,6 +1230,9 @@ func discoverInputPaths(storePaths []string) InputPaths {
 		if isDir(p + "/include") {
 			result.IncludeDirs = append(result.IncludeDirs, p+"/include")
 		}
+		if isDir(p + "/lib") {
+			result.LibDirs = append(result.LibDirs, p+"/lib")
+		}
 		if isDir(p + "/lib/pkgconfig") {
 			result.PkgConfigDirs = append(result.PkgConfigDirs, p+"/lib/pkgconfig")
 		}
@@ -1225,6 +1253,26 @@ func discoverInputPaths(storePaths []string) InputPaths {
 		walk(sp)
 	}
 	return result
+}
+
+// ccSuffixSaltRe extracts the cc-wrapper suffixSalt baked into its setup-hook
+// (e.g. NIX_CC_WRAPPER_TARGET_HOST_x86_64_unknown_linux_gnu=1). The salt is
+// targetPlatform.config with - → _, hardcoded at wrapper build time.
+var ccSuffixSaltRe = regexp.MustCompile(`NIX_CC_WRAPPER_TARGET_HOST_([0-9A-Za-z_]+)=1`)
+
+// ccSuffixSalt extracts the cc-wrapper suffixSalt from ccDir/nix-support/setup-hook.
+// Returns "" when the wrapper layout isn't recognised; callers fall back to
+// not setting NIX_LDFLAGS, which is safe (the link will fail loudly on a
+// missing -l rather than silently mis-linking).
+func ccSuffixSalt(ccDir string) string {
+	data, err := os.ReadFile(ccDir + "/nix-support/setup-hook")
+	if err != nil {
+		return ""
+	}
+	if m := ccSuffixSaltRe.FindSubmatch(data); m != nil {
+		return string(m[1])
+	}
+	return ""
 }
 
 // isDir returns true if path exists and is a directory.

--- a/go/go2nix/pkg/resolve/resolve_test.go
+++ b/go/go2nix/pkg/resolve/resolve_test.go
@@ -189,8 +189,11 @@ func TestDiscoverInputPaths(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// pkgC: bin only
+	// pkgC: bin + include
 	if err := os.MkdirAll(filepath.Join(pkgC, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(pkgC, "include"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -213,12 +216,46 @@ func TestDiscoverInputPaths(t *testing.T) {
 			pkgA+"/lib/pkgconfig", pkgB+"/lib/pkgconfig")
 	}
 
+	// IncludeDirs: pkgC/include only
+	if len(result.IncludeDirs) != 1 || result.IncludeDirs[0] != pkgC+"/include" {
+		t.Errorf("IncludeDirs = %v, want [%s]", result.IncludeDirs, pkgC+"/include")
+	}
+
+	// LibDirs: pkgA/lib, pkgB/lib (both have lib/ via lib/pkgconfig/)
+	if len(result.LibDirs) != 2 {
+		t.Fatalf("expected 2 LibDirs, got %d: %v", len(result.LibDirs), result.LibDirs)
+	}
+	if result.LibDirs[0] != pkgA+"/lib" || result.LibDirs[1] != pkgB+"/lib" {
+		t.Errorf("LibDirs = %v, want [%s %s]", result.LibDirs, pkgA+"/lib", pkgB+"/lib")
+	}
+
 	// All: pkgA, pkgB (transitive), pkgC — in walk order
 	if len(result.All) != 3 {
 		t.Fatalf("expected 3 All, got %d: %v", len(result.All), result.All)
 	}
 	if result.All[0] != pkgA || result.All[1] != pkgB || result.All[2] != pkgC {
 		t.Errorf("All = %v, want [%s %s %s]", result.All, pkgA, pkgB, pkgC)
+	}
+}
+
+func TestCCSuffixSalt(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "nix-support"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hook := `
+        0)
+            export NIX_CC_WRAPPER_TARGET_HOST_aarch64_unknown_linux_gnu=1
+            ;;
+`
+	if err := os.WriteFile(filepath.Join(dir, "nix-support", "setup-hook"), []byte(hook), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := ccSuffixSalt(dir); got != "aarch64_unknown_linux_gnu" {
+		t.Errorf("ccSuffixSalt = %q, want aarch64_unknown_linux_gnu", got)
+	}
+	if got := ccSuffixSalt(t.TempDir()); got != "" {
+		t.Errorf("ccSuffixSalt(no setup-hook) = %q, want empty", got)
 	}
 }
 

--- a/packages/test-drv-canary/expected.txt
+++ b/packages/test-drv-canary/expected.txt
@@ -3,7 +3,7 @@
 # go/go2nix/, packages/go2nix-nix-plugin/, nix/dag/hooks/, or the nixpkgs
 # flake input. A change to nix/dag/*.nix alone should NOT require
 # updating this file.
-testify-basic /nix/store/dwd0891b52gmyfgvvxszc8ndq9w7f7q1-testify-basic-0.0.1.drv
-xtest-local-dep /nix/store/wadfi2yz1bwhr2yxcd0zdx19v88g57yq-xtest-local-dep-0.0.1.drv
-cgo-internal-test /nix/store/hyjn415bqmga8zjr1xzkwrwifxksrjh2-cgo-internal-test-0.0.1.drv
-torture-app-full /nix/store/wz95zjwgd4knlacxm2jmlhgvvx2bq528-torture-app-full-0.0.1.drv
+testify-basic /nix/store/9csffkvgwyv1pmfphskqk8b4kmhmcj4q-testify-basic-0.0.1.drv
+xtest-local-dep /nix/store/7va2vdhw47wkk6sgajg8vs9rkfq459r7-xtest-local-dep-0.0.1.drv
+cgo-internal-test /nix/store/5f7v58dgrvj0fr20mahr3m0y8nwhfmms-cgo-internal-test-0.0.1.drv
+torture-app-full /nix/store/wqx0hwd7nwdgnq9s9v4ww4a3151mmrpw-torture-app-full-0.0.1.drv


### PR DESCRIPTION
## Summary

Closes the link-time gap #106 documented: synthesised link drvs don't run stdenv's setup-hook, so cc-wrapper never gets `NIX_LDFLAGS` for propagated lib dirs. `nwg-drawer-dynamic` failed on `-lz` (zlib, propagated by GTK). Default-mode link uses `stdenv.mkDerivation` + `overrideNativeBuildInputs` so cc-wrapper handles it.

`discoverInputPaths` now collects `lib/` dirs (propagated-input recursion was already present). At link time, `buildLinkDrv` sets `NIX_LDFLAGS_<suffixSalt>` (the salt extracted from `${cc}/nix-support/setup-hook`'s `NIX_CC_WRAPPER_TARGET_HOST_<salt>=1` line) — cc-wrapper reads the salted var unconditionally and adds each `-L` to the external linker. Avoids both the bintools role-var dance and `-extldflags` last-wins clobbering. Falls back to not setting the var (loud link failure) if the wrapper layout isn't recognised.

`LibDirs` is **not** applied at compile time (would overflow `_cgo_flags` for GTK closures; pkg-config supplies what compiles need).

Also: `setupGOMODCACHE` now only synthesises a fallback `module <path>` go.mod on `fs.ErrNotExist` — a permission/IO error returns instead of being masked.

`test-package-nwg-drawer-dynamic` wired into `flake.nix`; canary regenerated.

## Test plan

- [x] `test-package-nwg-drawer-dynamic` PASS — `nwg-drawer --help` runs (full GTK flag set), zero `cannot find -l`/`undefined reference`
- [x] `dotool-dynamic`, `yubikey-agent-dynamic`, default-mode `test-package-nwg-drawer` still PASS
- [x] **New unit** `TestDiscoverInputPaths` (LibDirs+IncludeDirs), `TestCCSuffixSalt`
- [x] `test-drv-canary` (regenerated), `test-golden-vs-gobuild`, `go test ./...`, `go vet ./...`, golangci-lint, `nix flake check`