### PR TITLE
torture: use sqlite3.SQLiteDriver instead of cgo-only ErrNo

### DIFF
--- a/packages/go2nix-testgen/cmd/torture.go
+++ b/packages/go2nix-testgen/cmd/torture.go
@@ -180,7 +180,7 @@ var categories = []DepCategory{
 			{Path: "github.com/dgraph-io/badger/v4", Alias: "badger", Usage: `_ = badger.DefaultOptions("")`},
 			{Path: "github.com/cockroachdb/pebble", Usage: "var _ *pebble.DB"},
 			{Path: "github.com/elastic/go-elasticsearch/v8", Alias: "elasticsearch", Usage: "_ = elasticsearch.Config{}"},
-			{Path: "github.com/mattn/go-sqlite3", Alias: "sqlite3", Usage: `_ = sqlite3.ErrNo(0)`},
+			{Path: "github.com/mattn/go-sqlite3", Alias: "sqlite3", Usage: `_ = sqlite3.SQLiteDriver{}`},
 			{Path: "github.com/lib/pq", Alias: "pq", Usage: `_ = pq.ErrSSLNotSupported`},
 			{Path: "github.com/uptrace/bun", Usage: "var _ *bun.DB"},
 			{Path: "github.com/pressly/goose/v3", Alias: "goose", Usage: "_ = goose.Up"},

--- a/tests/fixtures/torture-project/internal/conflict-a/conflicta.go
+++ b/tests/fixtures/torture-project/internal/conflict-a/conflicta.go
@@ -68,7 +68,7 @@ func Run() error {
 	_ = badger.DefaultOptions("")
 	var _ *pebble.DB
 	_ = elasticsearch.Config{}
-	_ = sqlite3.ErrNo(0)
+	_ = sqlite3.SQLiteDriver{}
 	_ = pq.ErrSSLNotSupported
 	var _ *bun.DB
 	_ = goose.Up

--- a/tests/fixtures/torture-project/internal/conflict-b/conflictb.go
+++ b/tests/fixtures/torture-project/internal/conflict-b/conflictb.go
@@ -68,7 +68,7 @@ func Run() error {
 	_ = badger.DefaultOptions("")
 	var _ *pebble.DB
 	_ = elasticsearch.Config{}
-	_ = sqlite3.ErrNo(0)
+	_ = sqlite3.SQLiteDriver{}
 	_ = pq.ErrSSLNotSupported
 	var _ *bun.DB
 	_ = goose.Up

--- a/tests/fixtures/torture-project/internal/db/db.go
+++ b/tests/fixtures/torture-project/internal/db/db.go
@@ -48,7 +48,7 @@ func Run() error {
 	_ = badger.DefaultOptions("")
 	var _ *pebble.DB
 	_ = elasticsearch.Config{}
-	_ = sqlite3.ErrNo(0)
+	_ = sqlite3.SQLiteDriver{}
 	_ = pq.ErrSSLNotSupported
 	var _ *bun.DB
 	_ = goose.Up


### PR DESCRIPTION
## Summary

The torture fixture's `internal/{conflict-a,conflict-b,db}` use `sqlite3.ErrNo(0)` to force the `mattn/go-sqlite3` import. `ErrNo` only exists in the cgo build — the package's `//go:build !cgo` stub defines `SQLiteDriver`/`SQLiteConn` but not the error types. So `bench-incremental --fixture torture --tools nix-*-nocgo` (and any `CGO_ENABLED=0` build of the fixture) fails at compile.

`SQLiteDriver{}` is defined in both builds; swap to that. Also updates the testgen template.

## Test plan
- [x] `CGO_ENABLED=0 go build ./internal/conflict-a` — was `undefined: sqlite3.ErrNo`, now OK
- [x] `CGO_ENABLED=1 go build ./internal/conflict-a` — still OK