### PR TITLE
plugin: add API_LEVEL guard between nix expr and resolver .so

### DIFF
--- a/nix/dag/default.nix
+++ b/nix/dag/default.nix
@@ -407,31 +407,50 @@ let
 
   lockfileModules = builtins.mapAttrs parseModEntry lockfileModTable;
 
+  # Bump in lockstep with API_LEVEL in
+  # packages/go2nix-nix-plugin/rust/src/resolve.rs.
+  apiLevel = 1;
+  resolverApiLevel = builtins.go2nixApiLevel or 0;
+  apiLevelGuard =
+    if resolverApiLevel == apiLevel then
+      x: x
+    else
+      lib.warn ''
+        go2nix-nix-plugin: API level mismatch.
+          nix builtin resolver = ${toString resolverApiLevel}
+          nix/dag/default.nix  = ${toString apiLevel}
+        Your nix was built against a different go2nix-nix-plugin revision
+        than the nix/ tree you are evaluating. Rebuild/reload the plugin
+        against this checkout.
+      '';
+
   # --- Package graph from plugin (eval-time go list) ---
   # goProxy is unset by default — inherits the environment's GOPROXY.
   # When resolveHashes is true, the plugin also computes NAR hashes for all
   # modules from go.sum + GOMODCACHE, returned as moduleHashes.
-  goPackagesResult = builtins.resolveGoPackages (
-    {
-      # `go` is intentionally omitted: the plugin uses the toolchain baked in
-      # at its own build time. Passing "${go}/bin/go" would carry derivation
-      # context, which the plugin rejects to keep this path IFD-free.
-      inherit
-        src
-        tags
-        modRoot
-        doCheck
-        ;
-      subPackages = normalizedSubPackages;
-      resolveHashes = !hasLockfile;
-      # File lists in the manifest are computed at eval time by `go list`;
-      # pass the same target platform here that the build derivations will
-      # use so constraint evaluation matches.
-      goos = targetGoos;
-      goarch = targetGoarch;
-    }
-    // (if goProxy != null then { inherit goProxy; } else { })
-    // (if CGO_ENABLED != null then { cgoEnabled = toString CGO_ENABLED; } else { })
+  goPackagesResult = apiLevelGuard (
+    builtins.resolveGoPackages (
+      {
+        # `go` is intentionally omitted: the plugin uses the toolchain baked in
+        # at its own build time. Passing "${go}/bin/go" would carry derivation
+        # context, which the plugin rejects to keep this path IFD-free.
+        inherit
+          src
+          tags
+          modRoot
+          doCheck
+          ;
+        subPackages = normalizedSubPackages;
+        resolveHashes = !hasLockfile;
+        # File lists in the manifest are computed at eval time by `go list`;
+        # pass the same target platform here that the build derivations will
+        # use so constraint evaluation matches.
+        goos = targetGoos;
+        goarch = targetGoarch;
+      }
+      // (if goProxy != null then { inherit goProxy; } else { })
+      // (if CGO_ENABLED != null then { cgoEnabled = toString CGO_ENABLED; } else { })
+    )
   );
 
   # Precomputed by the plugin: every src-relative directory containing a

--- a/packages/go2nix-nix-plugin/plugin/resolveGoPackages.cc
+++ b/packages/go2nix-nix-plugin/plugin/resolveGoPackages.cc
@@ -20,6 +20,7 @@ extern "C" {
         char **err_out
     );
     void go2nix_free_string(char *s);
+    unsigned go2nix_api_level(void);
 }
 
 using namespace nix;
@@ -153,5 +154,23 @@ static RegisterPrimOp rp(PrimOp {
     .impl = prim_resolveGoPackages,
 #else
     .fun = prim_resolveGoPackages,
+#endif
+});
+
+static void prim_go2nixApiLevel(EvalState &, const PosIdx, Value **, Value &v) {
+    v.mkInt(go2nix_api_level());
+}
+
+// Internal probe so nix/dag/default.nix can detect a skewed .so before
+// calling resolveGoPackages. Not user API.
+static RegisterPrimOp rpApiLevel(PrimOp {
+    .name = "__go2nixApiLevel",
+    .args = {},
+    .arity = 0,
+    .doc = "Internal: contract version of the loaded go2nix-nix-plugin resolver.",
+#ifdef NIX_PRIMOP_HAS_IMPL
+    .impl = prim_go2nixApiLevel,
+#else
+    .fun = prim_go2nixApiLevel,
 #endif
 });

--- a/packages/go2nix-nix-plugin/rust/src/lib.rs
+++ b/packages/go2nix-nix-plugin/rust/src/lib.rs
@@ -18,6 +18,12 @@ mod resolve;
 
 use std::ffi::{CStr, CString};
 
+/// Expose [`resolve::API_LEVEL`] to the C++ shim for `builtins.go2nixApiLevel`.
+#[no_mangle]
+pub extern "C" fn go2nix_api_level() -> u32 {
+    resolve::API_LEVEL
+}
+
 /// Resolve Go packages from JSON input, returning JSON output.
 ///
 /// Input JSON: `{ "go": "...", "src": "...", "tags": [], "doCheck": false, ... }`

--- a/packages/go2nix-nix-plugin/rust/src/resolve.rs
+++ b/packages/go2nix-nix-plugin/rust/src/resolve.rs
@@ -15,6 +15,12 @@ use std::process::Command;
 /// an explicit `go` field in the input always takes precedence.
 pub(crate) const DEFAULT_GO: Option<&str> = option_env!("GO2NIX_DEFAULT_GO");
 
+/// API level of the resolver output / Nix `nix/dag/default.nix` contract.
+/// Bump on any incompatible `JsonOutput` shape change; `nix/dag/default.nix`
+/// asserts equality via `builtins.go2nixApiLevel` before calling the
+/// resolver so skew surfaces with a clear message at the boundary.
+pub const API_LEVEL: u32 = 1;
+
 // ---------------------------------------------------------------------------
 // Go list JSON types
 // ---------------------------------------------------------------------------
@@ -1139,6 +1145,8 @@ struct JsonLocalPkg {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct JsonOutput {
+    /// See [`API_LEVEL`].
+    api_level: u32,
     packages: BTreeMap<String, JsonPkg>,
     local_packages: BTreeMap<String, JsonLocalPkg>,
     module_path: String,
@@ -1650,6 +1658,7 @@ pub(crate) fn package_graph_to_json(
     let nested_module_roots = find_nested_module_roots(&canon_src, &nested_starts)?;
 
     let output = JsonOutput {
+        api_level: API_LEVEL,
         packages,
         local_packages,
         module_path: graph.module_path.clone(),


### PR DESCRIPTION
A Nix that statically links one go2nix-nix-plugin revision while
evaluating a different nix/ tree surfaces today as an obscure
attribute-missing failure deep in the dag builder, after a successful
resolveGoPackages call returns a JsonOutput shape the consumer no
longer understands.

Stamp a contract version on both sides. The resolver exposes API_LEVEL
via a new __go2nixApiLevel primop (bound as builtins.go2nixApiLevel
since Nix strips the leading underscores); nix/dag/default.nix asserts
equality before calling resolveGoPackages and warns with both numbers
on mismatch. Mirrors cargo-nix-plugin so any future incompatible
JsonOutput change just bumps both constants in lockstep. The
experimental mode runs go list at build time and is unaffected.