### PR TITLE
resolve: GOWORK=off + passAsFile importcfg_entries (dynamic-mode torture fixes)

### DIFF
--- a/go/go2nix/pkg/resolve/resolve.go
+++ b/go/go2nix/pkg/resolve/resolve.go
@@ -205,6 +205,10 @@ func Resolve(cfg Config) error {
 		"GOMODCACHE=" + gomodcache,
 		"GONOSUMCHECK=*",
 		"GOPROXY=off",
+		// Match the plugin (resolve.rs): in workspace mode, individual
+		// modules' replace directives are ignored, so MVS may select a
+		// version the lockfile (generated per-module) doesn't have.
+		"GOWORK=off",
 		"GOFLAGS=-mod=readonly",
 		// The merged GOMODCACHE is assembled from symlinks to Nix store FOD
 		// outputs (see setupGOMODCACHE). Go's //go:embed rejects symlinks by


### PR DESCRIPTION
Dynamic-mode `resolve.go` didn't set `GOWORK=off`; the dag plugin does (`resolve.rs:382`). With a `go.work` present, workspace MVS ignores per-module `replace` directives, so it may select a version the per-module lockfile doesn't have — `go list -mod=readonly` then fails with `module lookup disabled by GOPROXY=off`. The torture fixture (which gained `go.work` in #121 for gazelle) hits this: `app-full` replaces gin → v1.9.1, workspace MVS picks v1.12.0 from `internal/web`.

Unblocks #124's torture×dynamic comparison.