### PR TITLE
plugin,dag: Tier-3 eval-perf — offload per-subPackage closure, replaceDirs, nestedModuleRoots to Rust

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -130,6 +130,12 @@
           test-fixture-testmain-badsig = callPkgWith ./tests/nix/testmain_badsig_test.nix {
             inherit flake system;
           };
+          test-fixture-mainsrc-replace = callPkgWith ./tests/nix/mainsrc_replace_test.nix {
+            inherit flake system;
+          };
+          test-fixture-nested-module = callPkgWith ./tests/nix/nested_module_test.nix {
+            inherit flake system;
+          };
           test-fixture-torture-app-full = callPkgWith ./packages/test-fixture-torture-app-full/default.nix {
             inherit flake system;
           };
@@ -200,8 +206,6 @@
           golangci-lint-go2nix-testgen = callPkg ./packages/golangci-lint-go2nix-testgen/default.nix;
           check-godebug-table = callPkg ./packages/check-godebug-table/default.nix;
           cross-platform-env = callPkgWith ./tests/nix/cross_platform_test.nix { inherit pkgs; };
-          mainsrc-replace = callPkgWith ./tests/nix/mainsrc_replace_test.nix { inherit pkgs; };
-          nested-module = callPkgWith ./tests/nix/nested_module_test.nix { inherit pkgs; };
           # tests/nix/{helpers,fetch_go_module}_test.nix return `true` or
           # throw. seq forces them at eval time so a failure breaks the
           # check; the runCommand body is just the success marker.

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -81,11 +81,7 @@ let
   inherit (lib)
     concatStringsSep
     filterAttrs
-    foldl
     genAttrs
-    hasPrefix
-    init
-    last
     mapAttrsToList
     optional
     optionalAttrs
@@ -93,7 +89,6 @@ let
     optionals
     removePrefix
     splitString
-    unique
     ;
 
   hasPackageOverrides = packageOverrides != { };
@@ -419,6 +414,15 @@ let
     // (if CGO_ENABLED != null then { cgoEnabled = toString CGO_ENABLED; } else { })
   );
 
+  # Precomputed by the plugin: every src-relative directory containing a
+  # go.mod. Replaces per-filter `pathExists (path + "/go.mod")` syscalls.
+  nestedModuleRootSet = builtins.listToAttrs (
+    map (r: {
+      name = r;
+      value = true;
+    }) goPackagesResult.nestedModuleRoots
+  );
+
   # Module hashes from plugin (lockfile-free path).
   pluginModules =
     if hasLockfile then
@@ -591,7 +595,7 @@ let
             let
               rel = removePrefix srcPrefix (toString path);
             in
-            !(localPkgDirSet ? ${rel} || builtins.pathExists (path + "/go.mod"))
+            !(localPkgDirSet ? ${rel} || nestedModuleRootSet ? ${rel})
           );
       };
 
@@ -803,54 +807,11 @@ let
         if modRoot == "." then clean else "${cleanModRoot}/${clean}"
       ) normalizedSubPackages;
 
-      # Resolve a/b/../c → a/c in src-relative string space. Kept here
-      # (not in helpers.nix) because it needs lib for string ops.
-      normalizeRelPath =
-        p:
-        let
-          folded = foldl (
-            acc: seg:
-            if seg == "" || seg == "." then
-              acc
-            else if seg == ".." then
-              if acc == [ ] || last acc == ".." then acc ++ [ ".." ] else init acc
-            else
-              acc ++ [ seg ]
-          ) [ ] (splitString "/" p);
-        in
-        if folded == [ ] then "." else concatStringsSep "/" folded;
-
-      # Transitively collect local-replace target dirs, src-relative.
-      # Reads go.mod via the src store path so it works whether src is a
-      # literal path, a fileset.toSource result, or a builtin fetcher.
-      replaceDirsOf =
-        startDir:
-        map (x: x.key) (
-          builtins.genericClosure {
-            startSet = [ { key = startDir; } ];
-            operator =
-              { key, ... }:
-              let
-                goMod = "${src}/${key}/go.mod";
-                rels =
-                  if hasPrefix ".." key then
-                    # Replace target escaped src — nothing more to read.
-                    [ ]
-                  else if builtins.pathExists goMod then
-                    helpers.parseLocalReplaces (builtins.readFile goMod)
-                  else
-                    [ ];
-              in
-              map (r: { key = normalizeRelPath "${key}/${r}"; }) rels;
-          }
-        );
-      # Only when tests run — keeps mainSrc (and so the link drv hash)
-      # unchanged for doCheck = false builds.
-      replaceDirs = optionals doCheck (
-        builtins.filter (d: d != cleanModRoot && d != "." && !(hasPrefix ".." d)) (
-          replaceDirsOf cleanModRoot
-        )
-      );
+      # Local-replace target dirs (src-relative, transitive). Computed in
+      # the plugin from go.mod, so no readFile + regex walk here. Only used
+      # when tests run — keeps mainSrc (and so the link drv hash) unchanged
+      # for doCheck = false builds.
+      replaceDirs = optionals doCheck goPackagesResult.localReplaceDirs;
 
       # Include modRoot for go.mod access plus sibling-replace module roots
       # so the testrunner can walk them.
@@ -906,7 +867,7 @@ let
         # A go.mod-bearing directory that isn't an allowed module root
         # (modRoot, a subPackage dir, or a local-replace target) is a
         # nested-module boundary; go list stopped there.
-        && !(type == "directory" && !(allowedDirSet ? ${rel}) && builtins.pathExists (path + "/go.mod"));
+        && !(type == "directory" && !(allowedDirSet ? ${rel}) && nestedModuleRootSet ? ${rel});
     };
 
   moduleRoot = if modRoot == "." then "${mainSrc}" else "${mainSrc}/${modRoot}";
@@ -964,7 +925,7 @@ let
     // {
       subPackages =
         let
-          inherit (goPackagesResult) modulePath;
+          inherit (goPackagesResult) modulePath subPackageClosures;
           spImportPath =
             sp:
             let
@@ -972,56 +933,13 @@ let
             in
             if sp == "." || clean == "" then modulePath else "${modulePath}/${clean}";
 
-          # Per-subPackage transitive module closure for modinfo deps.
-          # `go build` records only modules whose packages are actually
-          # linked into the binary; recording allModules over-reports
-          # test-only deps and modules used by other subPackages.
-          # genericClosure dedupes by key, so cycles terminate.
-          importsOf =
-            ip:
-            let
-              lp = goPackagesResult.localPackages.${ip} or null;
-              tp = goPackagesResult.packages.${ip} or null;
-            in
-            if lp != null then
-              (lp.localImports or [ ]) ++ (lp.thirdPartyImports or [ ])
-            else if tp != null then
-              tp.imports or [ ]
-            else
-              [ ];
-          closureOf =
-            ip:
-            builtins.genericClosure {
-              startSet = [ { key = ip; } ];
-              operator = item: map (i: { key = i; }) (importsOf item.key);
-            };
-          modKeysOf =
-            closure:
-            unique (
-              builtins.concatMap (
-                item:
-                let
-                  p = goPackagesResult.packages.${item.key} or null;
-                in
-                optional (p != null) p.modKey
-              ) closure
-            );
+          # Per-subPackage closure (modKeys + cxx) is precomputed in the
+          # plugin: `go build` records only modules whose packages are
+          # actually linked into the binary; recording allModules would
+          # over-report test-only deps and modules used by other subPackages.
           # cmd/go's gcToolchain.ld picks CXX over CC for -extld when any
           # package in root.Deps has CXXFiles || SwigCXXFiles
-          # (cmd/go/internal/work/gc.go:591-595). The closure already
-          # includes the main package (start node), so this also covers the
-          # main-package-itself-has-cxx case without a side-channel marker.
-          hasCxx =
-            closure:
-            builtins.any (
-              item:
-              let
-                f =
-                  (goPackagesResult.localPackages.${item.key} or goPackagesResult.packages.${item.key} or { }).files
-                    or { };
-              in
-              (f.cxxFiles or [ ]) != [ ] || (f.swigCxxFiles or [ ]) != [ ]
-            ) closure;
+          # (cmd/go/internal/work/gc.go:591-595).
           toModule =
             modKey:
             let
@@ -1040,15 +958,13 @@ let
           sp:
           let
             ip = spImportPath sp;
-            # Evaluated once and shared so genericClosure runs once per
-            # subPackage, not once each for modKeysOf and hasCxx.
-            closure = closureOf ip;
+            closure = subPackageClosures.${ip};
           in
           {
             path = sp;
             files = goPackagesResult.localPackages.${ip}.files or null;
-            modules = map toModule (modKeysOf closure);
-            cxx = hasCxx closure;
+            modules = map toModule closure.modKeys;
+            inherit (closure) cxx;
           }
         ) normalizedSubPackages;
       inherit moduleRoot;

--- a/packages/go2nix-nix-plugin/rust/src/lib.rs
+++ b/packages/go2nix-nix-plugin/rust/src/lib.rs
@@ -74,8 +74,7 @@ pub unsafe extern "C" fn resolve_go_packages_json(
             std::collections::BTreeMap::new()
         };
 
-        resolve::package_graph_to_json(&graph, &opts.src, hashes)
-            .map_err(|e| format!("{e:#}"))
+        resolve::package_graph_to_json(&graph, &opts, hashes).map_err(|e| format!("{e:#}"))
     }
 
     match inner(input_json) {

--- a/packages/go2nix-nix-plugin/rust/src/resolve.rs
+++ b/packages/go2nix-nix-plugin/rust/src/resolve.rs
@@ -6,7 +6,8 @@
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
 /// Baked-in default Go binary path, set at compile time via GO2NIX_DEFAULT_GO.
@@ -900,6 +901,15 @@ struct JsonOutput {
     /// Only populated when resolveHashes is true.
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     module_hashes: BTreeMap<String, String>,
+    /// Precomputed per-subPackage import closure (modKeys + cxx).
+    /// Replaces the Nix-side `genericClosure` walk.
+    sub_package_closures: BTreeMap<String, JsonClosure>,
+    /// Transitive local-replace target dirs (src-relative, normalized).
+    /// Replaces the Nix-side go.mod readFile + regex walk.
+    local_replace_dirs: Vec<String>,
+    /// All src-relative directories containing a go.mod. Replaces per-filter
+    /// `pathExists (path + "/go.mod")` syscalls.
+    nested_module_roots: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -925,6 +935,16 @@ struct JsonPkg {
 struct JsonReplacement {
     path: String,
     version: String,
+}
+
+/// Per-subPackage transitive closure summary so `nix/dag` can skip its
+/// `genericClosure` walk: the modKey set (for modinfo `dep` lines) and the
+/// CXX flag (for `-extld`).
+#[derive(Serialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct JsonClosure {
+    mod_keys: Vec<String>,
+    cxx: bool,
 }
 
 /// Convert a `PkgData` to a `JsonPkg`, filtering imports to only include
@@ -963,12 +983,228 @@ fn pkg_data_to_json_pkg(p: &PkgData, allowed_imports: &dyn Fn(&str) -> bool) -> 
     }
 }
 
+/// Map `["./cmd/foo", "."]` → import paths under `module_path`, matching
+/// dag.nix's `spImportPath`.
+fn sub_package_import_path(module_path: &str, sp: &str) -> String {
+    let clean = sp.strip_prefix("./").unwrap_or(sp);
+    if sp == "." || clean.is_empty() {
+        module_path.to_owned()
+    } else {
+        format!("{module_path}/{clean}")
+    }
+}
+
+/// BFS the import graph from each subPackage's import path, collecting the
+/// set of third-party modKeys and whether any reached package has C++/SWIG-C++
+/// sources. Mirrors dag.nix's `closureOf` + `modKeysOf` + `hasCxx`.
+fn compute_sub_package_closures(
+    graph: &PackageGraph,
+    sub_packages: &[String],
+) -> BTreeMap<String, JsonClosure> {
+    // Index third-party packages by import path → (modKey, hasCxx, &imports).
+    let mod_key_of = |p: &PkgData| -> String {
+        let v = if p.replace_version.is_empty() {
+            &p.mod_version
+        } else {
+            &p.replace_version
+        };
+        format!("{}@{v}", p.mod_path)
+    };
+    let has_cxx = |f: &PkgFiles| !f.cxx_files.is_empty() || !f.swig_cxx_files.is_empty();
+
+    let tp_index: BTreeMap<&str, (String, bool, &[String])> = graph
+        .packages
+        .iter()
+        .map(|p| {
+            (
+                p.import_path.as_str(),
+                (mod_key_of(p), has_cxx(&p.files), p.imports.as_slice()),
+            )
+        })
+        .collect();
+    let local_index: BTreeMap<&str, (&LocalPkgData, bool)> = graph
+        .local_packages
+        .iter()
+        .chain(graph.test_local_packages.iter())
+        .map(|p| (p.import_path.as_str(), (p, has_cxx(&p.files))))
+        .collect();
+
+    let mut out = BTreeMap::new();
+    for sp in sub_packages {
+        let root = sub_package_import_path(&graph.module_path, sp);
+        let mut visited: BTreeSet<&str> = BTreeSet::new();
+        let mut queue: VecDeque<&str> = VecDeque::new();
+        let mut mod_keys: BTreeSet<String> = BTreeSet::new();
+        let mut cxx = false;
+
+        queue.push_back(root.as_str());
+        while let Some(ip) = queue.pop_front() {
+            if !visited.insert(ip) {
+                continue;
+            }
+            if let Some((lp, lcxx)) = local_index.get(ip) {
+                cxx |= lcxx;
+                for imp in lp.local_imports.iter().chain(lp.third_party_imports.iter()) {
+                    queue.push_back(imp.as_str());
+                }
+            } else if let Some((mk, tcxx, imports)) = tp_index.get(ip) {
+                cxx |= tcxx;
+                mod_keys.insert(mk.clone());
+                for imp in imports.iter() {
+                    queue.push_back(imp.as_str());
+                }
+            }
+        }
+
+        out.insert(
+            root,
+            JsonClosure {
+                mod_keys: mod_keys.into_iter().collect(),
+                cxx,
+            },
+        );
+    }
+    out
+}
+
+/// Normalize `a/b/../c` → `a/c` in pure string space (mirrors dag.nix's
+/// `normalizeRelPath`).
+fn normalize_rel(p: &str) -> String {
+    let mut out: Vec<&str> = Vec::new();
+    for seg in p.split('/') {
+        match seg {
+            "" | "." => {}
+            ".." => match out.last() {
+                Some(&last) if last != ".." => {
+                    out.pop();
+                }
+                _ => out.push(".."),
+            },
+            s => out.push(s),
+        }
+    }
+    if out.is_empty() {
+        ".".to_owned()
+    } else {
+        out.join("/")
+    }
+}
+
+/// Transitively walk local-replace directives (`=> ./X` / `=> ../X`) starting
+/// from `mod_root`, returning normalized src-relative target dirs (excluding
+/// `mod_root` itself, `"."`, and any that escape `src` via `..`).
+/// Mirrors dag.nix's `replaceDirsOf` + the post-filter.
+fn walk_local_replace_dirs(src: &Path, mod_root: &str) -> Vec<String> {
+    fn parse_local_replaces(text: &str) -> Vec<String> {
+        // `=>` only appears in `replace` directives; a local target is one
+        // starting with `./` or `../`. Same condition as helpers.nix.
+        text.lines()
+            .filter_map(|l| {
+                let i = l.find("=>")?;
+                let tgt = l[i + 2..].trim().split_whitespace().next()?;
+                if tgt.starts_with("./") || tgt.starts_with("../") {
+                    Some(tgt.to_owned())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    let clean_mod_root = normalize_rel(mod_root);
+    let mut visited: BTreeSet<String> = BTreeSet::new();
+    let mut queue: VecDeque<String> = VecDeque::new();
+    queue.push_back(clean_mod_root.clone());
+    let mut out: Vec<String> = Vec::new();
+
+    while let Some(dir) = queue.pop_front() {
+        if !visited.insert(dir.clone()) {
+            continue;
+        }
+        if dir.starts_with("..") {
+            continue;
+        }
+        let go_mod = if dir == "." {
+            src.join("go.mod")
+        } else {
+            src.join(&dir).join("go.mod")
+        };
+        let Ok(text) = std::fs::read_to_string(&go_mod) else {
+            continue;
+        };
+        for r in parse_local_replaces(&text) {
+            let next = normalize_rel(&format!("{dir}/{r}"));
+            if visited.contains(&next) {
+                continue;
+            }
+            if next != clean_mod_root && next != "." && !next.starts_with("..") {
+                out.push(next.clone());
+            }
+            queue.push_back(next);
+        }
+    }
+    // Dedupe + sort for determinism.
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Walk `src` for every directory containing a `go.mod`; return src-relative
+/// paths (`.` for src itself). Descent does NOT stop at boundaries — the
+/// dag-side filter decides which are nested vs allowed (modRoot/replace dirs).
+fn find_nested_module_roots(src: &Path) -> Vec<String> {
+    fn rel_of(src: &Path, p: &Path) -> String {
+        let r = p.strip_prefix(src).unwrap_or(p);
+        let mut s = String::new();
+        for c in r.components() {
+            if let Component::Normal(seg) = c {
+                if !s.is_empty() {
+                    s.push('/');
+                }
+                s.push_str(&seg.to_string_lossy());
+            }
+        }
+        if s.is_empty() {
+            ".".to_owned()
+        } else {
+            s
+        }
+    }
+
+    let mut out: Vec<String> = Vec::new();
+    let mut stack: Vec<PathBuf> = vec![src.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        if dir.join("go.mod").is_file() {
+            out.push(rel_of(src, &dir));
+        }
+        let Ok(rd) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in rd.flatten() {
+            let Ok(ft) = entry.file_type() else { continue };
+            if !ft.is_dir() {
+                continue;
+            }
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            // Skip hidden + Go-ignored testdata/vendor.
+            if name.starts_with('.') || name == "testdata" || name == "vendor" {
+                continue;
+            }
+            stack.push(entry.path());
+        }
+    }
+    out.sort();
+    out
+}
+
 /// Convert a `PackageGraph` to a JSON string.
 pub(crate) fn package_graph_to_json(
     graph: &PackageGraph,
-    src_dir: &str,
+    input: &JsonInput,
     module_hashes: BTreeMap<String, String>,
 ) -> Result<String> {
+    let src_dir = input.src.as_str();
     let canon_src = std::fs::canonicalize(src_dir)
         .with_context(|| format!("failed to canonicalize src dir: {src_dir}"))?;
 
@@ -1070,6 +1306,10 @@ pub(crate) fn package_graph_to_json(
         })
         .collect();
 
+    let sub_package_closures = compute_sub_package_closures(graph, &input.sub_packages);
+    let local_replace_dirs = walk_local_replace_dirs(&canon_src, &input.mod_root);
+    let nested_module_roots = find_nested_module_roots(&canon_src);
+
     let output = JsonOutput {
         packages,
         local_packages,
@@ -1079,6 +1319,9 @@ pub(crate) fn package_graph_to_json(
         test_packages,
         test_local_packages,
         module_hashes,
+        sub_package_closures,
+        local_replace_dirs,
+        nested_module_roots,
     };
 
     serde_json::to_string(&output).context("failed to serialize output JSON")
@@ -1242,10 +1485,26 @@ mod tests {
         let graph = parse_go_packages(input.as_bytes()).unwrap();
 
         let mut hashes = BTreeMap::new();
-        hashes.insert("github.com/new/pkg@v2.0.0".to_owned(), "sha256-fork".to_owned());
+        hashes.insert(
+            "github.com/new/pkg@v2.0.0".to_owned(),
+            "sha256-fork".to_owned(),
+        );
 
         let src = tempfile::tempdir().unwrap();
-        let json = package_graph_to_json(&graph, src.path().to_str().unwrap(), hashes).unwrap();
+        let input = JsonInput {
+            go: None,
+            src: src.path().to_string_lossy().into_owned(),
+            do_check: false,
+            tags: vec![],
+            sub_packages: vec![".".into()],
+            mod_root: ".".into(),
+            goos: String::new(),
+            goarch: String::new(),
+            go_proxy: None,
+            cgo_enabled: String::new(),
+            resolve_hashes: false,
+        };
+        let json = package_graph_to_json(&graph, &input, hashes).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
 
         let mod_hashes = &v["moduleHashes"];
@@ -1357,7 +1616,11 @@ mod tests {
 
     // --- parse_test_packages ---
 
-    fn ptp(input: &str, third_party: &BTreeSet<String>, locals: &BTreeSet<String>) -> TestPassResult {
+    fn ptp(
+        input: &str,
+        third_party: &BTreeSet<String>,
+        locals: &BTreeSet<String>,
+    ) -> TestPassResult {
         let mut replacements = BTreeMap::new();
         parse_test_packages(input.as_bytes(), third_party, locals, &mut replacements).unwrap()
     }
@@ -1409,7 +1672,12 @@ mod tests {
         locals.insert("example.com/m/internal/app".to_owned());
         let input = [
             // Already in build graph: skipped.
-            local_pkg_json("example.com/m/internal/app", "example.com/m", "/src/app", &[]),
+            local_pkg_json(
+                "example.com/m/internal/app",
+                "example.com/m",
+                "/src/app",
+                &[],
+            ),
             // Test-only local importing build-graph local + test-only third-party.
             local_pkg_json(
                 "example.com/m/internal/testutil",
@@ -1704,7 +1972,11 @@ mod tests {
             return;
         };
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("go.mod"), "module example.com/mswig\n\ngo 1.23\n").unwrap();
+        std::fs::write(
+            dir.path().join("go.mod"),
+            "module example.com/mswig\n\ngo 1.23\n",
+        )
+        .unwrap();
         // CgoFiles is required for go/build to classify .m/.swig as package sources.
         std::fs::write(
             dir.path().join("a.go"),
@@ -1727,5 +1999,99 @@ mod tests {
         assert_eq!(f.m_files, vec!["x.m"], "MFiles missing from go list output");
         assert_eq!(f.swig_files, vec!["x.swig"], "SwigFiles missing");
         assert_eq!(f.swig_cxx_files, vec!["x.swigcxx"], "SwigCXXFiles missing");
+    }
+
+    // --- Tier-3 offload: closures ---
+
+    fn tp_with_imports(ip: &str, mp: &str, ver: &str, imports: &[&str], cxx: bool) -> String {
+        let imp: Vec<String> = imports.iter().map(|i| format!("\"{i}\"")).collect();
+        let cxx_field = if cxx { r#","CXXFiles":["a.cc"]"# } else { "" };
+        format!(
+            r#"{{"ImportPath":"{ip}","Module":{{"Path":"{mp}","Version":"{ver}"}},"Imports":[{}]{cxx_field}}}"#,
+            imp.join(",")
+        )
+    }
+
+    #[test]
+    fn test_sub_package_closures() {
+        // Graph: m/cmd/a → m/internal/x → tp/a/pkg, tp/b/pkg
+        //        tp/a/pkg → tp/c/pkg (transitive)
+        //        tp/b/pkg has CXXFiles
+        let stdout = format!(
+            "{}\n{}\n{}\n{}\n{}\n",
+            local_pkg_json("m/cmd/a", "m", "/src/cmd/a", &["m/internal/x"]),
+            local_pkg_json(
+                "m/internal/x",
+                "m",
+                "/src/internal/x",
+                &["tp/a/pkg", "tp/b/pkg"]
+            ),
+            tp_with_imports("tp/a/pkg", "tp/a", "v1.0.0", &["tp/c/pkg"], false),
+            tp_with_imports("tp/b/pkg", "tp/b", "v2.0.0", &[], true),
+            tp_with_imports("tp/c/pkg", "tp/c", "v3.0.0", &[], false),
+        );
+        let graph = parse_go_packages(stdout.as_bytes()).unwrap();
+        let closures = compute_sub_package_closures(&graph, &["./cmd/a".into()]);
+        let c = &closures["m/cmd/a"];
+        assert_eq!(
+            c.mod_keys,
+            vec!["tp/a@v1.0.0", "tp/b@v2.0.0", "tp/c@v3.0.0"]
+        );
+        assert!(c.cxx, "transitive cxx must be true (tp/b has CXXFiles)");
+
+        // Second subPackage with no third-party deps and no cxx.
+        let closures2 = compute_sub_package_closures(&graph, &[".".into()]);
+        // root "." → "m"; m has no local pkg in graph → empty closure
+        assert_eq!(closures2["m"].mod_keys, Vec::<String>::new());
+        assert!(!closures2["m"].cxx);
+    }
+
+    #[test]
+    fn test_normalize_rel() {
+        assert_eq!(normalize_rel("a/b/../c"), "a/c");
+        assert_eq!(normalize_rel("./a/./b"), "a/b");
+        assert_eq!(normalize_rel("a/b/../.."), ".");
+        assert_eq!(normalize_rel("../a"), "../a");
+        assert_eq!(normalize_rel("a/../../b"), "../b");
+    }
+
+    #[test]
+    fn test_walk_local_replace_dirs() {
+        let src = tempfile::tempdir().unwrap();
+        let app = src.path().join("app");
+        let sib = src.path().join("sib");
+        let nested = src.path().join("sib/nested");
+        std::fs::create_dir_all(&app).unwrap();
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(
+            app.join("go.mod"),
+            "module app\nreplace x => ../sib\nreplace y => github.com/y v1.0.0\n",
+        )
+        .unwrap();
+        std::fs::write(
+            sib.join("go.mod"),
+            "module sib\nreplace z => ./nested\nreplace esc => ../../escaped\n",
+        )
+        .unwrap();
+        std::fs::write(nested.join("go.mod"), "module nested\n").unwrap();
+
+        let dirs = walk_local_replace_dirs(src.path(), "app");
+        assert_eq!(dirs, vec!["sib", "sib/nested"]);
+    }
+
+    #[test]
+    fn test_nested_module_roots() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("go.mod"), "module root\n").unwrap();
+        let nested = src.path().join("a/b/nested");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("go.mod"), "module nested\n").unwrap();
+        // testdata is skipped
+        let td = src.path().join("testdata/x");
+        std::fs::create_dir_all(&td).unwrap();
+        std::fs::write(td.join("go.mod"), "module td\n").unwrap();
+
+        let roots = find_nested_module_roots(src.path());
+        assert_eq!(roots, vec![".", "a/b/nested"]);
     }
 }

--- a/packages/go2nix-nix-plugin/rust/src/resolve.rs
+++ b/packages/go2nix-nix-plugin/rust/src/resolve.rs
@@ -1101,7 +1101,7 @@ fn walk_local_replace_dirs(src: &Path, mod_root: &str) -> Vec<String> {
         text.lines()
             .filter_map(|l| {
                 let i = l.find("=>")?;
-                let tgt = l[i + 2..].trim().split_whitespace().next()?;
+                let tgt = l[i + 2..].split_whitespace().next()?;
                 if tgt.starts_with("./") || tgt.starts_with("../") {
                     Some(tgt.to_owned())
                 } else {
@@ -1149,10 +1149,17 @@ fn walk_local_replace_dirs(src: &Path, mod_root: &str) -> Vec<String> {
     out
 }
 
-/// Walk `src` for every directory containing a `go.mod`; return src-relative
-/// paths (`.` for src itself). Descent does NOT stop at boundaries — the
-/// dag-side filter decides which are nested vs allowed (modRoot/replace dirs).
-fn find_nested_module_roots(src: &Path) -> Vec<String> {
+/// Walk under each `start` directory (src-relative) for go.mod-bearing
+/// subdirectories; return all of them src-relative. Seeds are modRoot plus
+/// the local-replace targets — the only subtrees the dag-side `mainSrc` /
+/// `pkgSrc` filters ever descend into — so a monorepo `src` with
+/// `modRoot != "."` does no I/O outside the relevant module roots.
+///
+/// Descent stops at the first go.mod *strictly below* a seed (matches the
+/// `builtins.path` filter, which rejects a nested-module dir and so never
+/// recurses into it). Seeds themselves always have a go.mod and are
+/// included; the dag-side mainSrc filter exempts allowedDirs explicitly.
+fn find_nested_module_roots(src: &Path, starts: &[String]) -> Vec<String> {
     fn rel_of(src: &Path, p: &Path) -> String {
         let r = p.strip_prefix(src).unwrap_or(p);
         let mut s = String::new();
@@ -1171,11 +1178,22 @@ fn find_nested_module_roots(src: &Path) -> Vec<String> {
         }
     }
 
-    let mut out: Vec<String> = Vec::new();
-    let mut stack: Vec<PathBuf> = vec![src.to_path_buf()];
+    let seed_set: BTreeSet<PathBuf> = starts
+        .iter()
+        .map(|s| if s == "." { src.to_path_buf() } else { src.join(s) })
+        .collect();
+
+    let mut out: BTreeSet<String> = BTreeSet::new();
+    let mut stack: Vec<PathBuf> = seed_set.iter().cloned().collect();
     while let Some(dir) = stack.pop() {
-        if dir.join("go.mod").is_file() {
-            out.push(rel_of(src, &dir));
+        let has_gomod = dir.join("go.mod").is_file();
+        if has_gomod {
+            out.insert(rel_of(src, &dir));
+            // Nested boundary below a seed: stop here, matching the
+            // builtins.path filter's no-descend-on-reject behaviour.
+            if !seed_set.contains(&dir) {
+                continue;
+            }
         }
         let Ok(rd) = std::fs::read_dir(&dir) else {
             continue;
@@ -1194,8 +1212,7 @@ fn find_nested_module_roots(src: &Path) -> Vec<String> {
             stack.push(entry.path());
         }
     }
-    out.sort();
-    out
+    out.into_iter().collect()
 }
 
 /// Convert a `PackageGraph` to a JSON string.
@@ -1308,7 +1325,10 @@ pub(crate) fn package_graph_to_json(
 
     let sub_package_closures = compute_sub_package_closures(graph, &input.sub_packages);
     let local_replace_dirs = walk_local_replace_dirs(&canon_src, &input.mod_root);
-    let nested_module_roots = find_nested_module_roots(&canon_src);
+    let nested_starts: Vec<String> = std::iter::once(normalize_rel(&input.mod_root))
+        .chain(local_replace_dirs.iter().cloned())
+        .collect();
+    let nested_module_roots = find_nested_module_roots(&canon_src, &nested_starts);
 
     let output = JsonOutput {
         packages,
@@ -2081,17 +2101,26 @@ mod tests {
 
     #[test]
     fn test_nested_module_roots() {
+        // Monorepo layout: src/{app,sib,unrelated}/ each has go.mod;
+        // app/nested/ has go.mod; nested/under/ has go.mod (must NOT
+        // be reported — descent stops at app/nested).
         let src = tempfile::tempdir().unwrap();
-        std::fs::write(src.path().join("go.mod"), "module root\n").unwrap();
-        let nested = src.path().join("a/b/nested");
-        std::fs::create_dir_all(&nested).unwrap();
-        std::fs::write(nested.join("go.mod"), "module nested\n").unwrap();
-        // testdata is skipped
-        let td = src.path().join("testdata/x");
+        for d in ["app", "app/nested", "app/nested/under", "sib", "unrelated"] {
+            std::fs::create_dir_all(src.path().join(d)).unwrap();
+            std::fs::write(src.path().join(d).join("go.mod"), "module x\n").unwrap();
+        }
+        // testdata under a seed is skipped.
+        let td = src.path().join("app/testdata/x");
         std::fs::create_dir_all(&td).unwrap();
         std::fs::write(td.join("go.mod"), "module td\n").unwrap();
 
-        let roots = find_nested_module_roots(src.path());
-        assert_eq!(roots, vec![".", "a/b/nested"]);
+        // Seeds = modRoot + replaceDirs. unrelated/ is outside both → no I/O.
+        let roots =
+            find_nested_module_roots(src.path(), &["app".into(), "sib".into()]);
+        assert_eq!(roots, vec!["app", "app/nested", "sib"]);
+
+        // modRoot = "." walks the whole src.
+        let roots_all = find_nested_module_roots(src.path(), &[".".into()]);
+        assert_eq!(roots_all, vec!["app", "sib", "unrelated"]);
     }
 }

--- a/packages/test-drv-canary/expected.txt
+++ b/packages/test-drv-canary/expected.txt
@@ -3,7 +3,7 @@
 # go/go2nix/, packages/go2nix-nix-plugin/, nix/dag/hooks/, or the nixpkgs
 # flake input. A change to nix/dag/*.nix alone should NOT require
 # updating this file.
-testify-basic /nix/store/dwd0891b52gmyfgvvxszc8ndq9w7f7q1-testify-basic-0.0.1.drv
-xtest-local-dep /nix/store/wadfi2yz1bwhr2yxcd0zdx19v88g57yq-xtest-local-dep-0.0.1.drv
-cgo-internal-test /nix/store/hyjn415bqmga8zjr1xzkwrwifxksrjh2-cgo-internal-test-0.0.1.drv
-torture-app-full /nix/store/pm53im49pj1h19dfxhcps4l6y8659zwb-torture-app-full-0.0.1.drv
+testify-basic /nix/store/9csffkvgwyv1pmfphskqk8b4kmhmcj4q-testify-basic-0.0.1.drv
+xtest-local-dep /nix/store/7va2vdhw47wkk6sgajg8vs9rkfq459r7-xtest-local-dep-0.0.1.drv
+cgo-internal-test /nix/store/5f7v58dgrvj0fr20mahr3m0y8nwhfmms-cgo-internal-test-0.0.1.drv
+torture-app-full /nix/store/h6v7rjbqyjdd5jvk0l6pid408w1cyhva-torture-app-full-0.0.1.drv

--- a/packages/test-drv-canary/expected.txt
+++ b/packages/test-drv-canary/expected.txt
@@ -3,7 +3,7 @@
 # go/go2nix/, packages/go2nix-nix-plugin/, nix/dag/hooks/, or the nixpkgs
 # flake input. A change to nix/dag/*.nix alone should NOT require
 # updating this file.
-testify-basic /nix/store/9csffkvgwyv1pmfphskqk8b4kmhmcj4q-testify-basic-0.0.1.drv
-xtest-local-dep /nix/store/7va2vdhw47wkk6sgajg8vs9rkfq459r7-xtest-local-dep-0.0.1.drv
-cgo-internal-test /nix/store/5f7v58dgrvj0fr20mahr3m0y8nwhfmms-cgo-internal-test-0.0.1.drv
-torture-app-full /nix/store/wqx0hwd7nwdgnq9s9v4ww4a3151mmrpw-torture-app-full-0.0.1.drv
+testify-basic /nix/store/dwd0891b52gmyfgvvxszc8ndq9w7f7q1-testify-basic-0.0.1.drv
+xtest-local-dep /nix/store/wadfi2yz1bwhr2yxcd0zdx19v88g57yq-xtest-local-dep-0.0.1.drv
+cgo-internal-test /nix/store/hyjn415bqmga8zjr1xzkwrwifxksrjh2-cgo-internal-test-0.0.1.drv
+torture-app-full /nix/store/pm53im49pj1h19dfxhcps4l6y8659zwb-torture-app-full-0.0.1.drv

--- a/packages/test-eval-stats/default.nix
+++ b/packages/test-eval-stats/default.nix
@@ -79,10 +79,10 @@ else
         fi
       }
 
-      # Baseline @ 13b4e98: 611,001 / 327,242 / 957,299. ~15% headroom.
-      check nrFunctionCalls 700000
-      check nrPrimOpCalls   380000
-      check nrThunks        1100000
+      # Baseline post-Tier-3: 508,738 / 271,447 / 874,295. ~15% headroom.
+      check nrFunctionCalls 590000
+      check nrPrimOpCalls   320000
+      check nrThunks        1010000
 
       if [ "$fail" -ne 0 ]; then
         cat >&2 <<'EOF'

--- a/tests/nix/mainsrc_replace_test.nix
+++ b/tests/nix/mainsrc_replace_test.nix
@@ -7,66 +7,92 @@
 # resolve them. torture-project/app-full has 14 such siblings under
 # ../internal/*.
 #
-# Eval-only: mainSrc is computed from go.mod parsing alone and does not
-# force goPackagesResult, so this check does not need the plugin.
+# Plugin-wrapped: mainSrc reads goPackagesResult.localReplaceDirs, so the
+# inner evaluation needs --option plugin-files (and GOMODCACHE for the
+# torture project's go list pass).
 {
-  lib,
+  flake,
   pkgs,
-  runCommand,
+  system,
+  ...
 }:
-let
-  go2nix = import ../../packages/go2nix { inherit pkgs; };
-  scope = import ../../nix/mk-go-env.nix {
-    inherit (pkgs) go callPackage;
-    inherit go2nix;
-  };
-  mkApp =
-    doCheck:
-    scope.buildGoApplication {
-      pname = "mainsrc-replace-test";
-      version = "0.0.1";
-      src = ../fixtures/torture-project;
-      goLock = ../fixtures/torture-project/app-full/go2nix.toml;
-      modRoot = "app-full";
-      subPackages = [ "cmd/app-full" ];
-      inherit doCheck;
-    };
-  ms = (mkApp true).passthru.mainSrc;
-  msNoCheck = (mkApp false).passthru.mainSrc;
-
-  assertions = [
-    {
-      msg = "modRoot's own go.mod must be present";
-      ok = builtins.pathExists "${ms}/app-full/go.mod";
-    }
-    {
-      msg = "sibling replace target ../internal/aws must be in mainSrc";
-      ok = builtins.pathExists "${ms}/internal/aws/go.mod";
-    }
-    {
-      msg = "sibling replace target ../internal/common must be in mainSrc";
-      ok = builtins.pathExists "${ms}/internal/common/go.mod";
-    }
-    {
-      msg = "non-replace sibling app-partial must NOT be in mainSrc";
-      ok = !(builtins.pathExists "${ms}/app-partial");
-    }
-    {
-      msg = "non-replace sibling app-replace must NOT be in mainSrc";
-      ok = !(builtins.pathExists "${ms}/app-replace");
-    }
-    {
-      msg = "doCheck=false mainSrc must NOT include sibling dirs (no hash churn)";
-      ok = !(builtins.pathExists "${msNoCheck}/internal");
-    }
-  ];
-
-  failures = lib.filter (a: !a.ok) assertions;
-in
-if failures != [ ] then
-  throw "mainsrc-replace-test: ${lib.concatMapStringsSep "; " (a: a.msg) failures}"
-else
-  runCommand "mainsrc-replace-test" { } ''
-    echo "mainsrc-replace-test: ${toString (lib.length assertions)} assertions passed"
-    touch $out
+if !(flake.packages.${system} ? go2nix-nix-plugin) then
+  pkgs.runCommand "mainsrc-replace-test-unsupported" { meta.platforms = pkgs.lib.platforms.linux; } ''
+    echo "mainsrc-replace-test requires go2nix-nix-plugin (Linux only)" >&2
+    exit 1
   ''
+else
+  let
+    plugin = flake.packages.${system}.go2nix-nix-plugin;
+    nix = pkgs.nixVersions.nix_2_34;
+    go = pkgs.go_1_26;
+    nixpkgsPath = pkgs.path;
+    go2nixSrc = flake;
+
+    tortureModules = pkgs.stdenvNoCC.mkDerivation {
+      name = "torture-app-full-gomodcache";
+      outputHashMode = "recursive";
+      outputHashAlgo = "sha256";
+      outputHash = "sha256-uQKbuVSzWJhqbvPwi1KL5OKlYpPjHoA437m7zgQlrbA=";
+      nativeBuildInputs = [
+        go
+        pkgs.cacert
+      ];
+      dontUnpack = true;
+      buildPhase = ''
+        export HOME=$TMPDIR
+        export GOMODCACHE=$out
+        cd ${go2nixSrc}/tests/fixtures/torture-project/app-full
+        go mod download
+      '';
+      installPhase = "true";
+    };
+  in
+  pkgs.runCommand "mainsrc-replace-test"
+    {
+      nativeBuildInputs = [ nix ];
+      requiredSystemFeatures = [ "recursive-nix" ];
+    }
+    ''
+      export HOME=$(mktemp -d)
+      export NIX_CONFIG="extra-experimental-features = nix-command recursive-nix"
+
+      build_mainsrc() {
+        GOMODCACHE="${tortureModules}" nix-instantiate --eval --read-write-mode --raw \
+          -I nixpkgs=${nixpkgsPath} \
+          --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
+          -A passthru.mainSrc \
+          --argstr doCheck "$1" \
+          --expr "
+            { doCheck }:
+            let pkgs = import <nixpkgs> {}; go = pkgs.go_1_26;
+                go2nix = import ${go2nixSrc}/packages/go2nix { inherit pkgs; };
+                goEnv = import ${go2nixSrc}/nix/mk-go-env.nix {
+                  inherit go go2nix; inherit (pkgs) callPackage;
+                };
+            in goEnv.buildGoApplication {
+              pname = \"mainsrc-replace-test\"; version = \"0.0.1\";
+              src = ${go2nixSrc}/tests/fixtures/torture-project;
+              goLock = ${go2nixSrc}/tests/fixtures/torture-project/app-full/go2nix.toml;
+              modRoot = \"app-full\";
+              subPackages = [ \"cmd/app-full\" ];
+              doCheck = doCheck == \"true\";
+            }"
+      }
+
+      ms=$(build_mainsrc true)
+      msNoCheck=$(build_mainsrc false)
+
+      fail=0
+      check() { if ! eval "$1"; then echo "FAIL: $2"; fail=1; else echo "  ok: $2"; fi; }
+
+      check '[ -e "$ms/app-full/go.mod" ]'        "modRoot's own go.mod must be present"
+      check '[ -e "$ms/internal/aws/go.mod" ]'    "sibling replace target ../internal/aws must be in mainSrc"
+      check '[ -e "$ms/internal/common/go.mod" ]' "sibling replace target ../internal/common must be in mainSrc"
+      check '[ ! -e "$ms/app-partial" ]'          "non-replace sibling app-partial must NOT be in mainSrc"
+      check '[ ! -e "$ms/app-replace" ]'          "non-replace sibling app-replace must NOT be in mainSrc"
+      check '[ ! -e "$msNoCheck/internal" ]'      "doCheck=false mainSrc must NOT include sibling dirs (no hash churn)"
+
+      [ "$fail" -eq 0 ] || exit 1
+      echo "mainsrc-replace-test: 6 assertions passed" > $out
+    ''

--- a/tests/nix/nested_module_test.nix
+++ b/tests/nix/nested_module_test.nix
@@ -6,53 +6,50 @@
 # per-package pkgSrc filters must drop the whole subtree; otherwise touching
 # a nested-module file would invalidate the parent package's compile drv.
 #
-# Eval-only: mainSrc is computed from go.mod parsing alone and does not
-# force goPackagesResult, so this check does not need the plugin.
+# Plugin-wrapped: mainSrc reads goPackagesResult.nestedModuleRoots, so the
+# inner evaluation needs --option plugin-files.
 {
-  lib,
+  flake,
   pkgs,
-  runCommand,
+  system,
+  ...
 }:
-let
-  go2nix = import ../../packages/go2nix { inherit pkgs; };
-  scope = import ../../nix/mk-go-env.nix {
-    inherit (pkgs) go callPackage;
-    inherit go2nix;
-  };
-  app = scope.buildGoApplication {
-    pname = "nested-module-test";
-    version = "0.0.1";
-    src = ../fixtures/modroot-nested;
-    goLock = ../fixtures/modroot-nested/app/go2nix.toml;
-    modRoot = "app";
-  };
-  ms = app.passthru.mainSrc;
-
-  assertions = [
-    {
-      msg = "modRoot's own go.mod must be present";
-      ok = builtins.pathExists "${ms}/app/go.mod";
-    }
-    {
-      msg = "main.go must be present";
-      ok = builtins.pathExists "${ms}/app/main.go";
-    }
-    {
-      msg = "internal/util (a real local package) must be present";
-      ok = builtins.pathExists "${ms}/app/internal/util/util.go";
-    }
-    {
-      msg = "nested-module subtree must NOT be in mainSrc";
-      ok = !(builtins.pathExists "${ms}/app/nested-module");
-    }
-  ];
-
-  failures = lib.filter (a: !a.ok) assertions;
-in
-if failures != [ ] then
-  throw "nested-module-test: ${lib.concatMapStringsSep "; " (a: a.msg) failures}"
-else
-  runCommand "nested-module-test" { } ''
-    echo "nested-module-test: ${toString (lib.length assertions)} assertions passed"
-    touch $out
+if !(flake.packages.${system} ? go2nix-nix-plugin) then
+  pkgs.runCommand "nested-module-test-unsupported" { meta.platforms = pkgs.lib.platforms.linux; } ''
+    echo "nested-module-test requires go2nix-nix-plugin (Linux only)" >&2
+    exit 1
   ''
+else
+  let
+    plugin = flake.packages.${system}.go2nix-nix-plugin;
+    nix = pkgs.nixVersions.nix_2_34;
+    nixpkgsPath = pkgs.path;
+    go2nixSrc = flake;
+  in
+  pkgs.runCommand "nested-module-test"
+    {
+      nativeBuildInputs = [ nix ];
+      requiredSystemFeatures = [ "recursive-nix" ];
+    }
+    ''
+      export HOME=$(mktemp -d)
+      export NIX_CONFIG="extra-experimental-features = nix-command recursive-nix"
+      mkdir -p "$TMPDIR/empty-gmc"
+
+      ms=$(GOMODCACHE="$TMPDIR/empty-gmc" nix-instantiate --eval --read-write-mode --raw \
+        -I nixpkgs=${nixpkgsPath} \
+        --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
+        -A passthru.mainSrc \
+        ${go2nixSrc}/tests/fixtures/modroot-nested/dag.nix)
+
+      fail=0
+      check() { if ! eval "$1"; then echo "FAIL: $2"; fail=1; else echo "  ok: $2"; fi; }
+
+      check '[ -e "$ms/app/go.mod" ]'             "modRoot's own go.mod must be present"
+      check '[ -e "$ms/app/main.go" ]'            "main.go must be present"
+      check '[ -e "$ms/app/internal/util/util.go" ]' "internal/util (a real local package) must be present"
+      check '[ ! -e "$ms/app/nested-module" ]'    "nested-module subtree must NOT be in mainSrc"
+
+      [ "$fail" -eq 0 ] || exit 1
+      echo "nested-module-test: 4 assertions passed" > $out
+    ''


### PR DESCRIPTION
## Summary

Moves three structural computations from `nix/dag/default.nix` into the Rust plugin (`resolveGoPackages`) so they run once in Rust instead of in Nix eval. The plugin already has the full package graph; everything moved is pure post-processing of data it already holds.

**Plugin** (`resolve.rs` +~400):
- `compute_sub_package_closures` — BFS the import graph for each subPackage, collecting modKeys (third-party modules linked into the binary) and the cxx flag. Emitted as `subPackageClosures`.
- `walk_local_replace_dirs` — transitive go.mod local-replace walk (`=> ./X` / `=> ../X`), normalized src-relative dirs. Emitted as `localReplaceDirs`.
- `find_nested_module_roots` — bounded scan from `[modRoot] ∪ localReplaceDirs` for go.mod-bearing subdirectories. Stops at the first boundary below each seed. Emitted as `nestedModuleRoots`.

**`nix/dag/default.nix`** (1158 → 1074, **−84 lines**):
- `subPackages` closure: `importsOf`/`closureOf`/`modKeysOf`/`hasCxx` and the `genericClosure` walk deleted; reads `subPackageClosures.${ip}`.
- `replaceDirs`: `normalizeRelPath`/`replaceDirsOf` and the `readFile` + regex `genericClosure` deleted; reads `localReplaceDirs`.
- `pkgSrc`/`mainSrc` filters: `pathExists (path + "/go.mod")` per directory replaced with `nestedModuleRootSet ? rel`.
- Dropped now-unused `inherit (lib) foldl/init/last/unique`.

| eval-stats (torture, 1 subPackage / 477 modKeys) | before (Tier-2) | after | Δ |
|---|---|---|---|
| nrFunctionCalls | 548,874 | 508,738 | **−7.3%** |
| nrPrimOpCalls | 279,447 | 271,447 | **−2.9%** |
| nrThunks | 905,042 | 874,295 | **−3.4%** |

Torture under-weights this (single subPackage). The deleted `genericClosure` cost was per-subPackage × graph-size; the win scales linearly with `subPackages × packages` for projects with many binaries.

**Drv-hash:** `testify-basic` / `xtest-local-dep` / `cgo-internal-test` unchanged. `torture-app-full` changes only because modKeys are now BTreeSet-sorted (was Nix `unique` insertion-order); 477/477 modules identical, link binary unchanged.

**Test migration:** `tests/nix/{mainsrc_replace,nested_module}_test.nix` were eval-only (didn't force `goPackagesResult`); now `mainSrc` reads plugin output, so converted to recursive-nix wrappers using `nix-instantiate --eval --read-write-mode --raw -A passthru.mainSrc` with `--option plugin-files`. Moved from `checks.{mainsrc-replace,nested-module}` → `packages.test-fixture-{mainsrc-replace,nested-module}`. All 10 assertions pass.

## Test plan

- [x] `cargo test` 49 ok (4 new: `test_sub_package_closures`, `test_normalize_rel`, `test_walk_local_replace_dirs`, `test_nested_module_roots`)
- [x] `test-golden-vs-gobuild` 9/9 IDENTICAL/SUBSET-OK
- [x] `test-drv-canary` PASS (regenerated)
- [x] `test-eval-stats` PASS, thresholds lowered to lock in
- [x] `test-fixture-{nested-module,mainsrc-replace,testify-basic,modroot-nested,torture-app-full}` PASS
- [x] `nix flake check` (formatting)