### PR TITLE
backlog: seed grind work items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ docs/plans/
 
 # bench-incremental Go binary (built ad-hoc)
 go/bench-incremental/bench-incremental
+.grind-stop

--- a/backlog/README.md
+++ b/backlog/README.md
@@ -1,0 +1,16 @@
+# backlog/
+
+Known next steps for go2nix, one file per item. Delete the file when done
+— git history is the changelog.
+
+Naming: `<area>-<slug>.md` where area ∈ {bug, parity, perf, coverage,
+feat, refactor, arch, meta}. Each file: **What** / **Why** / **Approach**
+/ **Blockers**.
+
+`tried/` records abandoned experiments (with the % or reason) so they
+don't get retried blindly. `needs-human/` is where the merge queue
+routes denylist-hit items for manual review.
+
+The grind workflow (`.claude/commands/grind.md`) consumes these:
+specialists generate items, implementers pick them, the merge queue
+gates by file cluster (golden + canary + eval-stats).

--- a/backlog/coverage-dynamic-nwg-drawer-link.md
+++ b/backlog/coverage-dynamic-nwg-drawer-link.md
@@ -1,0 +1,14 @@
+**What:** `test-package-nwg-drawer-dynamic` is wired (#108) but the
+synthesised link drv's `NIX_LDFLAGS` propagation may have edge cases
+with very deep propagated-input chains.
+
+**Why:** Only one GTK-shaped test case; the salted `NIX_LDFLAGS_<suffix>`
+approach should be robust but isn't differentially tested.
+
+**Approach:**
+- Add a second dynamic-mode pkg-config fixture with a different
+  propagated-dep shape (e.g. `tests/packages/vinegar/dynamic.nix` —
+  vinegar uses GTK4)
+- Compare the resolved LibDirs against `pkg-config --libs` output
+
+**Blockers:** none

--- a/backlog/coverage-pie-buildmode.md
+++ b/backlog/coverage-pie-buildmode.md
@@ -1,0 +1,14 @@
+**What:** `buildmode=pie` is plumbed (linkbinary handles `-buildmode=pie`
+and adds `-shared` to gcflags) but no fixture exercises it end-to-end.
+
+**Why:** PIE is the default on some distros; one untested branch in
+linkbinary.go.
+
+**Approach:**
+- New `tests/fixtures/pie-basic/` (minimal main, dag.nix sets
+  `buildMode = "pie"`)
+- Wrapper asserts `file` output shows `pie executable` and modinfo
+  has `build -buildmode=pie`
+- Add to `test-golden-vs-gobuild` (vanilla side: `go build -buildmode=pie`)
+
+**Blockers:** none

--- a/backlog/feat-gofips140-snapshot.md
+++ b/backlog/feat-gofips140-snapshot.md
@@ -1,0 +1,17 @@
+**What:** `GOFIPS140=v1.0.0` (snapshot mode) compiles the stdlib snapshot
+correctly (via #34's goEnv plumbing) but linking fails: stdlib.nix's
+importcfg generator doesn't list snapshot-remapped paths under
+`crypto/internal/fips140/v*/`.
+
+**Why:** Completes FIPS support beyond `=latest` (#100). Low priority —
+no known consumer needs certified-module builds.
+
+**Approach:**
+- `nix/stdlib.nix`: when `goEnv.GOFIPS140` is a version, mirror
+  `cmd/go/internal/fips140.ResolveImport` so the importcfg includes
+  the remapped paths
+- Extend `tests/fixtures/fips140-latest/` with a snapshot variant
+  (gated on `ls $GOROOT/lib/fips140/*.zip` having a usable version)
+
+**Blockers:** needs a Go release with a published lib/fips140 snapshot
+zip; verify what 1.26.x ships

--- a/backlog/feat-vendor-directory.md
+++ b/backlog/feat-vendor-directory.md
@@ -1,0 +1,15 @@
+**What:** `vendor/` directory mode unsupported. With `-mod=vendor`,
+cmd/go reads deps from `vendor/` instead of GOMODCACHE — go2nix's
+resolver always uses go.sum + module cache.
+
+**Why:** Some upstream projects ship vendored. Low priority for the
+monorepo (no service vendors), but a real cmd/go feature gap.
+
+**Approach:**
+- `resolveGoPackages` (rust): detect `vendor/modules.txt`, skip
+  go.sum hash resolution, emit `vendored: true`
+- `nix/dag`: if vendored, third-party packages come from
+  `src + "/vendor/<path>"` instead of `fetchGoModule`
+- Fixture: `tests/fixtures/vendored/` with a checked-in `vendor/`
+
+**Blockers:** none, but it's a structural feature — likely 2-3 rounds

--- a/backlog/perf-dag-cache-revival.md
+++ b/backlog/perf-dag-cache-revival.md
@@ -1,0 +1,18 @@
+**What:** PR #48 (`feat/resolve-dag-cache`) — persistent on-disk cache
+for `resolveGoPackages` keyed on toolchain identity + go.sum hash. On
+hold per the user.
+
+**Why:** This is the remaining structural eval-perf lever after Tier 1-3.
+Repeated instantiates of an unchanged module skip the `go list` invocation
+entirely.
+
+**Approach:** when revived:
+- Rebase onto current main (#109+ changed the output schema; cache key
+  in `a51be38` already includes `GOFIPS140`)
+- The cache must include the schema version so old cache entries are
+  invalidated when output fields are added
+- Thread `GO2NIX_RESOLVE_CACHE_DIR` from the monorepo's coo wrapper
+
+**Blockers:** user explicitly said #48 won't be merged soon (2026-04-10).
+DO NOT pick this without checking with them first. File under needs-human
+if triage selects it.

--- a/backlog/refactor-clisource-excludes-tests.md
+++ b/backlog/refactor-clisource-excludes-tests.md
@@ -1,0 +1,16 @@
+**What:** `packages/go2nix/default.nix:13` uses `cleanSource ../../go/go2nix`
+which includes `*_test.go`. Any test-only PR (e.g. #103) changes the CLI
+drv hash → cascades to every fixture → `test-drv-canary` requires
+regeneration even though nothing functional changed.
+
+**Why:** Noise in the canary signal; test-only PRs shouldn't need
+`expected.txt` regen.
+
+**Approach:**
+- Replace `cleanSource` with `lib.fileset.toSource` filtering out
+  `**/*_test.go` and `**/testdata/**`
+- Prove canary is THEN stable across a synthetic test-only diff
+- One-time canary regen for the filter change itself
+
+**Blockers:** none (but changes the CLI drv hash once, so batch with
+other CLI-touching items if possible)

--- a/backlog/refactor-dead-cgo-markers.md
+++ b/backlog/refactor-dead-cgo-markers.md
@@ -1,0 +1,13 @@
+**What:** `pkg/compile/cgo.go` may still write `.has_cgo` / `.has_cxx`
+filesystem markers that nothing reads after #85 (which moved cxx
+detection to a closure-computed `sp.CXX` in linkbinary).
+
+**Why:** Dead writes; if confirmed, removing them is net-negative-line
+and slightly speeds the cgo compile path.
+
+**Approach:**
+- `rg "\.has_cgo|\.has_cxx" go/go2nix/` — find writers and readers
+- If only writers remain: delete the writes, golden + canary regen
+- If a reader exists: document why and close as not-dead
+
+**Blockers:** none

--- a/backlog/refactor-lockfile-dynamic-deadcode.md
+++ b/backlog/refactor-lockfile-dynamic-deadcode.md
@@ -1,0 +1,14 @@
+**What:** `pkg/lockfile/` may have unused code paths after #80/#81
+(which made default-mode lockfile-free) and #106 (which fixed dynamic
+mode's GOMODCACHE setup to derive everything from go.sum directly).
+
+**Why:** ~several hundred LOC potentially orphaned; clarity + reduced
+maintenance surface.
+
+**Approach:**
+- `rg "lockfile\." go/go2nix/ --type go -g '!*_test.go'` — find consumers
+- For each exported func/type: trace callers; delete if none outside
+  the package (or only from tests)
+- `go build ./...` + golden + canary regen
+
+**Blockers:** none

--- a/backlog/tried/README.md
+++ b/backlog/tried/README.md
@@ -1,0 +1,16 @@
+# backlog/tried/
+
+Abandoned experiments. Each file records what was attempted, the gate
+result (% regression or correctness diff), and why it was dropped — so
+the same approach isn't blindly retried.
+
+Seed entries from the perf-research and audit work that's already
+shipped or ruled out:
+
+- `perf-tier1-hoists.md` — shipped as #105 (−14% primops)
+- `perf-tier2-filter-precompute.md` — shipped as #107
+- `perf-tier3-plugin-offload.md` — shipped as #109
+- `perf-nestedmodule-readdir-walk.md` — prototyped during #107, dropped:
+  Nix-side `readDir` per directory adds more primops than it saves;
+  builtins.path's C++ traversal already enumerates them. Correct fix
+  was Tier-3 (plugin emits boundaries).


### PR DESCRIPTION
Seeds `backlog/` with known deferred items for the grind workflow. Each
file is one work item (What/Why/Approach/Blockers); deleted when done so
git history is the changelog. `backlog/tried/` records shipped/abandoned
work so it isn't retried.

Seeded from the post-#74-#114 deferred list:
- 3× refactor (dead-code candidates, canary cascade fix)
- 2× coverage (pie buildmode, second dynamic pkg-config)
- 2× feat (FIPS snapshot, vendor/ — both low priority)
- 1× perf (#48 revival, blocked-on-user)

Also adds `.grind-stop` to `.gitignore`.

Docs-only; no code, no flake, no tests changed.