### PR TITLE
go2nix-nix-plugin: build Rust core as cdylib alongside staticlib

### DIFF
--- a/packages/go2nix-nix-plugin/plugin/CMakeLists.txt
+++ b/packages/go2nix-nix-plugin/plugin/CMakeLists.txt
@@ -25,8 +25,10 @@ if(NIX_PRIMOP_HAS_IMPL)
 endif()
 target_link_libraries(go2nix_plugin nlohmann_json::nlohmann_json)
 
-target_link_directories(go2nix_plugin PRIVATE ${RUST_LIB_DIR})
-target_link_libraries(go2nix_plugin go2nix_nix_plugin)
+# Link the staticlib explicitly. The Rust crate emits both staticlib and
+# cdylib; an unqualified `-lgo2nix_nix_plugin` would let the linker pick
+# the .so, which isn't on the Nix plugin's runtime loader path.
+target_link_libraries(go2nix_plugin ${RUST_LIB_DIR}/libgo2nix_nix_plugin.a)
 
 if(APPLE)
   set_target_properties(go2nix_plugin PROPERTIES

--- a/packages/go2nix-nix-plugin/rust/Cargo.toml
+++ b/packages/go2nix-nix-plugin/rust/Cargo.toml
@@ -7,7 +7,7 @@ description = "Go package resolver for Nix — runs go list and returns the depe
 
 [lib]
 name = "go2nix_nix_plugin"
-crate-type = ["staticlib"]
+crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Adds `cdylib` to the Rust core's `crate-type` so the build emits `libgo2nix_nix_plugin.so` next to the existing `libgo2nix_nix_plugin.a`.
- The cppnix path is unchanged: the C++ MODULE keeps linking the staticlib. The cdylib is purely additive.
- Lets non-cppnix evaluators dlopen the resolver directly (its entire surface is the prefixed extern "C" trio: `resolve_go_packages_json`, `go2nix_free_string`, `go2nix_api_level`) and skip the C++ shim.

## Test plan
- [x] `nix build .#go2nix-nix-plugin` still succeeds (cppnix MODULE links the staticlib unchanged).
- [x] Built the core derivation in isolation; both `libgo2nix_nix_plugin.a` and `libgo2nix_nix_plugin.so` are produced.
- [x] `nm -D libgo2nix_nix_plugin.so` shows all three exported symbols with type `T`:
  ```
  T go2nix_api_level
  T go2nix_free_string
  T resolve_go_packages_json
  ```