### PR TITLE
ci: add benchmark regression check for PRs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,115 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Benchmark regression check
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: benchmark-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: NixOS/nix-installer-action@main
+        with:
+          extra-conf: |
+            experimental-features = nix-command flakes recursive-nix ca-derivations
+            extra-substituters = https://cache.numtide.com
+            extra-trusted-public-keys = niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g=
+
+      - name: Allow unprivileged user namespaces
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Benchmark baseline
+        run: |
+          git checkout "origin/${{ github.base_ref }}"
+          NIXPKGS_PATH=$(nix eval --raw --inputs-from . nixpkgs#path)
+          export NIXPKGS_PATH
+          nix run .#bench-incremental -- \
+            --runs 5 \
+            --json /tmp/baseline.json
+
+      - name: Benchmark current
+        run: |
+          git checkout "${{ github.sha }}"
+          NIXPKGS_PATH=$(nix eval --raw --inputs-from . nixpkgs#path)
+          export NIXPKGS_PATH
+          nix run .#bench-incremental -- \
+            --runs 5 --stderr-tail 4000 \
+            --json /tmp/current.json
+
+      - name: Compare results
+        id: compare
+        run: |
+          set +e
+          result=$(python3 scripts/compare-benchmarks.py \
+            /tmp/baseline.json /tmp/current.json --threshold 20)
+          exit_code=$?
+          set -e
+
+          {
+            echo 'table<<EOF'
+            echo "$result"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+          echo "regressed=$exit_code" >> "$GITHUB_OUTPUT"
+
+      - name: Post PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          TABLE: ${{ steps.compare.outputs.table }}
+        with:
+          script: |
+            const marker = '<!-- benchmark-regression-check -->';
+            const table = process.env.TABLE;
+            const body = [
+              marker,
+              '## Benchmark Regression Check',
+              '',
+              table,
+              '',
+              `Baseline: \`${{ github.base_ref }}\` | Current: \`${{ github.sha }}\``,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail on regression
+        if: steps.compare.outputs.regressed != '0'
+        run: |
+          echo "::error::Benchmark regression detected. See PR comment for details."
+          exit 1

--- a/formatter.nix
+++ b/formatter.nix
@@ -17,6 +17,10 @@ let
 
       # go
       gofumpt.enable = true;
+
+      # python
+      ruff-check.enable = true;
+      ruff-format.enable = true;
     };
     settings.formatter = {
       # nix
@@ -32,6 +36,12 @@ let
       shellcheck.priority = 1;
       shfmt.pipeline = "shell";
       shfmt.priority = 2;
+
+      # python
+      ruff-check.pipeline = "python";
+      ruff-check.priority = 1;
+      ruff-format.pipeline = "python";
+      ruff-format.priority = 2;
 
       # markdown
       mdformat.package = pkgs.lib.mkDefault (

--- a/go/bench-incremental/main.go
+++ b/go/bench-incremental/main.go
@@ -218,6 +218,7 @@ type nixTool struct {
 	exprPath    string
 	extraOpts   []string
 	storeRoot   string // local store root (NIX_REMOTE=local?root=...)
+	stderrTail  int    // bytes of stderr to keep in error messages
 }
 
 type buildResult struct {
@@ -251,8 +252,8 @@ func (t *nixTool) build(srcPath string) (buildResult, error) {
 	evalElapsed, evalOut, evalErr, err := runCommand("nix-instantiate", evalArgs, env)
 	if err != nil {
 		tail := evalErr
-		if len(tail) > 500 {
-			tail = tail[len(tail)-500:]
+		if len(tail) > t.stderrTail {
+			tail = tail[len(tail)-t.stderrTail:]
 		}
 		return buildResult{}, fmt.Errorf("nix-instantiate failed: %w\n%s", err, tail)
 	}
@@ -269,8 +270,8 @@ func (t *nixTool) build(srcPath string) (buildResult, error) {
 	buildElapsed, buildOut, buildErr, err := runCommand("nix-store", realiseArgs, env)
 	if err != nil {
 		tail := buildErr
-		if len(tail) > 500 {
-			tail = tail[len(tail)-500:]
+		if len(tail) > t.stderrTail {
+			tail = tail[len(tail)-t.stderrTail:]
 		}
 		return buildResult{}, fmt.Errorf("nix-store --realise failed: %w\n%s", err, tail)
 	}
@@ -613,6 +614,8 @@ func main() {
 	jsonOut := flag.String("json", "", "export results as JSON to this path")
 	assertCascade := flag.Int("assert-cascade", -1,
 		"fail if any tool builds more than N drvs on a touch scenario")
+	stderrTail := flag.Int("stderr-tail", 500,
+		"bytes of stderr to keep in error messages")
 	flag.Parse()
 
 	fc, ok := fixtures[*fixtureName]
@@ -694,20 +697,22 @@ func main() {
 		"nix": {
 			name: "nix", nixpkgsPath: nixpkgsPath, pluginPath: pluginPath,
 			gomodcache: gomodcache, exprPath: exprNix, storeRoot: storeRoot,
+			stderrTail: *stderrTail,
 		},
 		"nix-ca": {
 			name: "nix-ca", nixpkgsPath: nixpkgsPath, pluginPath: pluginPath,
 			gomodcache: gomodcache, exprPath: exprCA, storeRoot: storeRoot,
-			extraOpts: caOpts,
+			extraOpts: caOpts, stderrTail: *stderrTail,
 		},
 		"nix-nocgo": {
 			name: "nix-nocgo", nixpkgsPath: nixpkgsPath, pluginPath: pluginPath,
 			gomodcache: gomodcache, exprPath: exprNoCgo, storeRoot: storeRoot,
+			stderrTail: *stderrTail,
 		},
 		"nix-ca-nocgo": {
 			name: "nix-ca-nocgo", nixpkgsPath: nixpkgsPath, pluginPath: pluginPath,
 			gomodcache: gomodcache, exprPath: exprCANoCgo, storeRoot: storeRoot,
-			extraOpts: caOpts,
+			extraOpts: caOpts, stderrTail: *stderrTail,
 		},
 	}
 

--- a/scripts/compare-benchmarks.py
+++ b/scripts/compare-benchmarks.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Compare two bench-incremental JSON outputs and flag regressions.
+
+Reads baseline and current JSON files produced by bench-incremental,
+compares mean wall-clock times and derivation build counts per
+scenario+tool pair, and outputs a GitHub-flavoured Markdown table.
+
+Exits 0 if no regressions, 1 if any scenario regressed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class ToolStats:
+    mean: float
+    builds_mean: float
+
+
+@dataclass
+class Comparison:
+    scenario: str
+    tool: str
+    base: ToolStats
+    current: ToolStats
+
+    @property
+    def time_pct_change(self) -> float:
+        if self.base.mean == 0:
+            return 0.0
+        return ((self.current.mean - self.base.mean) / self.base.mean) * 100
+
+    @property
+    def drv_delta(self) -> float:
+        return self.current.builds_mean - self.base.builds_mean
+
+    def is_regression(self, threshold: float) -> tuple[bool, str]:
+        reasons: list[str] = []
+        if self.drv_delta > 0:
+            reasons.append("drvs")
+        if self.time_pct_change > threshold:
+            reasons.append("time")
+        if reasons:
+            return True, ", ".join(reasons)
+        return False, ""
+
+
+def load_results(path: Path) -> dict[str, dict[str, ToolStats]]:
+    """Parse bench-incremental JSON into {scenario: {tool: ToolStats}}."""
+    data = json.loads(path.read_text())
+    out: dict[str, dict[str, ToolStats]] = {}
+    for scenario in data["scenarios"]:
+        name = scenario["name"]
+        tools: dict[str, ToolStats] = {}
+        for tool_name, tool_data in scenario["tools"].items():
+            tools[tool_name] = ToolStats(
+                mean=tool_data["mean"],
+                builds_mean=tool_data["builds_mean"],
+            )
+        out[name] = tools
+    return out
+
+
+def compare(
+    baseline: dict[str, dict[str, ToolStats]],
+    current: dict[str, dict[str, ToolStats]],
+) -> list[Comparison]:
+    """Produce comparisons for all scenario+tool pairs present in both."""
+    comparisons: list[Comparison] = []
+    for scenario in baseline:
+        if scenario not in current:
+            continue
+        for tool in baseline[scenario]:
+            if tool not in current[scenario]:
+                continue
+            comparisons.append(
+                Comparison(
+                    scenario=scenario,
+                    tool=tool,
+                    base=baseline[scenario][tool],
+                    current=current[scenario][tool],
+                )
+            )
+    return comparisons
+
+
+def format_change(pct: float) -> str:
+    sign = "+" if pct >= 0 else ""
+    return f"{sign}{pct:.1f}%"
+
+
+def format_table(comparisons: list[Comparison], threshold: float) -> str:
+    lines: list[str] = []
+    lines.append(
+        "| Scenario | Tool | Base (s) | Current (s) | Change "
+        "| Drvs (base) | Drvs (curr) | Status |"
+    )
+    lines.append("|:---|:---|---:|---:|---:|---:|---:|:---|")
+    for c in comparisons:
+        is_reg, reason = c.is_regression(threshold)
+        status = f"REGRESSION ({reason})" if is_reg else "ok"
+        lines.append(
+            f"| {c.scenario} | {c.tool} "
+            f"| {c.base.mean:.2f} | {c.current.mean:.2f} "
+            f"| {format_change(c.time_pct_change)} "
+            f"| {c.base.builds_mean:.0f} | {c.current.builds_mean:.0f} "
+            f"| {status} |"
+        )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare bench-incremental JSON outputs for regressions."
+    )
+    parser.add_argument("baseline", type=Path, help="Baseline JSON (e.g. from main)")
+    parser.add_argument("current", type=Path, help="Current JSON (e.g. from PR)")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=20.0,
+        help="Wall-clock regression threshold in percent (default: 20)",
+    )
+    args = parser.parse_args()
+
+    baseline = load_results(args.baseline)
+    current = load_results(args.current)
+    comparisons = compare(baseline, current)
+
+    if not comparisons:
+        print("No matching scenario+tool pairs found between baseline and current.")
+        return 1
+
+    table = format_table(comparisons, args.threshold)
+    print(table)
+
+    regressions = [c for c in comparisons if c.is_regression(args.threshold)[0]]
+    if regressions:
+        print(
+            f"\n{len(regressions)} regression(s) detected "
+            f"(threshold: {args.threshold}%)",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nNo regressions detected.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Run bench-incremental on both the base branch and the PR head within the same CI runner so wall-clock comparisons are fair.  A Python comparison script flags two classes of regression:

  1. Derivation-count increase (deterministic, any delta is a failure).
  2. Wall-clock time increase above a configurable threshold (default 20%).

Results are posted as a PR comment and the check hard-fails on regression.

Also wires ruff-check and ruff-format into treefmt so Python files are linted as part of `nix fmt`.