### PR TITLE
dag: add extraMainSrcFiles for tests that read non-testdata runtime files

### DIFF
--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -74,6 +74,12 @@
   # the old (modRoot == ".") default existed. Matches buildGoModule.
   doCheck ? true,
   checkFlags ? [ ],
+  # Extra src-relative paths (files or directories) to include in mainSrc.
+  # The post-#110 mainSrc is precise (.go + resolved //go:embed + testdata/),
+  # so a test that does os.ReadFile("../config.yaml") at runtime won't find
+  # that file by default. Prefer the testdata/ convention; this is the
+  # escape hatch for paths that can't easily move.
+  extraMainSrcFiles ? [ ],
   ...
 }@args:
 
@@ -88,6 +94,7 @@ let
     optionalString
     optionals
     removePrefix
+    removeSuffix
     splitString
     ;
 
@@ -803,8 +810,9 @@ let
   #
   # Edge case: a test that does runtime reads outside testdata/ and outside
   # //go:embed (e.g. os.ReadFile("../config.yaml")) will not find that file.
-  # The supported convention is `testdata/`; anything else needs the caller
-  # to widen `src` or move the fixture under testdata/.
+  # The supported convention is `testdata/`; for paths that can't move, list
+  # them in `extraMainSrcFiles` (each entry is a src-relative file or
+  # directory; directories include their full subtree).
   mainSrc =
     let
       cleanModRoot = removePrefix "./" modRoot;
@@ -863,10 +871,19 @@ let
         }) relevantPkgs
       );
 
+      # extraMainSrcFiles entries match like testdata dirs: the path itself
+      # and (if a directory) everything under it. Trailing "/" is tolerated
+      # so "config/" and "config" behave the same.
+      extraSet = builtins.listToAttrs (
+        map (e: {
+          name = removeSuffix "/" (removePrefix "./" e);
+          value = true;
+        }) extraMainSrcFiles
+      );
+      prefixSet = testdataDirSet // extraSet;
+
       ancestorSet = builtins.listToAttrs (
-        builtins.concatMap walkAncestors (
-          builtins.attrNames mainSrcFileSet ++ builtins.attrNames testdataDirSet
-        )
+        builtins.concatMap walkAncestors (builtins.attrNames mainSrcFileSet ++ builtins.attrNames prefixSet)
       );
       walkAncestors =
         r:
@@ -878,14 +895,14 @@ let
         ]
         ++ optionals (r != "." && r != "") (walkAncestors (builtins.dirOf r));
 
-      underTestdata =
+      underPrefix =
         r:
-        testdataDirSet ? ${r}
+        prefixSet ? ${r}
         || (
           let
             d = builtins.dirOf r;
           in
-          d != "." && d != r && underTestdata d
+          d != "." && d != r && underPrefix d
         );
     in
     builtins.path {
@@ -897,9 +914,9 @@ let
           rel = removePrefix srcPrefix (toString path);
         in
         if type == "directory" then
-          ancestorSet ? ${rel} || underTestdata rel
+          ancestorSet ? ${rel} || underPrefix rel
         else
-          mainSrcFileSet ? ${rel} || underTestdata rel;
+          mainSrcFileSet ? ${rel} || underPrefix rel;
     };
 
   moduleRoot = if modRoot == "." then "${mainSrc}" else "${mainSrc}/${modRoot}";
@@ -932,6 +949,7 @@ let
     "packageOverrides"
     "doCheck"
     "checkFlags"
+    "extraMainSrcFiles"
     "contentAddressed"
   ];
 

--- a/packages/test-mainsrc-precise/default.nix
+++ b/packages/test-mainsrc-precise/default.nix
@@ -56,11 +56,13 @@ else
       assert_in  internal/embed/embed_test.go
       assert_in  internal/embed/schema.json
       assert_in  internal/embed/testdata/golden.json
+      # extraMainSrcFiles entry — runtime-read, not testdata/, not //go:embed
+      assert_in  internal/greet/adjacent.conf
       assert_out internal/greet/README.md
       assert_out internal/greet/unrelated.yaml
       assert_out go2nix.toml
       assert_out dag.nix
 
       [ "$fail" -eq 0 ] || exit 1
-      echo "mainsrc-precise-test: 13 assertions passed" > $out
+      echo "mainsrc-precise-test: 14 assertions passed" > $out
     ''

--- a/tests/fixtures/mainsrc-precise/dag.nix
+++ b/tests/fixtures/mainsrc-precise/dag.nix
@@ -3,6 +3,8 @@
 #   - build-time //go:embed (schema.json) is in mainSrc
 #   - test-only //go:embed (testdata/golden.json) is in mainSrc
 #   - README.md and unrelated.yaml are NOT in mainSrc
+#   - adjacent.conf (runtime-read, non-testdata, non-embed) IS in mainSrc
+#     because it is listed in extraMainSrcFiles
 let
   pkgs = import <nixpkgs> { };
   inherit (pkgs) go;
@@ -19,4 +21,5 @@ goEnv.buildGoApplication {
   goLock = ./go2nix.toml;
   subPackages = [ "./cmd/app" ];
   doCheck = true;
+  extraMainSrcFiles = [ "internal/greet/adjacent.conf" ];
 }

--- a/tests/fixtures/mainsrc-precise/internal/greet/adjacent.conf
+++ b/tests/fixtures/mainsrc-precise/internal/greet/adjacent.conf
@@ -1,0 +1,1 @@
+adjacent-value

--- a/tests/fixtures/mainsrc-precise/internal/greet/greet_test.go
+++ b/tests/fixtures/mainsrc-precise/internal/greet/greet_test.go
@@ -15,3 +15,15 @@ func TestHello(t *testing.T) {
 		t.Fatalf("Hello() = %q, want %q", got, strings.TrimSpace(string(want)))
 	}
 }
+
+// adjacent.conf is NOT under testdata/ and NOT //go:embed-ed; it reaches
+// mainSrc only because dag.nix lists it in extraMainSrcFiles.
+func TestReadAdjacent(t *testing.T) {
+	b, err := os.ReadFile("adjacent.conf")
+	if err != nil {
+		t.Fatalf("read adjacent.conf: %v", err)
+	}
+	if got := strings.TrimSpace(string(b)); got != "adjacent-value" {
+		t.Fatalf("adjacent.conf = %q, want %q", got, "adjacent-value")
+	}
+}


### PR DESCRIPTION
## Summary

Escape hatch for the documented #110 edge case: tests that do `os.ReadFile("../../config/foo")` (not via `//go:embed`, not under `testdata/`) lose those files under #110's precise `mainSrc`. `extraMainSrcFiles ? []` lets a caller opt specific src-relative paths (files or directory prefixes) into `mainSrc`.

Entries normalise `./` prefix and trailing `/`; directories include subtrees via the same `underPrefix` walk as `testdata/`. Hash-neutral when empty (`prefixSet = testdataDirSet // {}` → identical filter result).

## Test plan

- [x] **Hash-neutral when empty** — `test-drv-canary` PASS without regenerating `expected.txt`
- [x] `test-mainsrc-precise` 14/14: `adjacent.conf` IN; `README.md`/`unrelated.yaml` still OUT
- [x] `mainsrc-precise` checkPhase PASS with new `TestReadAdjacent` doing `os.ReadFile("adjacent.conf")`
- [x] `test-golden-vs-gobuild` 9/9 IDENTICAL
- [x] eval-stats +0/+2/+5 (under thresholds); formatting