### PR TITLE
dag: normalize modRoot to fix -trimpath leak when subPackages=["."]

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -136,6 +136,9 @@
           test-fixture-nested-module = callPkgWith ./tests/nix/nested_module_test.nix {
             inherit flake system;
           };
+          test-fixture-modroot-dotslash = callPkgWith ./tests/nix/modroot_dotslash_test.nix {
+            inherit flake system;
+          };
           test-fixture-mainsrc-precise = callPkgWith ./packages/test-fixture-mainsrc-precise/default.nix {
             inherit flake system;
           };

--- a/go/go2nix/cmd/go2nix/linkbinary.go
+++ b/go/go2nix/cmd/go2nix/linkbinary.go
@@ -217,7 +217,7 @@ func linkBinary(manifestPath, output string) error {
 		clean := strings.TrimPrefix(sp.Path, "./")
 		if sp.Path == "." || clean == "" {
 			importpath = modulePath
-			srcdir = m.ModuleRoot
+			srcdir = filepath.Clean(m.ModuleRoot)
 			binname = m.Pname
 			if binname == "" {
 				binname = filepath.Base(modulePath)

--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -98,6 +98,8 @@ let
     splitString
     ;
 
+  cleanModRoot = removePrefix "./" modRoot;
+
   hasPackageOverrides = packageOverrides != { };
 
   # Per-package override resolution. Factored from the three near-identical
@@ -845,7 +847,6 @@ let
   # directory; directories include their full subtree).
   mainSrc =
     let
-      cleanModRoot = removePrefix "./" modRoot;
       replaceDirs = goPackagesResult.localReplaceDirs;
 
       # Under doCheck the testrunner walks every local package; otherwise
@@ -958,7 +959,8 @@ let
           mainSrcFileSet ? ${rel} || underPrefix rel;
     };
 
-  moduleRoot = if modRoot == "." then "${mainSrc}" else "${mainSrc}/${modRoot}";
+  moduleRoot =
+    if cleanModRoot == "." || cleanModRoot == "" then "${mainSrc}" else "${mainSrc}/${cleanModRoot}";
 
   # Filter out known args so extra attrs pass through to mkDerivation.
   # Attrs we set ourselves below (env, buildInputs, passthru,
@@ -1148,7 +1150,11 @@ stdenv.mkDerivation (
     dontPatchELF = true;
     noAuditTmpdir = true;
 
-    disallowedReferences = optional (!allowGoReference) go ++ (args.disallowedReferences or [ ]);
+    disallowedReferences = [
+      mainSrc
+    ]
+    ++ optional (!allowGoReference) go
+    ++ (args.disallowedReferences or [ ]);
 
     passthru = {
       inherit

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -21,5 +21,6 @@
     xtest-local-dep = import ./fixtures/xtest-local-dep/dag.nix;
     cgo-internal-test = import ./fixtures/cgo-internal-test/dag.nix;
     modroot-nested = import ./fixtures/modroot-nested/dag.nix;
+    modroot-dotslash = import ./fixtures/modroot-dotslash/dag.nix;
   };
 }

--- a/tests/fixtures/modroot-dotslash/app/go.mod
+++ b/tests/fixtures/modroot-dotslash/app/go.mod
@@ -1,0 +1,3 @@
+module example.com/modroot-dotslash
+
+go 1.22

--- a/tests/fixtures/modroot-dotslash/app/main.go
+++ b/tests/fixtures/modroot-dotslash/app/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("ok")
+}

--- a/tests/fixtures/modroot-dotslash/dag.nix
+++ b/tests/fixtures/modroot-dotslash/dag.nix
@@ -1,0 +1,20 @@
+# Regression test: modRoot with a ./ prefix and the main package at the
+# module root. The -trimpath rewrite key must match the canonical srcdir
+# the compiler records; if the ./ survives into moduleRoot, the rewrite
+# misses and the binary references mainSrc — caught by disallowedReferences.
+let
+  pkgs = import <nixpkgs> { };
+  inherit (pkgs) go;
+  go2nix = import ../../../packages/go2nix { inherit pkgs; };
+  goEnv = import ../../../nix/mk-go-env.nix {
+    inherit go go2nix;
+    inherit (pkgs) callPackage;
+  };
+in
+goEnv.buildGoApplication {
+  pname = "modroot-dotslash";
+  version = "0.0.1";
+  src = ./.;
+  modRoot = "./app";
+  doCheck = false;
+}

--- a/tests/nix/modroot_dotslash_test.nix
+++ b/tests/nix/modroot_dotslash_test.nix
@@ -1,0 +1,61 @@
+# tests/nix/modroot_dotslash_test.nix — regression for -trimpath rewrite
+# missing when modRoot has a ./ prefix and the main package is at the
+# module root (subPackages = ["."]).
+#
+# Without normalization, moduleRoot = "${mainSrc}/./app" — the rewrite
+# key carries /./ but the compiler records the kernel-canonicalized cwd,
+# so objabi's prefix match misses and mainSrc lands in pclntab. The
+# disallowedReferences check on the link drv catches that; this test
+# just builds the fixture so the guard runs in CI.
+{
+  flake,
+  pkgs,
+  system,
+  ...
+}:
+if !(flake.packages.${system} ? go2nix-nix-plugin) then
+  pkgs.runCommand "modroot-dotslash-test-unsupported" { meta.platforms = pkgs.lib.platforms.linux; }
+    ''
+      echo "modroot-dotslash-test requires go2nix-nix-plugin (Linux only)" >&2
+      exit 1
+    ''
+else
+  let
+    plugin = flake.packages.${system}.go2nix-nix-plugin;
+    nix = pkgs.nixVersions.nix_2_34;
+    nixpkgsPath = pkgs.path;
+    go2nixSrc = flake;
+  in
+  pkgs.runCommand "modroot-dotslash-test"
+    {
+      nativeBuildInputs = [ nix ];
+      requiredSystemFeatures = [ "recursive-nix" ];
+    }
+    ''
+      export HOME=$(mktemp -d)
+      export NIX_CONFIG="extra-experimental-features = nix-command recursive-nix"
+      mkdir -p "$TMPDIR/empty-gmc"
+
+      out=$(GOMODCACHE="$TMPDIR/empty-gmc" nix-build --no-out-link \
+        -I nixpkgs=${nixpkgsPath} \
+        --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
+        ${go2nixSrc}/tests/fixtures/modroot-dotslash/dag.nix)
+
+      # disallowedReferences on the link drv already enforces no mainSrc;
+      # this is a belt-and-suspenders explicit check on the realised path.
+      ms=$(GOMODCACHE="$TMPDIR/empty-gmc" nix-instantiate --eval --read-write-mode --raw \
+        -I nixpkgs=${nixpkgsPath} \
+        --option plugin-files "${plugin}/lib/nix/plugins/libgo2nix_plugin.so" \
+        -A passthru.mainSrc \
+        ${go2nixSrc}/tests/fixtures/modroot-dotslash/dag.nix)
+
+      refs=$(nix-store -q --references "$out")
+      if echo "$refs" | grep -qF "$ms"; then
+        echo "FAIL: $out references mainSrc ($ms)" >&2
+        echo "$refs" >&2
+        exit 1
+      fi
+
+      "$out"/bin/modroot-dotslash > /dev/null
+      echo "modroot-dotslash-test: built, no mainSrc reference, binary runs" > $out
+    ''


### PR DESCRIPTION
## Summary

When `modRoot = "./foo"` and the main package is at the module root (`subPackages = ["."]`, the default), `moduleRoot = "${mainSrc}/${modRoot}"` produces `…-main-src/./foo`. `linkbinary.go` passes that as `srcdir` for the `sp.Path == "."` branch; `compile.go:88` builds the `-trimpath` rewrite key from it; `runIn` sets cwd to the same dirty path but the kernel canonicalizes; the compiler records the clean path; `cmd/internal/objabi`'s prefix match misses; `mainSrc` lands in pclntab and the binary's closure references the source tree.

`subPackages = ["./cmd/…"]` never hit this — that branch goes through `filepath.Join(m.ModuleRoot, clean)`, which normalizes.

## Changes

- **`nix/dag/default.nix`** — hoist `cleanModRoot` to the top-level let; use it in `moduleRoot`
- **`linkbinary.go`** — `filepath.Clean(m.ModuleRoot)` for the `sp.Path == "."` branch (covers any other unnormalized source of `ModuleRoot`)
- **`nix/dag/default.nix`** — add `mainSrc` to `disallowedReferences` so future leaks fail at build time instead of silently bloating the closure
- **`tests/fixtures/modroot-dotslash/`** + `tests/nix/modroot_dotslash_test.nix` — regression fixture (`modRoot = "./app"`, default subPackages); the disallowedReferences guard fails the build if the leak recurs, and the test additionally checks `nix-store -q --references` and runs the binary

## Reproduction

```console
$ nix-build tests/fixtures/modroot-dotslash/dag.nix  # before this PR
$ nix-store -q --references ./result
/nix/store/…-modroot-dotslash-main-src   # ← source tree in closure
…
```
