### PR TITLE
docs: sync builder-api/nix-plugin/test-support with current code

### DIFF
--- a/docs/src/builder-api.md
+++ b/docs/src/builder-api.md
@@ -60,7 +60,7 @@ time and emits an IFD warning.
 | `pgoProfile` | path or `null` | `null` | both | Path to a pprof CPU profile for profile-guided optimization. The profile is passed to every `go tool compile` invocation, so changing it invalidates all package derivations. See [Go's PGO docs](https://go.dev/doc/pgo) for producing a profile. |
 | `nativeBuildInputs` | list | `[]` | both | Extra build inputs for the final derivation. |
 | `packageOverrides` | attrset | `{}` | both | Per-package customization (see below). |
-| `doCheck` | bool | `modRoot == "."` | default only | Run tests. Defaults to `false` when `modRoot` is set, because test discovery may not find local replace targets outside the module root. See [Test Support](test-support.md). |
+| `doCheck` | bool | `true` | default only | Run tests. Matches `buildGoModule`'s default. See [Test Support](test-support.md). |
 | `checkFlags` | list of strings | `[]` | default only | Flags passed to the compiled test binary (e.g., `-v`, `-count=1`). See [Test Support](test-support.md). |
 | `goProxy` | string or `null` | `null` | default only | Custom GOPROXY URL. |
 | `allowGoReference` | bool | `false` | default only | Allow the output to reference the Go toolchain. |
@@ -86,10 +86,9 @@ goEnv.buildGoApplication {
 
 This is necessary when the module uses `replace` directives pointing to sibling
 directories outside `modRoot`. The builder needs access to the full `src` tree,
-with `modRoot` telling it where `go.mod` lives.
-
-When `modRoot != "."`, `doCheck` defaults to `false` — see
-[Test Support](test-support.md#enabling-tests) for why and when to override.
+with `modRoot` telling it where `go.mod` lives. The filtered `mainSrc` for the
+final derivation unions in those sibling replace directories, so `doCheck`
+works regardless of `modRoot`.
 
 ## `subPackages`
 

--- a/docs/src/builder-api.md
+++ b/docs/src/builder-api.md
@@ -138,7 +138,7 @@ goEnv = go2nix.lib.mkGoEnv {
 | `go2nix` | derivation | required | go2nix CLI binary. |
 | `callPackage` | function | required | `pkgs.callPackage`. |
 | `tags` | list of strings | `[]` | Build tags applied to all builds in this scope. |
-| `goEnv` | attrset | `{}` | Environment variables applied to stdlib compilation and every `go tool` invocation in this scope (e.g. `GOEXPERIMENT`). Scope-level because the stdlib derivation is shared by every build in the scope. |
+| `goEnv` | attrset | `{}` | Environment variables applied to stdlib compilation and every `go tool` invocation in this scope (e.g. `GOEXPERIMENT`, `GOFIPS140`). Scope-level because the stdlib derivation is shared by every build in the scope. |
 | `netrcFile` | path or `null` | `null` | `.netrc` file for private module authentication (see below). |
 | `nixPackage` | derivation or `null` | `null` | Nix binary. Required for `buildGoApplicationExperimental`. |
 
@@ -150,6 +150,25 @@ driven the standard nixpkgs way — pass a cross `pkgs` (e.g.
 resulting scope produces binaries for that target. The
 [Nix plugin](nix-plugin.md) is told the target `goos`/`goarch` so build-tag
 evaluation matches the host platform.
+
+## FIPS 140 mode (`GOFIPS140`)
+
+Set `GOFIPS140` via the scope-level `goEnv` to build against the Go FIPS 140
+crypto module, equivalent to `GOFIPS140=latest go build`:
+
+```nix
+goEnv = go2nix.lib.mkGoEnv {
+  inherit (pkgs) go callPackage;
+  go2nix = go2nix.packages.${system}.go2nix;
+  goEnv = { GOFIPS140 = "latest"; };
+};
+```
+
+The variable reaches both `go install std` (so the FIPS-aware stdlib is
+compiled) and the link step, where go2nix emits the matching
+`build GOFIPS140=` modinfo line and folds `fips140=on` into
+`DefaultGODEBUG` — `go version -m` output is identical to a vanilla
+`GOFIPS140=latest go build -trimpath`.
 
 ## Private modules (`netrcFile`)
 

--- a/docs/src/builder-api.md
+++ b/docs/src/builder-api.md
@@ -62,6 +62,7 @@ time and emits an IFD warning.
 | `packageOverrides` | attrset | `{}` | both | Per-package customization (see below). |
 | `doCheck` | bool | `true` | default only | Run tests. Matches `buildGoModule`'s default. See [Test Support](test-support.md). |
 | `checkFlags` | list of strings | `[]` | default only | Flags passed to the compiled test binary (e.g., `-v`, `-count=1`). See [Test Support](test-support.md). |
+| `extraMainSrcFiles` | list of strings | `[]` | default only | Extra `src`-relative paths (files or directories) kept in the filtered test source tree. Escape hatch for tests that read runtime files outside `testdata/` and `//go:embed`. See [Test Support](test-support.md#extramainsrcfiles). |
 | `goProxy` | string or `null` | `null` | default only | Custom GOPROXY URL. |
 | `allowGoReference` | bool | `false` | default only | Allow the output to reference the Go toolchain. |
 | `meta` | attrset | `{}` | default only | Nix meta attributes. |

--- a/docs/src/nix-plugin.md
+++ b/docs/src/nix-plugin.md
@@ -31,8 +31,10 @@ builtins.resolveGoPackages {
 `go` is intentionally omitted: the plugin defaults to the Go toolchain baked
 in at its own build time, so the call carries no derivation context and the
 default-mode evaluation stays IFD-free. You may pass
-`go = "/path/to/bin/go"` to override the toolchain (e.g. a `nix-shell` Go),
-but a derivation-backed value like `"${pkgs.go}/bin/go"` will be rejected.
+`go = "/path/to/bin/go"` to override the toolchain (e.g. a `nix-shell` Go).
+A derivation-backed value like `"${pkgs.go}/bin/go"` is accepted but emits a
+warning and forces the plugin to realise the derivation at eval time — i.e.
+opt-in IFD, still gated by `allow-import-from-derivation`.
 
 It runs `go list -json -deps` against `src` and returns:
 

--- a/docs/src/test-support.md
+++ b/docs/src/test-support.md
@@ -18,13 +18,11 @@ goEnv.buildGoApplication {
 }
 ```
 
-`doCheck` defaults to `true` when `modRoot == "."` and `false` otherwise.
-When `modRoot` points to a subdirectory, the source tree filtered for the
-final derivation may not include local replace targets outside the module
-root, causing test discovery to fail. Override with `doCheck = true` if your
-layout doesn't use out-of-tree replaces. See the
-[Builder API](builder-api.md) table for these and the other `buildGoApplication`
-defaults.
+`doCheck` defaults to `true` (matching `buildGoModule`). The filtered
+`mainSrc` for the final derivation includes local replace targets outside
+`modRoot`, so test discovery works for sibling-replace layouts without
+overrides. See the [Builder API](builder-api.md) table for the other
+`buildGoApplication` defaults.
 
 ## What gets tested
 
@@ -109,8 +107,6 @@ These map to the standard `testing` package flags (`-v`, `-run`, `-count`,
 ## Limitations
 
 - **Default mode only.** The experimental builder does not run tests.
-- **`modRoot != "."`** disables tests by default. The source filter for the
-  final derivation may exclude sibling modules needed by tests.
 - **No per-package test caching.** All local tests re-run whenever the final
   app derivation rebuilds; go2nix does not skip individual test packages
   whose inputs are unchanged (unlike `go test`'s cache).

--- a/docs/src/test-support.md
+++ b/docs/src/test-support.md
@@ -86,6 +86,32 @@ Embed directives in test files are supported:
 - `XTestEmbedPatterns` (from external `_test.go` files) are resolved and
   symlinked into the xtest source directory with their own embed config.
 
+## `extraMainSrcFiles`
+
+Tests run against a filtered copy of `src` that keeps only what the build
+needs: `.go` sources, resolved `//go:embed` targets, and every `testdata/`
+directory under a tested package. Anything else is dropped so unrelated
+edits don't invalidate the test derivation.
+
+A test that reads a file at runtime *without* `//go:embed` and *outside*
+`testdata/` — e.g. `os.ReadFile("../config.yaml")` — will not find it.
+Prefer moving such fixtures under `testdata/`. When that isn't practical,
+list the paths in `extraMainSrcFiles`:
+
+```nix
+goEnv.buildGoApplication {
+  src = ./.;
+  goLock = ./go2nix.toml;
+  pname = "my-app";
+  version = "0.1.0";
+  extraMainSrcFiles = [ "config.yaml" "internal/svc/fixtures" ];
+}
+```
+
+Each entry is relative to `src` (not `modRoot`). A directory entry includes
+its full subtree, and a trailing `/` is tolerated. An entry that does not
+exist under `src` fails evaluation.
+
 ## `checkFlags`
 
 Extra flags passed to the test binary (not to `go test`, since go2nix


### PR DESCRIPTION
Four doc fixes where `docs/src/` had drifted from code or didn't cover shipped features:

- **`doCheck` default** — builder-api.md/test-support.md still said it defaults to `modRoot == "."`; `nix/dag/default.nix:75` now sets `doCheck ? true` unconditionally since mainSrc unions sibling-replace dirs.
- **`extraMainSrcFiles`** — added in #111, undocumented. New section in test-support.md explains the runtime-read escape hatch (`os.ReadFile("../config.yaml")`) and entry semantics (src-relative, dirs recurse, missing entry throws); row added to builder-api.md table.
- **derivation-backed `go` arg** — nix-plugin.md said it "will be rejected"; `resolveGoPackages.cc:62-93` now warns and falls through to `realiseContext` (opt-in IFD via `allow-import-from-derivation`).
- **`GOFIPS140`** — supported via `goEnv` and tested by `test-fixture-fips140-latest`, but absent from docs. Added to the `mkGoEnv.goEnv` row and a short FIPS-140 section in builder-api.md.

`nix build .#docs` passes. All backtick-quoted identifiers grep-resolve in `go/`, `nix/`, or `packages/`.